### PR TITLE
Fix sample code and use file stream with SarifLogger

### DIFF
--- a/src/Samples/Sarif.Sdk.Sample/CreateOptions.cs
+++ b/src/Samples/Sarif.Sdk.Sample/CreateOptions.cs
@@ -14,11 +14,16 @@ namespace Sarif.Sdk.Sample
                Required = true)]
         public string OutputFilePath { get; internal set; }
 
-        [Option('n',
-                "numResult",
+        [Option("numResult",
                 Default = 1,
                 HelpText = "Number of results per rule to be generated in the sample program",
-                Required = true)]
+                Required = false)]
         public int NumOfResultPerRule { get; set; }
+
+        [Option("useFileStream",
+        Default = false,
+        HelpText = "Use file stream to write sarif file if true.",
+        Required = false)]
+        public bool UseFileStream { get; set; }
     }
 }

--- a/src/Samples/Sarif.Sdk.Sample/CreateOptions.cs
+++ b/src/Samples/Sarif.Sdk.Sample/CreateOptions.cs
@@ -13,5 +13,12 @@ namespace Sarif.Sdk.Sample
                HelpText = "The path of the file to be written.",
                Required = true)]
         public string OutputFilePath { get; internal set; }
+
+        [Option('n',
+                "numResult",
+                Default = 1,
+                HelpText = "Number of results per rule to be generated in the sample program",
+                Required = true)]
+        public int NumOfResultPerRule { get; set; }
     }
 }

--- a/src/Samples/Sarif.Sdk.Sample/Program.cs
+++ b/src/Samples/Sarif.Sdk.Sample/Program.cs
@@ -447,7 +447,7 @@ namespace Sarif.Sdk.Sample
                             }
                         }
                     },
-                    CodeFlows = new[] 
+                    CodeFlows = new[]
                     {
                         new CodeFlow
                         {


### PR DESCRIPTION
Optimized the sample code to use file stream instead of string builder for writing to .sarif file.

Below are comparisons between filestream and memory:

500 results.
```
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 500 --useFileStream
Serialize Sarif Result using FileStream in 744 ms and 1.1 MB RAM.
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 500
Serialize Sarif Result using StringBuilder in 667 ms and 22.4 MB RAM.
```

5000 results.
```
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 5000 --useFileStream
Serialize Sarif Result using FileStream in 4,542 ms and 1.1 MB RAM.
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 5000
Serialize Sarif Result using StringBuilder in 4,689 ms and 213.7 MB RAM.
```

50000 results:
```
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 50000
using string builder crashed with out of memory exception.
..\bin\Release> .\SarifSdkSample.exe create C:\SarifLog\sample1.sarif --numResult 50000 --useFileStream
Serialize Sarif Result using FileStream in 39,285 ms and 1.1 MB RAM.