### PR TITLE
Fix location Uri and number of artifact in work item description

### DIFF
--- a/src/Sarif.WorkItems/SarifWorkItemModel.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemModel.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
             this.BodyOrDescription =
                 Environment.NewLine +
-                sarifLog.CreateWorkItemDescription(this.Context, LocationUris) +
+                sarifLog.CreateWorkItemDescription(this.Context) +
                 descriptionFooter;
 
             // These properties are Azure DevOps-specific. All ADO work item board

--- a/src/Sarif.WorkItems/SarifWorkItemsExtensions.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemsExtensions.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             string phrasedToolNames = toolNames.ToAndPhrase();
             string multipleToolsFooter = toolNames.Count > 1 ? WorkItemsResources.MultipleToolsFooter : string.Empty;
 
-            IEnumerable<Result> results = log.Runs?[0]?.Results.Where(r => r.ShouldBeFiled());
+            IEnumerable<Result> results = log?.Runs?[0]?.Results.Where(r => r.ShouldBeFiled());
             Uri runRepositoryUri = log?.Runs.FirstOrDefault()?.VersionControlProvenance?.FirstOrDefault().RepositoryUri;
             Uri detectionLocationUri = !string.IsNullOrEmpty(runRepositoryUri?.OriginalString) ?
                                        runRepositoryUri :
@@ -158,7 +158,8 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 ? context.CreateLinkText(detectionLocationUri.OriginalString, detectionLocationUri?.OriginalString)
                 : detectionLocationUri?.OriginalString;
 
-            int locCount = results
+            int locCount = results == null ? 0 :
+                           results
                            .Where(r => r.Locations != null)
                            .SelectMany(r => r.Locations)
                            .Where(l => l.PhysicalLocation != null && l.PhysicalLocation.ArtifactLocation != null && l.PhysicalLocation.ArtifactLocation.Uri != null)

--- a/src/Sarif.WorkItems/SarifWorkItemsExtensions.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemsExtensions.cs
@@ -141,23 +141,32 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 .Sum() ?? 0;
         }
 
-        public static string CreateWorkItemDescription(this SarifLog log, SarifWorkItemContext context, IList<Uri> locationUris)
+        public static string CreateWorkItemDescription(this SarifLog log, SarifWorkItemContext context)
         {
             int totalResults = log.GetAggregateFilableResultsCount();
             List<string> toolNames = log.GetToolNames();
             string phrasedToolNames = toolNames.ToAndPhrase();
             string multipleToolsFooter = toolNames.Count > 1 ? WorkItemsResources.MultipleToolsFooter : string.Empty;
 
+            IEnumerable<Result> results = log.Runs?[0]?.Results.Where(r => r.ShouldBeFiled());
             Uri runRepositoryUri = log?.Runs.FirstOrDefault()?.VersionControlProvenance?.FirstOrDefault().RepositoryUri;
-            Uri detectionLocationUri = !string.IsNullOrEmpty(runRepositoryUri?.OriginalString) ? runRepositoryUri : locationUris?[0];
+            Uri detectionLocationUri = !string.IsNullOrEmpty(runRepositoryUri?.OriginalString) ?
+                                       runRepositoryUri :
+                                       results?.FirstOrDefault().Locations?[0].PhysicalLocation?.ArtifactLocation?.Uri;
 
             string detectionLocation = (detectionLocationUri?.IsAbsoluteUri == true && detectionLocationUri?.Scheme == "https")
                 ? context.CreateLinkText(detectionLocationUri.OriginalString, detectionLocationUri?.OriginalString)
                 : detectionLocationUri?.OriginalString;
 
-            if (locationUris?.Count > 1)
+            int locCount = results
+                           .Where(r => r.Locations != null)
+                           .SelectMany(r => r.Locations)
+                           .Where(l => l.PhysicalLocation != null && l.PhysicalLocation.ArtifactLocation != null && l.PhysicalLocation.ArtifactLocation.Uri != null)
+                           .Count();
+
+            if (locCount > 1)
             {
-                int additionalLocations = locationUris.Count - 1;
+                int additionalLocations = locCount - 1;
                 detectionLocation = $"{detectionLocation} (+{additionalLocations} locations)";
             }
 

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
+using Microsoft.VisualStudio.Services.Common;
 
 using Xunit;
 
@@ -238,6 +239,76 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             string description = sarifLog.CreateWorkItemDescription(new SarifWorkItemContext() { CurrentProvider = Microsoft.WorkItems.FilingClient.SourceControlProvider.AzureDevOps });
 
             description.Should().BeEquivalentTo($"This work item contains 1 '{toolName}' issue(s) detected in {firstLocation} (+{additionLocationCount} locations). Click the 'Scans' tab to review results.");
+        }
+
+        [Fact]
+        public void SarifWorkItemExtensions_CreateWorkItemDescription_MultipleResults()
+        {
+            string toolName = "TestToolName";
+            string firstLocation = @"C:\Test\Data\File{0}sarif";
+            int numOfResult = 15;
+            string additionLocationCount = "14";
+
+            int index = 1;
+            SarifLog sarifLog = TestData.CreateSimpleLogWithRules(0, numOfResult);
+            sarifLog.Runs[0].Results.ForEach(r => r.Locations
+                                               = new[]
+                                               {
+                                                   new Location
+                                                   {
+                                                       PhysicalLocation = new PhysicalLocation
+                                                       {
+                                                           ArtifactLocation = new ArtifactLocation
+                                                           {
+                                                               Uri = new Uri(string.Format(firstLocation, index++))
+                                                           }
+                                                       }
+                                                   }
+                                               });
+
+            string description = sarifLog.CreateWorkItemDescription(new SarifWorkItemContext() { CurrentProvider = Microsoft.WorkItems.FilingClient.SourceControlProvider.AzureDevOps });
+
+            description.Should().BeEquivalentTo($"This work item contains {numOfResult} '{toolName}' issue(s) detected in {string.Format(firstLocation, 1)} (+{additionLocationCount} locations). Click the 'Scans' tab to review results.");
+        }
+
+        [Fact]
+        public void SarifWorkItemExtensions_CreateWorkItemDescription_MultipleResultsMultipleLocations()
+        {
+            string toolName = "TestToolName";
+            string firstLocation = @"C:\Test\Data\File{0}sarif";
+            int numOfResult = 15;
+            string additionLocationCount = "29"; // 15 results each results have 2 locations
+
+            int index = 1;
+            SarifLog sarifLog = TestData.CreateSimpleLogWithRules(0, numOfResult);
+            sarifLog.Runs[0].Results.ForEach(r => r.Locations
+                                               = new[]
+                                               {
+                                                   new Location
+                                                   {
+                                                       PhysicalLocation = new PhysicalLocation
+                                                       {
+                                                           ArtifactLocation = new ArtifactLocation
+                                                           {
+                                                               Uri = new Uri(string.Format(firstLocation, index++))
+                                                           }
+                                                       }
+                                                   },
+                                                   new Location
+                                                   {
+                                                       PhysicalLocation = new PhysicalLocation
+                                                       {
+                                                           ArtifactLocation = new ArtifactLocation
+                                                           {
+                                                               Uri = new Uri(string.Format(firstLocation, index++))
+                                                           }
+                                                       }
+                                                   }
+                                               });
+
+            string description = sarifLog.CreateWorkItemDescription(new SarifWorkItemContext() { CurrentProvider = Microsoft.WorkItems.FilingClient.SourceControlProvider.AzureDevOps });
+
+            description.Should().BeEquivalentTo($"This work item contains {numOfResult} '{toolName}' issue(s) detected in {string.Format(firstLocation, 1)} (+{additionLocationCount} locations). Click the 'Scans' tab to review results.");
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
@@ -225,6 +225,94 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             toolNames.Count.Should().Be(0);
         }
 
+        [Fact]
+        public void SarifWorkItemExtensions_CreateWorkItemDescription_SingleResultMultipleLocations()
+        {
+            string toolName = "TestToolName";
+            string firstLocation = @"C:\Test\Data\File1.sarif";
+            string additionLocationCount = "2";
+
+            SarifLog sarifLog = TestData.CreateOneIdThreeLocations();
+            sarifLog.Runs[0].VersionControlProvenance = null;
+
+            string description = sarifLog.CreateWorkItemDescription(new SarifWorkItemContext() { CurrentProvider = Microsoft.WorkItems.FilingClient.SourceControlProvider.AzureDevOps });
+
+            description.Should().BeEquivalentTo($"This work item contains 1 '{toolName}' issue(s) detected in {firstLocation} (+{additionLocationCount} locations). Click the 'Scans' tab to review results.");
+        }
+
+        [Fact]
+        public void SarifWorkItemExtensions_CreateWorkItemDescription_SingleResultWithMultipleArtifacts()
+        {
+            string toolName = "TestToolName";
+            string firstLocation = @"C:\Test\Data\File1.sarif";
+            string secondLocation = @"C:\Test\Data\File2.sarif";
+            string thirdLocation = @"C:\Test\Data\File3.sarif";
+
+            SarifLog sarifLog = TestData.CreateSimpleLogWithRules(0, 1);
+            sarifLog.Runs[0].Results[0].Locations = new[]
+            {
+                new Location
+                {
+                    PhysicalLocation = new PhysicalLocation
+                    {
+                        ArtifactLocation = new ArtifactLocation
+                        {
+                            Uri = new Uri(firstLocation),
+                        }
+                    }
+                }
+            };
+
+            sarifLog.Runs[0].Results[0].RelatedLocations = new[]
+            {
+                new Location
+                {
+                    PhysicalLocation = new PhysicalLocation
+                    {
+                        ArtifactLocation = new ArtifactLocation
+                        {
+                            Uri = new Uri(secondLocation),
+                        }
+                    }
+                }
+            };
+
+            sarifLog.Runs[0].Results[0].CodeFlows = new[]
+            {
+                new CodeFlow
+                {
+                    ThreadFlows = new[]
+                    {
+                        new ThreadFlow
+                        {
+                            Locations = new[]
+                            {
+                                new ThreadFlowLocation
+                                {
+                                    Location = new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                            ArtifactLocation = new ArtifactLocation
+                                            {
+                                                Uri = new Uri(thirdLocation),
+                                            }
+                                       }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            sarifLog.Runs[0].VersionControlProvenance = null;
+
+            string description = sarifLog.CreateWorkItemDescription(new SarifWorkItemContext() { CurrentProvider = Microsoft.WorkItems.FilingClient.SourceControlProvider.AzureDevOps });
+
+            description.Should().BeEquivalentTo($"This work item contains 1 '{toolName}' issue(s) detected in {firstLocation}. Click the 'Scans' tab to review results.");
+        }
+
         private static readonly string ToolName = Guid.NewGuid().ToString();
 
         public Tuple<string, Result>[] ResultsWithVariousRuleExpressions = new[]


### PR DESCRIPTION
Fixes #2385

Existing code calculate total artifacts using global artifacts, which includes all artifacts if referenced by result's codeFlows/relatedLocations, and pick first artifact uri in description, which may not be the result's location uri.

The change is only calculate artifacts based on results.