### PR TITLE
Reusing results from MultithreadedAnalyzeCommandBase when hash is enabled

### DIFF
--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -617,10 +617,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 if (_computeHashes)
                 {
                     context.Hashes = HashUtilities.ComputeHashes(filePath);
-                    _pathToHashDataMap[filePath] = context.Hashes;
-                    _run.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
-                                      dataToInsert: _dataToInsert,
-                                      hashData: context.Hashes);
+                    if (_pathToHashDataMap != null)
+                    {
+                        _pathToHashDataMap[filePath] = context.Hashes;
+                        _run.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
+                                          dataToInsert: _dataToInsert,
+                                          hashData: context.Hashes);
+                    }
                 }
             }
 

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var sortedDiskItems = new SortedSet<string>();
 
             queue.Enqueue(directory);
-            foreach (string childDirectory in Directory.EnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly))
+            foreach (string childDirectory in FileSystem.DirectoryEnumerateDirectories(directory, "*", SearchOption.TopDirectoryOnly))
             {
                 sortedDiskItems.Add(childDirectory);
             }

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -75,6 +75,29 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         /// <summary>
+        /// Returns an enumerable collection of directory full names in a specified path.
+        /// </summary>
+        /// <param name="path">
+        /// Thee relative or absolute path to the directory to search. This string is not case-sensitive.
+        /// </param>
+        /// <param name="searchPattern">
+        /// The search string to match against the names of directories in path. This parameter can contain
+        /// a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.
+        /// </param>
+        /// <param name="searchOption">
+        /// One of the enumeration values that specifies whether the search operation should include only the current
+        /// directory or should include all subdirectories. The default value is TopDirectoryOnly.
+        /// </param>
+        /// <returns>
+        /// An enumerable collection of the full names (including paths) for the directories in the directory specified
+        /// by path and that match the specified search pattern and search option.
+        /// </returns>
+        public IEnumerable<string> DirectoryEnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
+        }
+
+        /// <summary>
         /// Returns the names of subdirectories (including their paths) in the specified directory.
         /// </summary>
         /// <param name="path">

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -31,14 +31,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static IDictionary<string, HashData> MultithreadedComputeTargetFileHashes(IEnumerable<string> analysisTargets, bool suppressConsoleOutput = false)
         {
-            if (analysisTargets == null) { return null; }
+            var fileToHashDataMap = new ConcurrentDictionary<string, HashData>();
+            if (analysisTargets == null) { return fileToHashDataMap; }
 
             if (!suppressConsoleOutput)
             {
                 Console.WriteLine("Computing file hashes...");
             }
-
-            var fileToHashDataMap = new ConcurrentDictionary<string, HashData>();
 
             var queue = new ConcurrentQueue<string>(analysisTargets);
 

--- a/src/Sarif/IFileSystem.cs
+++ b/src/Sarif/IFileSystem.cs
@@ -52,6 +52,26 @@ namespace Microsoft.CodeAnalysis.Sarif
         void DirectoryDelete(string path, bool recursive = false);
 
         /// <summary>
+        /// Returns an enumerable collection of directory full names in a specified path.
+        /// </summary>
+        /// <param name="path">
+        /// Thee relative or absolute path to the directory to search. This string is not case-sensitive.
+        /// </param>
+        /// <param name="searchPattern">
+        /// The search string to match against the names of directories in path. This parameter can contain
+        /// a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.
+        /// </param>
+        /// <param name="searchOption">
+        /// One of the enumeration values that specifies whether the search operation should include only the current
+        /// directory or should include all subdirectories. The default value is TopDirectoryOnly.
+        /// </param>
+        /// <returns>
+        /// An enumerable collection of the full names (including paths) for the directories in the directory specified
+        /// by path and that match the specified search pattern and search option.
+        /// </returns>
+        IEnumerable<string> DirectoryEnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
+
+        /// <summary>
         /// Returns an enumerable collection of file names in a specified path.
         /// </summary>
         /// <param name="path">

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                         new Uri(target, UriKind.RelativeOrAbsolute),
                         dataToInsert,
                         encoding,
-                        hashData: hashData);
+                        hashData);
 
                     var fileLocation = new ArtifactLocation
                     {
@@ -197,9 +197,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     artifact.Location.Index = _run.GetFileIndex(
                         artifact.Location,
                         addToFilesTableIfNotPresent: true,
-                        dataToInsert: dataToInsert,
-                        encoding: encoding,
-                        hashData: hashData);
+                        dataToInsert,
+                        encoding,
+                        hashData);
                 }
             }
 
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 addToFilesTableIfNotPresent: _persistArtifacts,
                 _dataToInsert,
                 encoding,
-                hashData: hashData);
+                hashData);
 
             // Remove redundant Uri and UriBaseId once index has been set
             if (index > -1 && this.Optimize)

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -447,12 +447,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 catch (ArgumentException) { } // Unrecognized encoding name
             }
 
+            HashData hashData = null;
+            AnalysisTargetToHashDataMap?.TryGetValue(fileLocation.Uri.LocalPath, out hashData);
+
             // Ensure Artifact is in Run.Artifacts and ArtifactLocation.Index is set to point to it
             int index = _run.GetFileIndex(
                 fileLocation,
                 addToFilesTableIfNotPresent: _persistArtifacts,
                 _dataToInsert,
-                encoding);
+                encoding,
+                hashData: hashData);
 
             // Remove redundant Uri and UriBaseId once index has been set
             if (index > -1 && this.Optimize)

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -448,10 +448,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
 
             HashData hashData = null;
-            if (fileLocation.Uri.IsAbsoluteUri)
-            {
-                AnalysisTargetToHashDataMap?.TryGetValue(fileLocation.Uri.LocalPath, out hashData);
-            }
+            AnalysisTargetToHashDataMap?.TryGetValue(fileLocation.Uri.OriginalString, out hashData);
 
             // Ensure Artifact is in Run.Artifacts and ArtifactLocation.Index is set to point to it
             int index = _run.GetFileIndex(

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -448,7 +448,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
 
             HashData hashData = null;
-            AnalysisTargetToHashDataMap?.TryGetValue(fileLocation.Uri.LocalPath, out hashData);
+            if (fileLocation.Uri.IsAbsoluteUri)
+            {
+                AnalysisTargetToHashDataMap?.TryGetValue(fileLocation.Uri.LocalPath, out hashData);
+            }
 
             // Ensure Artifact is in Run.Artifacts and ArtifactLocation.Index is set to point to it
             int index = _run.GetFileIndex(

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -953,7 +953,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var testCase = new ResultsCachingTestCase()
             {
                 Files = new List<string> { "Note.dll", "Note.exe", "Note.sys" },
-                PersistLogFileToDisk = true
             };
 
             // Notes are verbose only results
@@ -1001,6 +1000,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase);
+
+            testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
+
+            testCase.Verbose = true;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
         }
 
         [Fact]
@@ -1031,12 +1036,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase);
 
-            testCase = new ResultsCachingTestCase
-            {
-                Files = ComprehensiveKindAndLevelsByFilePath,
-                PersistLogFileToDisk = true,
-            };
-
+            testCase.Files = ComprehensiveKindAndLevelsByFilePath;
             RunResultsCachingTestCase(testCase, multithreaded: true);
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase, multithreaded: true);

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1002,6 +1002,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             RunResultsCachingTestCase(testCase);
 
             testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+            testCase.Verbose = false;
             RunResultsCachingTestCase(testCase, multithreaded: true);
 
             testCase.Verbose = true;
@@ -1033,11 +1034,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             };
 
             RunResultsCachingTestCase(testCase);
+
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase);
 
             testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+            testCase.Verbose = false;
             RunResultsCachingTestCase(testCase, multithreaded: true);
+
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase, multithreaded: true);
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -299,7 +299,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             );
         }
 
-
         [Fact]
         public void ExceptionRaisedInvokingAnalyze_PersistInnerException()
         {
@@ -315,7 +314,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             string fqn = stack.Frames[0].Location.LogicalLocation.FullyQualifiedName;
             fqn.Contains(nameof(TestRule.RaiseExceptionViaReflection)).Should().BeTrue();
         }
-
 
         [Fact]
         public void ExceptionRaisedInEngine()
@@ -334,6 +332,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 analyzeOptions: options);
 
             TestAnalyzeCommand.RaiseUnhandledExceptionInDriverCode = false;
+            TestMultithreadedAnalyzeCommand.RaiseUnhandledExceptionInDriverCode = false;
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -983,6 +983,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase);
+
+            testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+            testCase.Verbose = false;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
+
+            testCase.Verbose = true;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
         }
 
         [Fact]
@@ -1022,6 +1029,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             testCase.Verbose = true;
             RunResultsCachingTestCase(testCase);
+
+            testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+            testCase.Verbose = false;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
+
+            testCase.Verbose = true;
+            RunResultsCachingTestCase(testCase, multithreaded: true);
         }
 
         [Fact]


### PR DESCRIPTION
## Description

When someone uses `MultithreadedAnalyzeCommandBase`, the analysis will execute in parallel.
If we have the same file copied over and over it would process it multiple times since we don't have any caching mechanism that could be enabled.

Comparing with `AnalyzeCommandBase`, if we have the `--insert Hashes` argument, it would cache the result and re-use the results.
https://github.com/microsoft/sarif-sdk/blob/28b7706a4d684a07ff38dd79bdf52469d24526c2/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs#L650-L684

## Proposal

The idea is to re-use the results from a previous analysis if the hash of the file is the same.
This would mimic `AnalyzeCommandBase` caching mechanism if `--insert Hashes` is enabled. Otherwise, the cache would **not** be constructed/used.