### PR TITLE
Improving memory usage

### DIFF
--- a/src/Sarif/Writers/CachingLogger.cs
+++ b/src/Sarif/Writers/CachingLogger.cs
@@ -48,6 +48,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 throw new ArgumentNullException(nameof(result));
             }
 
+            if (!ShouldLog(result))
+            {
+                return;
+            }
+
             if (rule.GetType().Name != nameof(ReportingDescriptor))
             {
                 rule = rule.DeepClone();


### PR DESCRIPTION
For a specific run, I observed that we were caching results that weren't need based on the level/kind.

Before:
![image](https://user-images.githubusercontent.com/16199012/109428392-c381f100-79d5-11eb-8559-e7ce1630c55e.png)

After:
![image](https://user-images.githubusercontent.com/16199012/109428410-d1d00d00-79d5-11eb-87e6-da0e551d7cf2.png)

During the first 40 seconds, I could see the number of objects increasing:

Before:
![image](https://user-images.githubusercontent.com/16199012/109428454-f926da00-79d5-11eb-95f6-5794495bdaa9.png)

After:
![image](https://user-images.githubusercontent.com/16199012/109428463-00e67e80-79d6-11eb-8859-63955e95e845.png)
