### PR TITLE
Report inner exception details if available.

### DIFF
--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string message = string.Format(CultureInfo.CurrentCulture, messageFormat, args);
 
             ExceptionData exceptionData = exception != null && persistExceptionStack
-                ? ExceptionData.Create(exception)
+                ? ExceptionData.Create(exception.InnerException ?? exception)
                 : null;
 
             PhysicalLocation physicalLocation = uri != null

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -290,6 +290,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             );
         }
 
+
+        [Fact]
+        public void ExceptionRaisedInvokingAnalyze_PersistInnerException()
+        {
+            string location = GetThisTestAssemblyFilePath();
+
+            Run run = AnalyzeFile(location,
+                                  TestRuleBehaviors.RaiseExceptionInvokingAnalyze,
+                                  runtimeConditions: RuntimeConditions.ExceptionInSkimmerAnalyze,
+                                  expectedReturnCode: 1);
+
+            run.Invocations[0]?.ToolExecutionNotifications.Count.Should().Be(1);
+            Stack stack = run.Invocations[0]?.ToolExecutionNotifications[0].Exception.Stack;
+            string fqn = stack.Frames[0].Location.LogicalLocation.FullyQualifiedName;
+            fqn.Contains(nameof(TestRule.RaiseExceptionViaReflection)).Should().BeTrue();
+        }
+
+
         [Fact]
         public void ExceptionRaisedInEngine()
         {

--- a/src/Test.UnitTests.Sarif.Driver/TestRule.cs
+++ b/src/Test.UnitTests.Sarif.Driver/TestRule.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
+using System.Reflection;
 using System.Resources;
 
 using FluentAssertions;
@@ -148,7 +149,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 case TestRuleBehaviors.RaiseExceptionInvokingAnalyze:
                 {
-                    throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionInvokingAnalyze));
+                    MethodInfo mi = this.GetType().GetMethod("RaiseExceptionViaReflection");
+                    mi.Invoke(null, new object[] { });
+                    break;
                 }
 
                 case TestRuleBehaviors.RaiseTargetParseError:
@@ -233,6 +236,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                     nameof(SkimmerBaseTestResources.TEST1001_Information),
                     context.TargetUri.GetFileName()));
             }
+        }
+
+        public static void RaiseExceptionViaReflection()
+        {
+            throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionInvokingAnalyze));
         }
 
         public IEnumerable<IOption> GetOptions()


### PR DESCRIPTION
@eddynaka 

We currently do not persist exception stack to logs when the exception is passed via an inner exception.