### PR TITLE
Repository check should be case insensitive

### DIFF
--- a/src/Sarif/GitHelper.cs
+++ b/src/Sarif/GitHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 repoPath.Substring(0, repoPath.Length - 1) :
                 repoPath;
 
-            return repoPath.Equals(GetTopLevel(repoPath));
+            return repoPath.Equals(GetTopLevel(repoPath), StringComparison.OrdinalIgnoreCase);
         }
 
         public GitHelper(IFileSystem fileSystem = null, ProcessRunner processRunner = null)


### PR DESCRIPTION
## Motivation
When we analyze a folder using SPAM and we pass a path that is not using the same casing, it won't fill the VersionControlProvenance because it will say that is different. With that, this will fix those cases.