### PR TITLE
Disposing context after usage

### DIFF
--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         // ways depending on whether output is captured to a log file disk or not. In the latter case,
         // the captured output is useful to verify behavior.
         internal bool _captureConsoleOutput;
+
         internal ConsoleLogger _consoleLogger;
 
         private Run _run;
@@ -84,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                     if (!(ex is ExitApplicationException<ExitReason>))
                     {
-                        // These exceptions escaped our net and must be logged here                    
+                        // These exceptions escaped our net and must be logged here
                         RuntimeErrors |= Errors.LogUnhandledEngineException(_rootContext, ex);
                     }
                     ExecutionException = ex;
@@ -220,20 +221,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     itemsSeen.Add(item);
 
                     // This condition can occur if currentIndex moves
-                    // ahead in array processing due to operations 
-                    // against it by other threads. For this case, 
-                    // since the relevant file has already been 
+                    // ahead in array processing due to operations
+                    // against it by other threads. For this case,
+                    // since the relevant file has already been
                     // processed, we just ignore this notification.
                     if (currentIndex > item) { break; }
 
-                    TContext context = default;
+                    TContext context;
                     try
                     {
                         context = _fileContexts[currentIndex];
 
                         while (context?.AnalysisComplete == true)
                         {
-                            CachingLogger cachingLogger = ((CachingLogger)context.Logger);
+                            var cachingLogger = (CachingLogger)context.Logger;
                             IDictionary<ReportingDescriptor, IList<Result>> results = cachingLogger.Results;
 
                             if (results?.Count > 0)
@@ -276,6 +277,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                             RuntimeErrors |= context.RuntimeErrors;
 
+                            context.Dispose();
                             _fileContexts[currentIndex] = default;
 
                             context = currentIndex < (_fileContexts.Count - 1)
@@ -1017,7 +1019,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             SortedSet<Skimmer<TContext>> disabledSkimmers = new SortedSet<Skimmer<TContext>>(SkimmerIdComparer<TContext>.Instance);
 
-            // ONE-TIME initialization of skimmers. Do not call 
+            // ONE-TIME initialization of skimmers. Do not call
             // Initialize more than once per skimmer instantiation
             foreach (Skimmer<TContext> skimmer in skimmers)
             {


### PR DESCRIPTION
With this change, the quantity of GC will reduce, since we are saying: "hey, GC, you can dispose this."
If the number of calls to GC reduces, less time we will wait for GC to finish, so, in theory, the program will be faster!

Before:
![image](https://user-images.githubusercontent.com/16199012/109430483-6c354e00-79e0-11eb-9945-b8a5b32cb434.png)

After:
![image](https://user-images.githubusercontent.com/16199012/109430490-75261f80-79e0-11eb-9c7e-b00f9d7416c6.png)
