### PR TITLE
Fixing null reference in SARIF1012 validation

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,8 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+* BUGFIX: Fix NullReference in SARIF1012 rule validation [#2254](https://github.com/microsoft/sarif-sdk/pull/2254)
+
 ## **v2.3.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.17) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.3.17)
 * BREAKING: Move `CommandBase` class from `Multitool.Library` assembly to `Driver`. [#2238](https://github.com/microsoft/sarif-sdk/pull/2238)
-* FEASTURE: Argument `VersionControlDetails` for `OptionallyEmittedData` in a analysis command will fill `VersionControlProvenance`. [#2237](https://github.com/microsoft/sarif-sdk/pull/2237)
+* FEATURE: Argument `VersionControlDetails` for `OptionallyEmittedData` in a analysis command will fill `VersionControlProvenance`. [#2237](https://github.com/microsoft/sarif-sdk/pull/2237)
 
 ## **v2.3.16** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.16) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.16) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.16) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.16) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.3.16)
 * BREAKING: Rename flag `VersionControlInformation` to `VersionControlDetails` from `OptionallyEmittedData`. [#2222](https://github.com/microsoft/sarif-sdk/pull/2222)

--- a/src/Sarif.Multitool.Library/Rules/SARIF1012.MessageArgumentsMustBeConsistentWithRule.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF1012.MessageArgumentsMustBeConsistentWithRule.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                         result.Message.Id,
                         result.ResolvedRuleId(run) ?? "null",
                         numArgsRequired.ToString(),
-                        result.Message.Arguments.Count.ToString());
+                        (result.Message.Arguments?.Count ?? 0).ToString());
                 }
             }
         }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
@@ -76,9 +76,37 @@
           "ruleIndex": 0,
           "level": "error",
           "message": {
-            "id": "Error_MessageIdMustExist",
+            "id": "Error_SupplyEnoughMessageArguments",
             "arguments": [
               "runs[0].results[1]",
+              "DoesExist",
+              "TEST1001",
+              "2",
+              "0"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 36,
+                  "startColumn": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1012",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_MessageIdMustExist",
+            "arguments": [
+              "runs[0].results[2]",
               "DoesNotExist",
               "TEST1001"
             ]
@@ -90,7 +118,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 36,
+                  "startLine": 43,
                   "startColumn": 9
                 }
               }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
@@ -37,6 +37,13 @@
           "ruleId": "TEST1001",
           "ruleIndex": 0,
           "message": {
+            "id": "DoesExist"
+          }
+        },
+        {
+          "ruleId": "TEST1001",
+          "ruleIndex": 0,
+          "message": {
             "id": "DoesNotExist",
             "arguments": [
               "runs[0].originalUriBaseIds.SRCINVALID"


### PR DESCRIPTION
## Changes
- When we have a result without message arguments and the rule contains arguments, we were causing a null reference, since we were trying to get the actual count of arguments that the result had. With that, if arguments are null, the count is zero.