### PR TITLE
Fix CodeQL code scanning issues

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
         languages: csharp
 
     - run: |
-        .\BuildAndTest.cmd -NoFormat
+        .\BuildAndTest.cmd -NoFormat -NoTest
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         internal static readonly string s_codeFlowsPerResultKey = $"{s_resultsPerRunKey}/0/{SarifPropertyName.CodeFlows}";
         internal static readonly string s_locationsPerThreadFlowKey = $"{s_codeFlowsPerResultKey}/0/{SarifPropertyName.ThreadFlows}/0/{SarifPropertyName.Locations}";
 
-        internal static Dictionary<string, int> s_arraySizeLimitDictionary = new Dictionary<string, int>
+        internal static ConcurrentDictionary<string, int> s_arraySizeLimitDictionary = new ConcurrentDictionary<string, int>
         {
             [s_runsPerLogKey] = 5,
             [s_rulesPerRunKey] = 1000,

--- a/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         internal static readonly string s_codeFlowsPerResultKey = $"{s_resultsPerRunKey}/0/{SarifPropertyName.CodeFlows}";
         internal static readonly string s_locationsPerThreadFlowKey = $"{s_codeFlowsPerResultKey}/0/{SarifPropertyName.ThreadFlows}/0/{SarifPropertyName.Locations}";
 
-        internal static ConcurrentDictionary<string, int> s_arraySizeLimitDictionary = new ConcurrentDictionary<string, int>
+        internal static readonly ConcurrentDictionary<string, int> s_arraySizeLimitDictionary = new ConcurrentDictionary<string, int>
         {
             [s_runsPerLogKey] = 5,
             [s_rulesPerRunKey] = 1000,

--- a/src/Test.UnitTests.Sarif.Converters/FortifyConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyConverterTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyConverter_Convert_ShortMessageIsUnset()
         {
-            Result result = FortifyConverter.ConvertFortifyIssueToSarifIssue(FortifyConverterTests.GetBasicIssue());
+            FortifyConverter.ConvertFortifyIssueToSarifIssue(FortifyConverterTests.GetBasicIssue());
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Converters/FxCopConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FxCopConverterTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 new LogicalLocation { ParentIndex = 2, Name = "mymember(string)", FullyQualifiedName = "mybinary.dll!mynamespace.mytype.mymember(string)", Kind = LogicalLocationKind.Member }
             };
             var converter = new FxCopConverter();
-            Result result = converter.CreateResult(context);
+            converter.CreateResult(context);
 
             ValidateLogicalLocations(expectedLogicalLocations, converter.LogicalLocations);
         }
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var converter = new FxCopConverter();
-            Result result = converter.CreateResult(context);
+            converter.CreateResult(context);
 
             ValidateLogicalLocations(expectedLogicalLocations, converter.LogicalLocations);
         }
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var converter = new FxCopConverter();
-            Result result = converter.CreateResult(context);
+            converter.CreateResult(context);
 
             ValidateLogicalLocations(expectedLogicalLocations, converter.LogicalLocations);
         }

--- a/src/Test.UnitTests.Sarif.Converters/ToolFileConverterBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/ToolFileConverterBaseTests.cs
@@ -34,14 +34,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void ConverterBase_SingleLogicalLocation()
         {
-            Location location = new Location
-            {
-                LogicalLocation = new LogicalLocation
-                {
-                    FullyQualifiedName = "a"
-                }
-            };
-
             var logicalLocation = new LogicalLocation
             {
                 Name = "a",
@@ -61,22 +53,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void ConverterBase_TwoIdenticalLogicalLocations()
         {
-            Location location1 = new Location
-            {
-                LogicalLocation = new LogicalLocation
-                {
-                    FullyQualifiedName = "a"
-                }
-            };
-
-            Location location2 = new Location
-            {
-                LogicalLocation = new LogicalLocation
-                {
-                    FullyQualifiedName = "a"
-                }
-            };
-
             var logicalLocation1 = new LogicalLocation
             {
                 Name = "a",
@@ -107,26 +83,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void ConverterBase_MultipleDistinctIdenticallyNamedLogicalLocations()
         {
-            Location location1 = new Location
-            {
-                LogicalLocation = new LogicalLocation
-                {
-                    FullyQualifiedName = "a"
-                }
-            };
-
             var logicalLocation1 = new LogicalLocation
             {
                 Name = "a",
                 Kind = LogicalLocationKind.Namespace
-            };
-
-            Location location2 = new Location
-            {
-                LogicalLocation = new LogicalLocation
-                {
-                    FullyQualifiedName = "a"
-                }
             };
 
             var logicalLocation2 = new LogicalLocation

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             analyzeOptions ??= new TestAnalyzeOptions()
             {
-                TargetFileSpecifiers = new string[] { }
+                TargetFileSpecifiers = Array.Empty<string>()
             };
 
             ExceptionTestHelperImplementation(
@@ -57,13 +57,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
              bool multithreaded)
         {
             TestRule.s_testRuleBehaviors = analyzeOptions.TestRuleBehaviors.AccessibleOutsideOfContextOnly();
-
-            analyzeOptions = analyzeOptions ?? new TestAnalyzeOptions()
-            {
-                TestRuleBehaviors = analyzeOptions.TestRuleBehaviors.AccessibleWithinContextOnly(),
-                TargetFileSpecifiers = new string[0]
-            };
-
             Assembly[] plugInAssemblies = null;
 
             if (analyzeOptions.DefaultPlugInFilePaths != null)

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             try
             {
-                using (FileStream stream = File.OpenWrite(path))
+                using (_ = File.OpenWrite(path))
                 {
                     // Our log file is locked for write
                     // causing exceptions at analysis time.
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             path = Path.Combine(path, Guid.NewGuid().ToString());
 
-            using (FileStream stream = File.Create(path, 1, FileOptions.DeleteOnClose))
+            using (_ = File.Create(path, 1, FileOptions.DeleteOnClose))
             {
                 // Attempt to persist to unauthorized location will raise exception.
                 var options = new TestAnalyzeOptions()
@@ -485,7 +485,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string path = Path.GetTempFileName() + ".sarif";
 
-            using (FileStream stream = File.Create(path, 1, FileOptions.DeleteOnClose))
+            using (_ = File.Create(path, 1, FileOptions.DeleteOnClose))
             {
                 var options = new TestAnalyzeOptions()
                 {
@@ -1087,7 +1087,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 options.Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None };
             }
 
-            int expectedResultsCount = testCase.ExpectedWarningCount + testCase.ExpectedErrorCount;
             Run runWithoutCaching = RunAnalyzeCommand(options, testCase);
 
             options.DataToInsert = new OptionallyEmittedData[] { OptionallyEmittedData.Hashes };

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/RuleUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/RuleUtilitiesTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             (context.RuntimeErrors & RuntimeConditions.OneOrMoreWarningsFired).Should().Be(RuntimeConditions.None);
             (context.RuntimeErrors & RuntimeConditions.OneOrMoreErrorsFired).Should().Be(RuntimeConditions.OneOrMoreErrorsFired);
 
-            result = RuleUtilities.BuildResult(
+            RuleUtilities.BuildResult(
                 FailureLevel.Warning,
                 context,
                 region,

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/SarifLoggerTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var textWriter = new StringWriter();
 
-            var logger = new SarifLogger(
+            _ = new SarifLogger(
                 textWriter,
                 analysisTargets: Enumerable.Empty<string>(),
                 logFilePersistenceOptions: LogFilePersistenceOptions.None,

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
@@ -191,7 +191,6 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         [Fact]
         public void SarifWorkItemExtensions_GetAggregateResultCount_ComputeResultCountsFromLogs()
         {
-            var context = new SarifWorkItemContext();
             SarifLog sarifLog = TestData.CreateOneIdThreeLocations();
 
             int resultCount = sarifLog.GetAggregateFilableResultsCount();
@@ -209,7 +208,6 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         [Fact]
         public void SarifWorkItemExtensions_GetRunToolNames_FetchesAllRunToolNames()
         {
-            var context = new SarifWorkItemContext();
             SarifLog sarifLog = TestData.CreateOneIdThreeLocations();
 
             List<string> toolNames = sarifLog.GetToolNames();

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemFilerTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemFilerTests.cs
@@ -142,14 +142,13 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             //       This implies created both the connection mocks and the mocks for filing, updating, and attaching work items.
             //       We are required to put this mock behind an interface due to an inability to mock these types directly.
 
-            FilingClient filingClient;
             if (adoClient == true)
             {
-                filingClient = CreateAdoMocksAndFilingClient(attachmentReference, workItem, filer);
+                CreateAdoMocksAndFilingClient(attachmentReference, workItem, filer);
             }
             else
             {
-                filingClient = CreateGitHubMocksAndFilingClient(bugUriText, bugHtmlUriText, filer);
+                CreateGitHubMocksAndFilingClient(bugUriText, bugHtmlUriText, filer);
             }
 
             string sarifLogText = JsonConvert.SerializeObject(sarifLog);

--- a/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
+++ b/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             foreach (T member in expected)
             {
-                actual.Should().Contain(expected);
+                actual.Should().Contain(member);
             }
             actual.Count.Should().Be(expected.Count);
         }

--- a/src/Test.UnitTests.Sarif/WarningsTests.cs
+++ b/src/Test.UnitTests.Sarif/WarningsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             testLogger.Messages.Should().BeNull();
             testLogger.ToolNotifications.Should().BeNull();
             testLogger.ConfigurationNotifications.Count.Should().Equals(1);
-            testLogger.ConfigurationNotifications[0].Descriptor.Id.Should().Equals(ruleId);
+            testLogger.ConfigurationNotifications[0].Descriptor.Id.Should().BeEquivalentTo(Warnings.Wrn999_RuleExplicitlyDisabled);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     Assert.False(true, pathToExe + " " + commandLine);
                 }
 
-                using (var sarifLogger = new SarifLogger(
+                using (_ = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
                     logFilePersistenceOptions: LogFilePersistenceOptions.None,
@@ -243,10 +243,10 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             string output = sb.ToString();
-            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(output);
+            JsonConvert.DeserializeObject<SarifLog>(output);
 
             string sarifLoggerLocation = typeof(SarifLogger).Assembly.Location;
-            string expectedVersion = FileVersionInfo.GetVersionInfo(sarifLoggerLocation).FileVersion;
+            _ = FileVersionInfo.GetVersionInfo(sarifLoggerLocation).FileVersion;
         }
 
         [Fact]
@@ -254,14 +254,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             string propertyName = "numberValue";
             double propertyValue = 3.14;
-            string logicalId = nameof(logicalId) + ":" + Guid.NewGuid().ToString();
             string baselineInstanceGuid = nameof(baselineInstanceGuid) + ":" + Guid.NewGuid().ToString();
             string runInstanceGuid = Guid.NewGuid().ToString();
             string automationLogicalId = nameof(automationLogicalId) + ":" + Guid.NewGuid().ToString();
             string runInstanceId = automationLogicalId + "/" + runInstanceGuid;
-            string architecture = nameof(architecture) + ":" + "x86";
             var conversion = new Conversion() { Tool = DefaultTool };
-            DateTime utcNow = DateTime.UtcNow;
             var versionControlUri = new Uri("https://www.github.com/contoso/contoso");
             var versionControlDetails = new VersionControlDetails() { RepositoryUri = versionControlUri, AsOfTimeUtc = DateTime.UtcNow };
             string originalUriBaseIdKey = "testBase";
@@ -291,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 run.DefaultEncoding = defaultEncoding;
                 run.RedactionTokens = redactionTokens;
 
-                using (var sarifLogger = new SarifLogger(
+                using (_ = new SarifLogger(
                     textWriter,
                     run: run,
                     invocationPropertiesToLog: null,
@@ -363,8 +360,6 @@ namespace Microsoft.CodeAnalysis.Sarif
             using (var tempFile = new TempFile(".txt"))
             {
                 string tempFilePath = tempFile.Name;
-                string tempFileDirectory = Path.GetDirectoryName(tempFilePath);
-                string tempFileName = Path.GetFileName(tempFilePath);
 
                 File.WriteAllText(tempFilePath, "#include \"windows.h\";");
 
@@ -383,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var textWriter = new StringWriter(sb))
                 {
                     // Create a logger that inserts artifact contents.
-                    using (var sarifLogger = new SarifLogger(
+                    using (_ = new SarifLogger(
                         textWriter,
                         run: run,
                         analysisTargets: analysisTargets,
@@ -854,7 +849,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
+                using (_ = new SarifLogger(
                     textWriter,
                     run: run,
                     levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
@@ -900,7 +895,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
+                using (_ = new SarifLogger(
                     textWriter,
                     run: run,
                     analysisTargets: analysisTargets,
@@ -935,7 +930,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             using (var textWriter = new StringWriter(sb))
             {
                 // Create a logger that uses that run but specifies a different encoding.
-                using (var sarifLogger = new SarifLogger(
+                using (_ = new SarifLogger(
                     textWriter,
                     run: run,
                     defaultFileEncoding: Utf7,


### PR DESCRIPTION
- Dereferenced variable is always null
- Equals on incomparable types
- Container contents are never accessed
- Unsynchronized access to static collection member in non-static context