### PR TITLE
Enable automation details for command base

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         internal ConsoleLogger _consoleLogger;
 
+        private Run _run;
         private Tool _tool;
         private TContext _rootContext;
         private CacheByFileHashLogger _cacheByFileHashLogger;
@@ -432,6 +433,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         SarifLogger sarifLogger;
 
+                        _run = new Run();
+
+                        if (!string.IsNullOrWhiteSpace(analyzeOptions.AutomationId) || !string.IsNullOrWhiteSpace(analyzeOptions.AutomationGuid))
+                        {
+                            _run.AutomationDetails = new RunAutomationDetails
+                            {
+                                Id = analyzeOptions.AutomationId,
+                                Guid = analyzeOptions.AutomationGuid
+                            };
+                        }
+
                         if (analyzeOptions.SarifOutputVersion != SarifVersion.OneZeroZero)
                         {
                             sarifLogger = new SarifLogger(
@@ -440,7 +452,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                                     dataToInsert,
                                     dataToRemove,
                                     tool: _tool,
-                                    run: null,
+                                    run: _run,
                                     analysisTargets: targets,
                                     quiet: analyzeOptions.Quiet,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
@@ -456,7 +468,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                                     dataToInsert,
                                     dataToRemove,
                                     tool: _tool,
-                                    run: null,
+                                    run: _run,
                                     analysisTargets: targets,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
                                     invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog,

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -433,16 +433,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         SarifLogger sarifLogger;
 
-                        _run = new Run();
-
-                        if (!string.IsNullOrWhiteSpace(analyzeOptions.AutomationId) || !string.IsNullOrWhiteSpace(analyzeOptions.AutomationGuid))
+                        _run = new Run()
                         {
-                            _run.AutomationDetails = new RunAutomationDetails
+                            AutomationDetails = new RunAutomationDetails
                             {
                                 Id = analyzeOptions.AutomationId,
                                 Guid = analyzeOptions.AutomationGuid
-                            };
-                        }
+                            }
+                        };
 
                         if (analyzeOptions.SarifOutputVersion != SarifVersion.OneZeroZero)
                         {

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -112,12 +112,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         [Option(
             "automationId",
-            HelpText = "An id that will be used in the output SARIF and show in the 'automationDetails.id' under 'run'.")]
+            HelpText = "An id that will be persisted to the 'Run.AutomationDetails.Id' property. See section '3.17.3' of the SARIF specification for more information.")]
         public string AutomationId { get; set; }
 
         [Option(
             "automationGuid",
-            HelpText = "A guid that will be used in the output SARIF and show in the 'automationDetails.guid' under 'run'.")]
+            HelpText = "A guid that will be persisted to the 'Run.AutomationDetails.Guid' property. See section '3.17.4' of the SARIF specification for more information.")]
         public string AutomationGuid { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -107,7 +107,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         [Option(
             "baseline",
-            HelpText = "A Sarif file to be used as baseline")]
+            HelpText = "A SARIF file to be used as baseline.")]
         public string BaselineSarifFile { get; set; }
+
+        [Option(
+            "automationId",
+            HelpText = "An id that will be used in the output SARIF and show in the 'automationDetails.id' under 'run'.")]
+        public string AutomationId { get; set; }
+
+        [Option(
+            "automationGuid",
+            HelpText = "A guid that will be used in the output SARIF and show in the 'automationDetails.guid' under 'run'.")]
+        public string AutomationGuid { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -731,6 +731,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         _run = new Run();
 
+                        if (!string.IsNullOrWhiteSpace(analyzeOptions.AutomationId) || !string.IsNullOrWhiteSpace(analyzeOptions.AutomationGuid))
+                        {
+                            _run.AutomationDetails = new RunAutomationDetails
+                            {
+                                Id = analyzeOptions.AutomationId,
+                                Guid = analyzeOptions.AutomationGuid
+                            };
+                        }
+
                         if (analyzeOptions.SarifOutputVersion != SarifVersion.OneZeroZero)
                         {
                             sarifLogger = new SarifLogger(analyzeOptions.OutputFilePath,

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -729,16 +729,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         SarifLogger sarifLogger;
 
-                        _run = new Run();
-
-                        if (!string.IsNullOrWhiteSpace(analyzeOptions.AutomationId) || !string.IsNullOrWhiteSpace(analyzeOptions.AutomationGuid))
+                        _run = new Run()
                         {
-                            _run.AutomationDetails = new RunAutomationDetails
+                            AutomationDetails = new RunAutomationDetails
                             {
                                 Id = analyzeOptions.AutomationId,
                                 Guid = analyzeOptions.AutomationGuid
-                            };
-                        }
+                            }
+                        };
 
                         if (analyzeOptions.SarifOutputVersion != SarifVersion.OneZeroZero)
                         {

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -220,6 +220,12 @@ namespace Microsoft.CodeAnalysis.Sarif
             return this.Graphs.HasAtLeastOneNonDefaultValue(Graph.ValueComparer);
         }
 
+        public bool ShouldSerializeAutomationDetails()
+        {
+            return !string.IsNullOrWhiteSpace(this.AutomationDetails?.Id) ||
+                !string.IsNullOrWhiteSpace(this.AutomationDetails?.Guid);
+        }
+
         public bool ShouldSerializeInvocations()
         {
             return this.Invocations.HasAtLeastOneNonNullValue();

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -222,8 +222,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public bool ShouldSerializeAutomationDetails()
         {
-            return !string.IsNullOrWhiteSpace(this.AutomationDetails?.Id) ||
-                !string.IsNullOrWhiteSpace(this.AutomationDetails?.Guid);
+            return this.AutomationDetails?.Description != null ||
+                !string.IsNullOrWhiteSpace(this.AutomationDetails?.Id) ||
+                !string.IsNullOrWhiteSpace(this.AutomationDetails?.Guid) ||
+                !string.IsNullOrWhiteSpace(this.AutomationDetails?.CorrelationGuid);
         }
 
         public bool ShouldSerializeInvocations()

--- a/src/Sarif/Core/RunAutomationDetails.cs
+++ b/src/Sarif/Core/RunAutomationDetails.cs
@@ -8,8 +8,12 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public partial class RunAutomationDetails
     {
+        public bool ShouldSerializeDescription() => this.Description != null;
+
         public bool ShouldSerializeId() => !string.IsNullOrWhiteSpace(this.Id);
 
         public bool ShouldSerializeGuid() => !string.IsNullOrWhiteSpace(this.Guid);
+
+        public bool ShouldSerializeCorrelationGuid() => !string.IsNullOrWhiteSpace(this.CorrelationGuid);
     }
 }

--- a/src/Sarif/Core/RunAutomationDetails.cs
+++ b/src/Sarif/Core/RunAutomationDetails.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// Information that describes a run's identity and role within an engineering system process.
+    /// </summary>
+    public partial class RunAutomationDetails
+    {
+        public bool ShouldSerializeId() => !string.IsNullOrWhiteSpace(this.Id);
+
+        public bool ShouldSerializeGuid() => !string.IsNullOrWhiteSpace(this.Guid);
+    }
+}

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1302,14 +1302,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (testCase.PersistLogFileToDisk)
             {
+                runWithCaching.Artifacts.Should().NotBeEmpty();
                 runWithCaching.AutomationDetails.Id.Should().Be(options.AutomationId);
                 runWithCaching.AutomationDetails.Guid.Should().Be(options.AutomationGuid);
                 runWithCaching.AutomationDetails.Should().BeEquivalentTo(runWithoutCaching.AutomationDetails);
-            }
-
-            if (testCase.PersistLogFileToDisk)
-            {
-                runWithCaching.Artifacts.Should().NotBeEmpty();
             }
             // Tool configuration errors, such as 'Could not locate scan target PDB.'
             runWithoutCaching.Invocations?[0].ToolConfigurationNotifications?.Should()

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1289,7 +1289,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             $@"{Environment.CurrentDirectory}\Review.2.of.2.dll"
         };
 
-        private static void RunResultsCachingTestCase(ResultsCachingTestCase testCase, bool multithreaded = false, TestAnalyzeOptions enhancedOptions = null)
+        private static void RunResultsCachingTestCase(ResultsCachingTestCase testCase,
+                                                      bool multithreaded = false,
+                                                      TestAnalyzeOptions enhancedOptions = null)
         {
             // This makes sure that we will reinitialize the mock file system. This
             // allows callers to reuse test case instances, by adjusting specific

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1077,6 +1077,44 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             RunResultsCachingTestCase(testCase, multithreaded: true);
         }
 
+        [Fact]
+        public void AnalyzeCommandBase_ShouldEmitAutomationDetailsWhenIdOrGuidExists()
+        {
+            const string automationId = "automation-id";
+            const string automationGuid = "automation-guid";
+
+            TestAnalyzeOptions[] enhancedOptions = new[]
+            {
+                new TestAnalyzeOptions
+                {
+                    AutomationId = automationId
+                },
+                new TestAnalyzeOptions
+                {
+                    AutomationGuid = automationGuid
+                },
+                new TestAnalyzeOptions
+                {
+                    AutomationId = automationId,
+                    AutomationGuid = automationGuid
+                }
+            };
+
+            foreach (TestAnalyzeOptions enhancedOption in enhancedOptions)
+            {
+                var testCase = new ResultsCachingTestCase
+                {
+                    Files = ComprehensiveKindAndLevelsByFileName,
+                    PersistLogFileToDisk = true,
+                };
+
+                RunResultsCachingTestCase(testCase, enhancedOptions: enhancedOption);
+
+                testCase.Files = ComprehensiveKindAndLevelsByFilePath;
+                RunResultsCachingTestCase(testCase, multithreaded: true, enhancedOptions: enhancedOption);
+            }
+        }
+
         [Fact(Timeout = 5000)]
         public void AnalyzeCommandBase_ShouldGenerateSameResultsWhenRunningSingleAndMultiThread_CoyoteTest()
         {
@@ -1251,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             $@"{Environment.CurrentDirectory}\Review.2.of.2.dll"
         };
 
-        private static void RunResultsCachingTestCase(ResultsCachingTestCase testCase, bool multithreaded = false)
+        private static void RunResultsCachingTestCase(ResultsCachingTestCase testCase, bool multithreaded = false, TestAnalyzeOptions enhancedOptions = null)
         {
             // This makes sure that we will reinitialize the mock file system. This
             // allows callers to reuse test case instances, by adjusting specific
@@ -1266,9 +1304,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 TargetFileSpecifiers = new string[] { Guid.NewGuid().ToString() },
                 Kind = new List<ResultKind> { ResultKind.Fail },
                 Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                AutomationId = "Test Automation",
-                AutomationGuid = Guid.NewGuid().ToString()
             };
+
+            EnhanceOptions(options, enhancedOptions);
 
             if (testCase.Verbose)
             {
@@ -1303,8 +1341,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (testCase.PersistLogFileToDisk)
             {
                 runWithCaching.Artifacts.Should().NotBeEmpty();
-                runWithCaching.AutomationDetails.Id.Should().Be(options.AutomationId);
-                runWithCaching.AutomationDetails.Guid.Should().Be(options.AutomationGuid);
+
+                if (!string.IsNullOrWhiteSpace(options.AutomationId))
+                {
+                    runWithCaching.AutomationDetails.Id.Should().Be(options.AutomationId);
+                }
+
+                if (!string.IsNullOrWhiteSpace(options.AutomationGuid))
+                {
+                    runWithCaching.AutomationDetails.Guid.Should().Be(options.AutomationGuid);
+                }
+
                 runWithCaching.AutomationDetails.Should().BeEquivalentTo(runWithoutCaching.AutomationDetails);
             }
             // Tool configuration errors, such as 'Could not locate scan target PDB.'
@@ -1314,6 +1361,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             // Not yet explicitly tested
             runWithoutCaching.Invocations?[0].ToolExecutionNotifications?.Should()
                 .BeEquivalentTo(runWithCaching.Invocations?[0].ToolExecutionNotifications);
+        }
+
+        private static void EnhanceOptions(TestAnalyzeOptions current, TestAnalyzeOptions enhancement)
+        {
+            current.AutomationId ??= enhancement?.AutomationId;
+            current.AutomationGuid ??= enhancement?.AutomationGuid;
         }
 
         private static IFileSystem CreateDefaultFileSystemForResultsCaching(IList<string> files, bool generateSameInput = false)

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1265,7 +1265,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 OutputFilePath = testCase.PersistLogFileToDisk ? Guid.NewGuid().ToString() : null,
                 TargetFileSpecifiers = new string[] { Guid.NewGuid().ToString() },
                 Kind = new List<ResultKind> { ResultKind.Fail },
-                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
+                Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                AutomationId = "Test Automation",
+                AutomationGuid = Guid.NewGuid().ToString()
             };
 
             if (testCase.Verbose)
@@ -1296,6 +1298,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     withCache.Locations.Count.Should().Be(withoutCache.Locations.Count);
                     withCache.Locations[0].PhysicalLocation.ArtifactLocation.Uri.Should().Be(withoutCache.Locations[0].PhysicalLocation.ArtifactLocation.Uri);
                 }
+            }
+
+            if (testCase.PersistLogFileToDisk)
+            {
+                runWithCaching.AutomationDetails.Id.Should().Be(options.AutomationId);
+                runWithCaching.AutomationDetails.Guid.Should().Be(options.AutomationGuid);
+                runWithCaching.AutomationDetails.Should().BeEquivalentTo(runWithoutCaching.AutomationDetails);
             }
 
             if (testCase.PersistLogFileToDisk)

--- a/src/Test.UnitTests.Sarif.Multitool.Library/TestData/QueryCommand/elfie-arriba.CSCAN0020.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/TestData/QueryCommand/elfie-arriba.CSCAN0020.sarif
@@ -77,7 +77,6 @@
           }
         }
       ],
-      "automationDetails": {},
       "columnKind": "utf16CodeUnits"
     }
   ]


### PR DESCRIPTION
## Description

Imagine SARIF Pattern Matcher being run by someone, and we want to automatically ingest the output SARIF somehow.

With this, we could ask the user to run SARIF Pattern Matcher and pass `--automationId` and `--automationGuid`, that information would be stored in the SARIF and we would know that the SARIF was generated by a specific team.

## Follow-up change

Change the `commandBase` to accept a URI and this URI will be used to send the generated SARIF to that endpoint.

cc: @cfaucon 