### PR TITLE
Response to comments

### DIFF
--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -56,19 +56,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (deferred)
             {
                 serializer.ContractResolver = new SarifDeferredContractResolver();
-                var jptr = new JsonPositionedTextReader(Stream.Synchronized(source));
-                return serializer.Deserialize<SarifLog>(jptr);
+                var jsonPositionedTextReader = JsonPositionedTextReader.FromStream(Stream.Synchronized(source));
+                return serializer.Deserialize<SarifLog>(jsonPositionedTextReader);
             }
-            else
+            using (var streamReader = new StreamReader(source))
+            using (var jsonTextReader = new JsonTextReader(streamReader))
             {
-                using (var sr = new StreamReader(source))
-                {
-                    using (var jtr = new JsonTextReader(sr))
-                    {
-                        // NOTE: Load with JsonSerializer.Deserialize, not JsonConvert.DeserializeObject, to avoid a string of the whole file in memory.
-                        return serializer.Deserialize<SarifLog>(jtr);
-                    }
-                }
+                // NOTE: Load with JsonSerializer.Deserialize, not JsonConvert.DeserializeObject, to avoid a string of the whole file in memory.
+                return serializer.Deserialize<SarifLog>(jsonTextReader);
             }
         }
 

--- a/src/Sarif/Readers/DelegatingStream.cs
+++ b/src/Sarif/Readers/DelegatingStream.cs
@@ -11,17 +11,22 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         /// <summary>
         /// This is a wrapper for a stream that protects the underlying stream from being disposed.
+        /// Disposing this object is a no-op. To dispose the underlying stream use the DisposeUnderlyingStream method.
         /// </summary>
         /// <param name="underlyingStream"></param>
         internal DelegatingStream(Stream underlyingStream)
         {
             stream = underlyingStream;
-            stream.Seek(0L, SeekOrigin.Begin);
         }
+
         public override bool CanRead => stream.CanRead;
+
         public override bool CanSeek => stream.CanSeek;
+
         public override bool CanWrite => stream.CanWrite;
+
         public override long Length => stream.Length;
+
         public override long Position
         {
             set
@@ -30,26 +35,20 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
             get => stream.Position;
         }
-        public override void Flush()
-        {
-            stream.Flush();
-        }
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return stream.Read(buffer, offset, count);
-        }
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return stream.Seek(offset, origin);
-        }
-        public override void SetLength(long value)
-        {
-            stream.SetLength(value);
-        }
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            stream.Write(buffer, offset, count);
-        }
+
+        public override void Flush() => stream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => stream.Seek(offset, origin);
+
+        public override void SetLength(long value) => stream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
+
+        /// <summary>
+        /// Calls the dispose method on the wrapped stream.
+        /// </summary>
         public void DisposeUnderlyingStream()
         {
             stream.Dispose();

--- a/src/Sarif/Readers/JsonPositionedTextReader.cs
+++ b/src/Sarif/Readers/JsonPositionedTextReader.cs
@@ -39,15 +39,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
 
         /// <summary>
-        /// Create a JsonPositionedTextReader based on a Stream and passes this to deferred collections.
+        /// Create a JsonPositionedTextReader based on a single Stream to be reused. Note: The stream must be seekable.
         /// </summary>
         /// <param name="stream"></param>
-        public JsonPositionedTextReader(Stream stream) : this(() => new DelegatingStream(stream))
+        /// <exception cref="ArgumentException">If the stream is not seekable.</exception>
+        public static JsonPositionedTextReader FromStream(Stream stream)
         {
             if (!stream.CanSeek)
             {
                 throw new ArgumentException("The stream should be seekable.", nameof(stream));
             }
+            return new JsonPositionedTextReader(() => new DelegatingStream(stream));
         }
 
         /// <summary>

--- a/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
@@ -89,6 +89,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 Assert.IsType<DeferredList<LogMessage>>(actual.Messages);
             }
 
+            CompareReadNormalToReadDeferredLogs(expected, actual);
+        }
+
+        private static void CompareReadNormalToReadDeferredLogs(Log expected, Log actual)
+        {
             // Deep compare objects which were returned
             AssertEqual(expected, actual);
 
@@ -176,66 +181,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 Assert.IsType<DeferredList<LogMessage>>(actual.Messages);
             }
 
-            // Deep compare objects which were returned
-            AssertEqual(expected, actual);
-
-            // DeferredList Code Coverage - CopyTo()
-            LogMessage[] messages = new LogMessage[actual.Messages.Count + 1];
-            actual.Messages.CopyTo(messages, 1);
-            if (actual.Messages.Count > 0) { Assert.Equal<LogMessage>(actual.Messages[0], messages[1]); }
-
-            // DeferredDictionary Code Coverage
-            CodeContext context;
-
-            // TryGetValue
-            Assert.False(actual.CodeContexts.TryGetValue("missing", out context));
-            if (actual.CodeContexts.Count > 0) { Assert.True(actual.CodeContexts.TryGetValue("load", out context)); }
-
-            // ContainsKey
-            Assert.False(actual.CodeContexts.ContainsKey("missing"));
-            if (actual.CodeContexts.Count > 0) { Assert.True(actual.CodeContexts.ContainsKey("load")); }
-
-            // Contains
-            context = new CodeContext() { Name = "LoadRules()", Type = CodeContextType.Method, ParentContextID = "run" };
-            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("missing", context)));        // Missing Key
-            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("run", context)));            // Different Value
-
-            if (actual.CodeContexts.Count > 0)
-            {
-                Assert.True(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", context)));        // Match
-                Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", null)));          // Match vs. Null
-            }
-
-            // CopyTo
-            KeyValuePair<string, CodeContext>[] contexts = new KeyValuePair<string, CodeContext>[actual.CodeContexts.Count + 1];
-            actual.CodeContexts.CopyTo(contexts, 1);
-            if (actual.CodeContexts.Count > 0) { Assert.Equal(actual.CodeContexts.First(), contexts[1]); }
-
-            // Enumeration
-            Dictionary<string, CodeContext> contextsCopy = new Dictionary<string, CodeContext>();
-            foreach (KeyValuePair<string, CodeContext> pair in actual.CodeContexts)
-            {
-                contextsCopy[pair.Key] = pair.Value;
-            }
-            Assert.Equal(actual.CodeContexts.Count, contextsCopy.Count);
-
-            // Enumerate Keys
-            int keyCount = 0;
-            foreach (string key in actual.CodeContexts.Keys)
-            {
-                Assert.True(contextsCopy.ContainsKey(key));
-                keyCount++;
-            }
-            Assert.Equal(contextsCopy.Count, keyCount);
-
-            // Enumerate Values
-            int valueCount = 0;
-            foreach (CodeContext value in actual.CodeContexts.Values)
-            {
-                Assert.True(contextsCopy.ContainsValue(value));
-                valueCount++;
-            }
-            Assert.Equal(contextsCopy.Count, valueCount);
+            CompareReadNormalToReadDeferredLogs(expected, actual);
         }
 
         private static void AssertEqual(Log expected, Log actual)

--- a/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
@@ -39,6 +39,118 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             CompareReadNormalToReadDeferred(LogModelSampleBuilder.SampleOneLinePath);
         }
 
+        [Fact]
+        public void EndToEnd_NormalLog_WithStream()
+        {
+            CompareReadNormalToReadDeferredWithStreams(LogModelSampleBuilder.SampleLogPath);
+        }
+
+        [Fact]
+        public void EndToEnd_EmptyLog_WithStream()
+        {
+            CompareReadNormalToReadDeferredWithStreams(LogModelSampleBuilder.SampleEmptyPath);
+        }
+
+        [Fact]
+        public void EndToEnd_NoDictionary_WithStream()
+        {
+            CompareReadNormalToReadDeferredWithStreams(LogModelSampleBuilder.SampleNoCodeContextsPath);
+        }
+
+        [Fact]
+        public void EndToEnd_SingleLineJson_WithStream()
+        {
+            CompareReadNormalToReadDeferredWithStreams(LogModelSampleBuilder.SampleOneLinePath);
+        }
+
+        private static void CompareReadNormalToReadDeferredWithStreams(string filePath)
+        {
+            LogModelSampleBuilder.EnsureSamplesBuilt();
+            JsonSerializer serializer = new JsonSerializer();
+
+            Log expected;
+            Log actual;
+            // Read normally (JsonSerializer -> JsonTextReader -> StreamReader)
+            using (JsonTextReader reader = new JsonTextReader(new StreamReader(filePath)))
+            {
+                expected = serializer.Deserialize<Log>(reader);
+                Assert.IsType<Dictionary<string, CodeContext>>(expected.CodeContexts);
+                Assert.IsType<List<LogMessage>>(expected.Messages);
+            }
+
+            // Read with Deferred collections
+            serializer.ContractResolver = new LogModelDeferredContractResolver();
+            Stream contents = File.OpenRead(filePath);
+
+            using (JsonPositionedTextReader reader = JsonPositionedTextReader.FromStream(contents))
+            {
+                actual = serializer.Deserialize<Log>(reader);
+                Assert.IsType<DeferredDictionary<CodeContext>>(actual.CodeContexts);
+                Assert.IsType<DeferredList<LogMessage>>(actual.Messages);
+            }
+
+            // Deep compare objects which were returned
+            AssertEqual(expected, actual);
+
+            // DeferredList Code Coverage - CopyTo()
+            LogMessage[] messages = new LogMessage[actual.Messages.Count + 1];
+            actual.Messages.CopyTo(messages, 1);
+            if (actual.Messages.Count > 0) { Assert.Equal<LogMessage>(actual.Messages[0], messages[1]); }
+
+            // DeferredDictionary Code Coverage
+            CodeContext context;
+
+            // TryGetValue
+            Assert.False(actual.CodeContexts.TryGetValue("missing", out context));
+            if (actual.CodeContexts.Count > 0) { Assert.True(actual.CodeContexts.TryGetValue("load", out context)); }
+
+            // ContainsKey
+            Assert.False(actual.CodeContexts.ContainsKey("missing"));
+            if (actual.CodeContexts.Count > 0) { Assert.True(actual.CodeContexts.ContainsKey("load")); }
+
+            // Contains
+            context = new CodeContext() { Name = "LoadRules()", Type = CodeContextType.Method, ParentContextID = "run" };
+            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("missing", context)));        // Missing Key
+            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("run", context)));            // Different Value
+
+            if (actual.CodeContexts.Count > 0)
+            {
+                Assert.True(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", context)));        // Match
+                Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", null)));          // Match vs. Null
+            }
+
+            // CopyTo
+            KeyValuePair<string, CodeContext>[] contexts = new KeyValuePair<string, CodeContext>[actual.CodeContexts.Count + 1];
+            actual.CodeContexts.CopyTo(contexts, 1);
+            if (actual.CodeContexts.Count > 0) { Assert.Equal(actual.CodeContexts.First(), contexts[1]); }
+
+            // Enumeration
+            Dictionary<string, CodeContext> contextsCopy = new Dictionary<string, CodeContext>();
+            foreach (KeyValuePair<string, CodeContext> pair in actual.CodeContexts)
+            {
+                contextsCopy[pair.Key] = pair.Value;
+            }
+            Assert.Equal(actual.CodeContexts.Count, contextsCopy.Count);
+
+            // Enumerate Keys
+            int keyCount = 0;
+            foreach (string key in actual.CodeContexts.Keys)
+            {
+                Assert.True(contextsCopy.ContainsKey(key));
+                keyCount++;
+            }
+            Assert.Equal(contextsCopy.Count, keyCount);
+
+            // Enumerate Values
+            int valueCount = 0;
+            foreach (CodeContext value in actual.CodeContexts.Values)
+            {
+                Assert.True(contextsCopy.ContainsValue(value));
+                valueCount++;
+            }
+            Assert.Equal(contextsCopy.Count, valueCount);
+        }
+
         private static void CompareReadNormalToReadDeferred(string filePath)
         {
             LogModelSampleBuilder.EnsureSamplesBuilt();

--- a/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    public class DelegatingStreamTests
+    {
+        [Fact]
+        public void DelegatingStreamBasicRead()
+        {
+            const string testStr = "Hello";
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testStr));
+            DelegatingStream delegatingStream = new DelegatingStream(memoryStream);
+
+            Assert.Equal(0, delegatingStream.Position);
+            Assert.Equal(memoryStream.Position, delegatingStream.Position);
+            using StreamReader streamReader = new StreamReader(delegatingStream);
+            Assert.Equal(testStr, streamReader.ReadToEnd());
+            Assert.Equal(testStr.Length, delegatingStream.Position);
+            Assert.Equal(memoryStream.Position, delegatingStream.Position);
+        }
+
+        [Fact]
+        public void DelegatingStreamBasicSeek()
+        {
+            const string testStr = "Hello";
+            const int newPosition = 3;
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testStr));
+            DelegatingStream delegatingStream = new DelegatingStream(memoryStream);
+
+            Assert.Equal(0, delegatingStream.Position);
+            Assert.Equal(memoryStream.Position, delegatingStream.Position);
+
+            delegatingStream.Position = newPosition;
+
+            Assert.Equal(newPosition, delegatingStream.Position);
+            Assert.Equal(memoryStream.Position, delegatingStream.Position);
+        }
+
+        [Fact]
+        public void DelegatingStreamDontPerturbPositionOnCtor()
+        {
+            const string testStr = "Hello";
+            const int startingPosition = 3;
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testStr));
+            memoryStream.Position = startingPosition;
+            DelegatingStream delegatingStream = new DelegatingStream(memoryStream);
+
+            Assert.Equal(startingPosition, delegatingStream.Position);
+            Assert.Equal(memoryStream.Position, delegatingStream.Position);
+        }
+
+        [Fact]
+        public void DelegatingStreamNonSeekable()
+        {
+            const string testStr = "Hello";
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testStr));
+            NonSeekableStream nonSeekableStream = new NonSeekableStream(memoryStream);
+            DelegatingStream delegatingStream = new DelegatingStream(nonSeekableStream);
+
+            using StreamReader streamReader = new StreamReader(delegatingStream);
+            Assert.Equal(testStr, streamReader.ReadToEnd());
+        }
+
+        private class NonSeekableStream : Stream
+        {
+            private readonly Stream stream;
+
+            /// <summary>
+            /// This is a wrapper for a stream that protects the underlying stream from being disposed.
+            /// Disposing this object is a no-op. To dispose the underlying stream use the DisposeUnderlyingStream method.
+            /// </summary>
+            /// <param name="underlyingStream"></param>
+            internal NonSeekableStream(Stream underlyingStream)
+            {
+                stream = underlyingStream;
+            }
+
+            public override bool CanRead => stream.CanRead;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => stream.CanWrite;
+
+            public override long Length => stream.Length;
+
+            public override long Position
+            {
+                set
+                {
+                    throw new NotSupportedException();
+                }
+                get => stream.Position;
+            }
+
+            public override void Flush() => stream.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => stream.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
+
+            /// <summary>
+            /// Calls the dispose method on the wrapped stream.
+            /// </summary>
+            public void DisposeUnderlyingStream()
+            {
+                stream.Dispose();
+            }
+        }
+
+    }
+}

--- a/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
@@ -73,8 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             private readonly Stream stream;
 
             /// <summary>
-            /// This is a wrapper for a stream that protects the underlying stream from being disposed.
-            /// Disposing this object is a no-op. To dispose the underlying stream use the DisposeUnderlyingStream method.
+            /// This is a wrapper for a that prevents seeking for tests.
             /// </summary>
             /// <param name="underlyingStream"></param>
             internal NonSeekableStream(Stream underlyingStream)
@@ -109,12 +108,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
 
-            /// <summary>
-            /// Calls the dispose method on the wrapped stream.
-            /// </summary>
-            public void DisposeUnderlyingStream()
+            protected override void Dispose(bool disposing)
             {
-                stream.Dispose();
+                if (disposing)
+                {
+                    stream.Dispose();
+                }
+                base.Dispose(disposing);
             }
         }
 

--- a/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DelegatedStreamTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.IO;
 using System.Text;
 
+using Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Readers;
+
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Readers
@@ -67,56 +69,5 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             using StreamReader streamReader = new StreamReader(delegatingStream);
             Assert.Equal(testStr, streamReader.ReadToEnd());
         }
-
-        private class NonSeekableStream : Stream
-        {
-            private readonly Stream stream;
-
-            /// <summary>
-            /// This is a wrapper for a that prevents seeking for tests.
-            /// </summary>
-            /// <param name="underlyingStream"></param>
-            internal NonSeekableStream(Stream underlyingStream)
-            {
-                stream = underlyingStream;
-            }
-
-            public override bool CanRead => stream.CanRead;
-
-            public override bool CanSeek => false;
-
-            public override bool CanWrite => stream.CanWrite;
-
-            public override long Length => stream.Length;
-
-            public override long Position
-            {
-                set
-                {
-                    throw new NotSupportedException();
-                }
-                get => stream.Position;
-            }
-
-            public override void Flush() => stream.Flush();
-
-            public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
-
-            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-
-            public override void SetLength(long value) => stream.SetLength(value);
-
-            public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
-
-            protected override void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    stream.Dispose();
-                }
-                base.Dispose(disposing);
-            }
-        }
-
     }
 }

--- a/src/Test.UnitTests.Sarif/Readers/JsonPositionedTextReaderTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/JsonPositionedTextReaderTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+using Microsoft.CodeAnalysis.Sarif.Readers;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Readers
+{
+    public class JsonPositionedTextReaderTests
+    {
+        [Fact]
+        public void ThrowsExceptionWithNonSeekable()
+        {
+            Assert.Throws<ArgumentException>(() => JsonPositionedTextReader.FromStream(new NonSeekableStream(new MemoryStream())));
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Readers/NonSeekableStream.cs
+++ b/src/Test.UnitTests.Sarif/Readers/NonSeekableStream.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Readers
+{internal class NonSeekableStream : Stream
+    {
+        private readonly Stream stream;
+
+        /// <summary>
+        /// This is a wrapper for a that prevents seeking for tests.
+        /// </summary>
+        /// <param name="underlyingStream"></param>
+        internal NonSeekableStream(Stream underlyingStream)
+        {
+            stream = underlyingStream;
+        }
+
+        public override bool CanRead => stream.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => stream.CanWrite;
+
+        public override long Length => stream.Length;
+
+        public override long Position
+        {
+            set
+            {
+                throw new NotSupportedException();
+            }
+            get => stream.Position;
+        }
+
+        public override void Flush() => stream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => stream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                stream.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Some formatting.
Removes seek in ctor.
Changes JsonPositionedTextReader(Stream) to be a factory method so we can enforce that the stream provided is seekable.
Adds some unit tests for DelegatingStream.
Moves DelegatingStream next to JsonPositionedTextReader since it is a helper class.
Adds test cases for deferred collections reading from the new stream API.
Adds a test file for jsonpositionedtextreader along with a test to confirm it throws when given a non seekable stream to the factory function. 