### PR TITLE
Change validation in BaseLogger and correct unit tests and code 

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (!succeeded)
             {
                 //  TODO: This seems like uninformative error output.  All these errors get squished into one generic message
-                //  whenever something goes wrong.
+                //  whenever something goes wrong. #2260 https://github.com/microsoft/sarif-sdk/issues/2260
                 ThrowExitApplicationException(context, ExitReason.InvalidCommandLineOption);
             }
         }

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -662,7 +662,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                                     run: _run,
                                     analysisTargets: null,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
-                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog);
+                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog,
+                                    levels: analyzeOptions.Level,
+                                    kinds: analyzeOptions.Kind);
                         }
                         else
                         {
@@ -675,7 +677,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                                     run: _run,
                                     analysisTargets: null,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
-                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog);
+                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog,
+                                    levels: analyzeOptions.Level,
+                                    kinds: analyzeOptions.Kind);
                         }
                         _pathToHashDataMap = sarifLogger.AnalysisTargetToHashDataMap;
                         sarifLogger.AnalysisStarted();

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private void ValidateParameters()
         {
-            if (_resultKinds.Count==0 || (_resultKinds.Count==1 && _resultKinds[0] == ResultKind.None))
+            if (_resultKinds.Count == 0 || (_resultKinds.Count == 1 && _resultKinds[0] == ResultKind.None))
             {
                 throw new ArgumentException("At least one kind is required");
             }
 
-            bool failureLevelsEffectivelyEmpty =    _failureLevels == null
+            bool failureLevelsEffectivelyEmpty = _failureLevels == null
                                                     || _failureLevels.Count == 0
                                                     || (_failureLevels.Count == 1 && _failureLevels[0] == FailureLevel.None);
 

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -15,36 +15,35 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         protected BaseLogger(IEnumerable<FailureLevel> failureLevels,
             IEnumerable<ResultKind> resultKinds)
         {
-            if (failureLevels == null || failureLevels.Count() == 0)
-            {
-                _failureLevels = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning };
-            }
-            else
-            {
-                _failureLevels = failureLevels.ToList();
-            }
-
-            if (resultKinds == null || resultKinds.Count() == 0)
-            {
-                _resultKinds = new List<ResultKind> { ResultKind.Fail };
-            }
-            else
-            {
-                _resultKinds = resultKinds.ToList();
-            }
+            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>();
+            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
 
             ValidateParameters();
         }
 
         private void ValidateParameters()
         {
-            //  If we got here, both resultKinds and failurelevels can neither be null nor empty.
-            //  If resultKinds does not include "fail" then failureLevels MUST be none/zero
-            if (!_resultKinds.Contains(ResultKind.Fail))
+            if (_resultKinds.Count==0 || (_resultKinds.Count==1 && _resultKinds[0] == ResultKind.None))
             {
-                if (_failureLevels.Count > 1 || _failureLevels[0] != FailureLevel.None)
+                throw new ArgumentException("At least one kind is required");
+            }
+
+            bool failureLevelsEffectivelyEmpty =    _failureLevels == null
+                                                    || _failureLevels.Count == 0
+                                                    || (_failureLevels.Count == 1 && _failureLevels[0] == FailureLevel.None);
+
+            if (_resultKinds.Contains(ResultKind.Fail))
+            {
+                if (failureLevelsEffectivelyEmpty)
                 {
-                    throw new ArgumentException("Invalid kind & level combination");
+                    throw new ArgumentException("Failure level required if logging kind 'fail'");
+                }
+            }
+            else
+            {
+                if (!failureLevelsEffectivelyEmpty)
+                {
+                    throw new ArgumentException("Failure level must be empty if logging kind does not include 'fail'");
                 }
             }
         }
@@ -56,13 +55,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public bool ShouldLog(Result result)
         {
-            // If resultKinds is the default value (Fail), we should just filter based on failureLevels
-            if (_resultKinds.Count == 1 && _resultKinds[0] == ResultKind.Fail)
+            if (_resultKinds.Contains(result.Kind))
             {
-                return _failureLevels.Contains(result.Level);
+                if (result.Kind == ResultKind.Fail)
+                {
+                    return _failureLevels.Contains(result.Level);
+                }
+
+                return true;
             }
 
-            return _resultKinds.Contains(result.Kind) && _failureLevels.Contains(result.Level);
+            return false;
         }
     }
 }

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -471,6 +471,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 UpdateInputsToCurrentSarif = updateInputsToCurrentSarif,
                 PrettyPrint = true,
                 Optimize = true,
+                Kind = new List<ResultKind> { ResultKind.Fail },
                 Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None },
             };
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1009,10 +1009,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 TestRuleBehaviors = testCase.TestRuleBehaviors,
                 OutputFilePath = testCase.PersistLogFileToDisk ? Guid.NewGuid().ToString() : null,
                 TargetFileSpecifiers = new string[] { Guid.NewGuid().ToString() },
+                Kind = new List<ResultKind> { ResultKind.Fail },
+                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
             };
 
             if (testCase.Verbose)
             {
+                options.Kind = new List<ResultKind> { ResultKind.Informational, ResultKind.Open, ResultKind.Review, ResultKind.Fail, ResultKind.Pass, ResultKind.NotApplicable, ResultKind.None };
                 options.Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None };
             }
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -24,7 +25,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 analysisTargets: Enumerable.Empty<string>(),
                 logFilePersistenceOptions: LogFilePersistenceOptions.None,
                 invocationTokensToRedact: null,
-                invocationPropertiesToLog: null);
+                invocationPropertiesToLog: null,
+                kinds : new List<ResultKind> { ResultKind.Fail },
+                levels : new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error });
 
             string result = textWriter.ToString();
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 logFilePersistenceOptions: LogFilePersistenceOptions.None,
                 invocationTokensToRedact: null,
                 invocationPropertiesToLog: null,
-                kinds : new List<ResultKind> { ResultKind.Fail },
-                levels : new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error });
+                kinds: new List<ResultKind> { ResultKind.Fail },
+                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error });
 
             string result = textWriter.ToString();
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 
 using FluentAssertions;
@@ -50,7 +51,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             var options = new ValidateOptions
             {
                 SchemaFilePath = SchemaFilePath,
-                TargetFileSpecifiers = new string[] { logFilePath }
+                TargetFileSpecifiers = new string[] { logFilePath },
+                Kind = new List<ResultKind> { ResultKind.Fail },
+                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
             };
 
             int returnCode = validateCommand.Run(options);
@@ -77,7 +80,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             {
                 SchemaFilePath = SchemaFilePath,
                 TargetFileSpecifiers = new string[] { logFilePath },
-                OutputFilePath = OutputFilePath
+                OutputFilePath = OutputFilePath,
+                Kind = new List<ResultKind> { ResultKind.Fail },
+                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
             };
 
             int returnCode = validateCommand.Run(options);
@@ -118,7 +123,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 TargetFileSpecifiers = new string[] { path },
                 OutputFilePath = outputPath,
                 Force = true,
-                ConfigurationFilePath = configuration
+                ConfigurationFilePath = configuration,
+                Kind = new List<ResultKind> { ResultKind.Fail },
+                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
             };
 
             // Verify command returned success

--- a/src/Test.UnitTests.Sarif/Writers/BaseLoggerTestConcrete.cs
+++ b/src/Test.UnitTests.Sarif/Writers/BaseLoggerTestConcrete.cs
@@ -14,8 +14,5 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Writers
     {
         public BaseLoggerTestConcrete(IEnumerable<FailureLevel> failureLevels,
                                         IEnumerable<ResultKind> resultKinds) : base(failureLevels, resultKinds) { }
-
-        public List<FailureLevel> FailureLevelsPublicViewer => _failureLevels;
-        public List<ResultKind> ResultKindPublicViewer => _resultKinds;
     }
 }

--- a/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
@@ -14,25 +14,13 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Writers
 {
     public class BaseLoggerTests
     {
-        private void AssertLevelAndKindAreNonEmpty(BaseLoggerTestConcrete baseLoggerTestConcrete)
-        {
-            baseLoggerTestConcrete.FailureLevelsPublicViewer.Should().NotBeEmpty();
-            baseLoggerTestConcrete.ResultKindPublicViewer.Should().NotBeEmpty();
-        }
-
         [Fact]
         public void BaseLogger_ShouldCorrectlyValidateParameters()
         {
             BaseLoggerTestConcrete baseLoggerTestConcrete = null;
 
-            try
-            {
-                baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.Error },
-                                                                    new List<ResultKind> { ResultKind.Informational });
-                Assert.True(false, "Expected exception not thrown, BaseLogger did not validate correctly.");
-            }
-            catch (ArgumentException)
-            { }
+            Assert.Throws<ArgumentException>(() => new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.Error },
+                                                                    new List<ResultKind> { ResultKind.Informational }));
             //  The rest are fine.
             baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.Error },
                                                                 new List<ResultKind> { ResultKind.Informational, ResultKind.Fail });

--- a/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
@@ -14,43 +14,10 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Writers
 {
     public class BaseLoggerTests
     {
-        [Fact]
-        public void BaseLogger_ShouldAcceptEmptyAndNullKindsAndFailures()
-        {
-            //  null levels, null kinds
-            BaseLoggerTestConcrete baseLoggerTestConcrete = new BaseLoggerTestConcrete(null, null);
-            AssertLevelAndKindAreNonEmpty(baseLoggerTestConcrete);
-
-            //  null levels, empty kinds
-            baseLoggerTestConcrete = new BaseLoggerTestConcrete(null, new List<ResultKind> { });
-            AssertLevelAndKindAreNonEmpty(baseLoggerTestConcrete);
-
-            //  empty levels, null kinds
-            baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { }, null);
-            AssertLevelAndKindAreNonEmpty(baseLoggerTestConcrete);
-
-            //  empty levels, empty kinds
-            baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { }, new List<ResultKind> { });
-            AssertLevelAndKindAreNonEmpty(baseLoggerTestConcrete);
-        }
-
         private void AssertLevelAndKindAreNonEmpty(BaseLoggerTestConcrete baseLoggerTestConcrete)
         {
             baseLoggerTestConcrete.FailureLevelsPublicViewer.Should().NotBeEmpty();
             baseLoggerTestConcrete.ResultKindPublicViewer.Should().NotBeEmpty();
-        }
-
-        [Fact]
-        public void BaseLogger_ShouldCorrectlyDefault()
-        {
-            BaseLoggerTestConcrete baseLoggerTestConcrete = new BaseLoggerTestConcrete(null, null);
-
-            baseLoggerTestConcrete.ResultKindPublicViewer.Count.Should().Be(1);
-            baseLoggerTestConcrete.ResultKindPublicViewer[0].Should().Be(ResultKind.Fail);
-
-            baseLoggerTestConcrete.FailureLevelsPublicViewer.Count.Should().Be(2);
-            baseLoggerTestConcrete.FailureLevelsPublicViewer.Should().Contain(FailureLevel.Warning);
-            baseLoggerTestConcrete.FailureLevelsPublicViewer.Should().Contain(FailureLevel.Error);
         }
 
         [Fact]
@@ -69,9 +36,6 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Writers
             //  The rest are fine.
             baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.Error },
                                                                 new List<ResultKind> { ResultKind.Informational, ResultKind.Fail });
-
-            baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.None },
-                                                                new List<ResultKind> { ResultKind.Fail });
 
             baseLoggerTestConcrete = new BaseLoggerTestConcrete(new List<FailureLevel> { FailureLevel.Note },
                                                                 new List<ResultKind> { ResultKind.Fail });

--- a/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 }
             };
 
-            var logger = new ConsoleLogger( quietConsole: false, 
+            var logger = new ConsoleLogger(quietConsole: false,
                                             toolName: tool,
                                             levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
                                             kinds: new List<ResultKind> { ResultKind.Fail })

--- a/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 using FluentAssertions;
 
@@ -44,7 +45,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 }
             };
 
-            var logger = new ConsoleLogger(quietConsole: false, toolName: tool)
+            var logger = new ConsoleLogger( quietConsole: false, 
+                                            toolName: tool,
+                                            levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                            kinds: new List<ResultKind> { ResultKind.Fail })
             {
                 CaptureOutput = true
             };

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -58,7 +58,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 streamWriter,
                 logFilePersistenceOptions: LogFilePersistenceOptions.PrettyPrint,
                 dataToRemove: OptionallyEmittedData.NondeterministicProperties,
-                closeWriterOnDispose: closeWriterOnDispose))
+                closeWriterOnDispose: closeWriterOnDispose,
+                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                kinds: new List<ResultKind> { ResultKind.Fail } ))
             {
                 logger.Log(
                     new ReportingDescriptor { Id = "MyId" },
@@ -174,7 +176,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     logFilePersistenceOptions: LogFilePersistenceOptions.None,
                     invocationTokensToRedact: tokensToRedact,
-                    invocationPropertiesToLog: new List<string> { "CommandLine" })) { }
+                    invocationPropertiesToLog: new List<string> { "CommandLine" },
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail })) { }
 
                 string result = sb.ToString();
                 result.Split(new string[] { SarifConstants.RedactedMarker }, StringSplitOptions.None)
@@ -204,7 +208,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     using (var sarifLogger = new SarifLogger(
                         textWriter,
                         analysisTargets: analysisTargets,
-                        dataToInsert: OptionallyEmittedData.Hashes))
+                        dataToInsert: OptionallyEmittedData.Hashes,
+                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                        kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                         LogSimpleResult(sarifLogger);
                     }
@@ -228,7 +234,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: new string[] { @"example.cpp" },
                     logFilePersistenceOptions: LogFilePersistenceOptions.None,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -286,7 +294,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     run: run,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -324,7 +334,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: new string[] { file },
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -375,7 +387,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                         textWriter,
                         run: run,
                         analysisTargets: analysisTargets,
-                        dataToInsert: OptionallyEmittedData.TextFiles))
+                        dataToInsert: OptionallyEmittedData.TextFiles,
+                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                        kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                     }
 
@@ -453,7 +467,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     using (var sarifLogger = new SarifLogger(
                         textWriter,
                         run: run,
-                        dataToInsert: OptionallyEmittedData.TextFiles))
+                        dataToInsert: OptionallyEmittedData.TextFiles,
+                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                        kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                         sarifLogger.Log(rule, result);
                     }
@@ -486,7 +502,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     dataToInsert: OptionallyEmittedData.TextFiles,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null,
-                    defaultFileEncoding: "ImaginaryEncoding"))
+                    defaultFileEncoding: "ImaginaryEncoding",
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -512,7 +530,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     string ruleId = "RuleId";
                     var rule = new ReportingDescriptor { Id = ruleId };
@@ -653,7 +673,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     var toolNotification = new Notification
                     {
@@ -712,7 +734,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null))
+                    invocationPropertiesToLog: null,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -744,7 +768,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: new[] { "WorkingDirectory", "ProcessId" }))
+                    invocationPropertiesToLog: new[] { "WorkingDirectory", "ProcessId" },
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -780,7 +806,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     analysisTargets: null,
                     dataToInsert: OptionallyEmittedData.Hashes,
                     invocationTokensToRedact: null,
-                    invocationPropertiesToLog: new[] { "WORKINGDIRECTORY", "prOCessID" }))
+                    invocationPropertiesToLog: new[] { "WORKINGDIRECTORY", "prOCessID" },
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -803,7 +831,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(textWriter))
+                using (var sarifLogger = new SarifLogger(   textWriter: textWriter, 
+                                                            levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                            kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     var rule = new ReportingDescriptor { Id = "RuleId" };
                     var result = new Result { RuleId = "RuleId/1" };
@@ -826,7 +856,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
-                    run: run))
+                    run: run,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -871,7 +903,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     run: run,
-                    analysisTargets: analysisTargets))
+                    analysisTargets: analysisTargets,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -904,7 +938,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     run: run,
-                    defaultFileEncoding: Utf7))
+                    defaultFileEncoding: Utf7,
+                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                    kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -937,7 +973,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             var sb = new StringBuilder();
 
             using (var writer = new StringWriter(sb))
-            using (var sarifLogger = new SarifLogger(writer))
+            using (var sarifLogger = new SarifLogger(   writer,
+                                                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                        kinds: new List<ResultKind> { ResultKind.Fail }))
             {
                 var rule = new ReportingDescriptor
                 {
@@ -975,7 +1013,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 SarifLogger logger;
 
                 // Validates overload that accept a path argument.
-                using (logger = new SarifLogger(fileName, loggingOption))
+                using (logger = new SarifLogger(fileName, 
+                                                loggingOption,
+                                                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 };
@@ -985,7 +1026,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 // StringBuilder instance).
                 var sb = new StringBuilder();
                 var stringWriter = new StringWriter(sb);
-                using (logger = new SarifLogger(stringWriter, loggingOption))
+                using (logger = new SarifLogger(stringWriter, 
+                                                loggingOption,
+                                                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 };

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 dataToRemove: OptionallyEmittedData.NondeterministicProperties,
                 closeWriterOnDispose: closeWriterOnDispose,
                 levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                kinds: new List<ResultKind> { ResultKind.Fail } ))
+                kinds: new List<ResultKind> { ResultKind.Fail }))
             {
                 logger.Log(
                     new ReportingDescriptor { Id = "MyId" },
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(   textWriter: textWriter, 
+                using (var sarifLogger = new SarifLogger(textWriter: textWriter,
                                                             levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
                                                             kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var sb = new StringBuilder();
 
             using (var writer = new StringWriter(sb))
-            using (var sarifLogger = new SarifLogger(   writer,
+            using (var sarifLogger = new SarifLogger(writer,
                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
             {
@@ -1013,7 +1013,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 SarifLogger logger;
 
                 // Validates overload that accept a path argument.
-                using (logger = new SarifLogger(fileName, 
+                using (logger = new SarifLogger(fileName,
                                                 loggingOption,
                                                 levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
                                                 kinds: new List<ResultKind> { ResultKind.Fail }))
@@ -1026,7 +1026,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 // StringBuilder instance).
                 var sb = new StringBuilder();
                 var stringWriter = new StringWriter(sb);
-                using (logger = new SarifLogger(stringWriter, 
+                using (logger = new SarifLogger(stringWriter,
                                                 loggingOption,
                                                 levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
                                                 kinds: new List<ResultKind> { ResultKind.Fail }))

--- a/src/Test.Utilities.Sarif/TestAnalyzeOptions.cs
+++ b/src/Test.Utilities.Sarif/TestAnalyzeOptions.cs
@@ -1,12 +1,20 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public class TestAnalyzeOptions : AnalyzeOptionsBase
     {
+        public TestAnalyzeOptions()
+        {
+            Kind = new List<ResultKind> { ResultKind.Fail };
+            Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error };
+        }
+
         public TestRuleBehaviors TestRuleBehaviors { get; set; }
 
         public bool DisableCheck { get; set; }


### PR DESCRIPTION
"kinds" must not be empty, and many of our unit tests left it that way.  I put some default values in to most of them.  This probably could have been abstracted a little better, but I wanted to handle that separately.