### PR TITLE
LGTM and NetAnalyzers improvements

### DIFF
--- a/src/Sarif.Driver/Sdk/DriverSdkExtensions.cs
+++ b/src/Sarif.Driver/Sdk/DriverSdkExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
     {
         public static IDictionary<string, ArtifactLocation> ConstructUriBaseIdsDictionary(this CommonOptionsBase options)
         {
-            if (options.UriBaseIds == null || options.UriBaseIds.Count() == 0) { return null; }
+            if (options.UriBaseIds == null || !options.UriBaseIds.Any()) { return null; }
 
             var uriBaseIdsDictionary = new Dictionary<string, ArtifactLocation>();
 

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 }
             }
 
-            Debug.Assert(_fileContexts.Count == 0);
+            Debug.Assert(_fileContexts.IsEmpty);
             Debug.Assert(_fileContextsCount == currentIndex);
 
             return true;

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -182,9 +182,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         protected virtual void PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem)
         {
-            PostLogFile(postUri, outputFilePath, fileSystem, new HttpClient())
-                .GetAwaiter()
-                .GetResult();
+            using (var httpClient = new HttpClient())
+            {
+                PostLogFile(postUri, outputFilePath, fileSystem, httpClient)
+                    .GetAwaiter()
+                    .GetResult();
+            }
         }
 
         internal static async Task PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem, HttpClient httpClient)

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public bool TryGetProperty(string propertyName, out string value)
         {
-            if (Properties != null && Properties.Keys.Contains(propertyName))
+            if (Properties != null && Properties.ContainsKey(propertyName))
             {
                 value = GetProperty(propertyName);
                 return true;

--- a/src/Sarif/VersionOne/Core/PropertyBagHolderVersionOne.cs
+++ b/src/Sarif/VersionOne/Core/PropertyBagHolderVersionOne.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif.VersionOne
 
         public bool TryGetProperty(string propertyName, out string value)
         {
-            if (Properties != null && Properties.Keys.Contains(propertyName))
+            if (Properties != null && Properties.ContainsKey(propertyName))
             {
                 value = GetProperty(propertyName);
                 return true;
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif.VersionOne
 
         public bool TryGetProperty<T>(string propertyName, out T value)
         {
-            if (Properties != null && Properties.Keys.Contains(propertyName))
+            if (Properties != null && Properties.ContainsKey(propertyName))
             {
                 value = GetProperty<T>(propertyName);
                 return true;

--- a/src/Test.EndToEnd.Baselining/Extensions/IEnumerableStringExtensions.cs
+++ b/src/Test.EndToEnd.Baselining/Extensions/IEnumerableStringExtensions.cs
@@ -19,7 +19,7 @@ namespace SarifBaseline.Extensions
         /// <returns>Strings in set which contain requiredPart, or full set if no requiredPart provided</returns>
         public static IEnumerable<string> WhereContainsPart(this IEnumerable<string> set, string requiredPart)
         {
-            if (set == null) { throw new ArgumentNullException("set"); }
+            if (set == null) { throw new ArgumentNullException(nameof(set)); }
 
             if (string.IsNullOrEmpty(requiredPart))
             {

--- a/src/Test.EndToEnd.Baselining/Extensions/SarifLogExtensions.cs
+++ b/src/Test.EndToEnd.Baselining/Extensions/SarifLogExtensions.cs
@@ -21,7 +21,7 @@ namespace SarifBaseline.Extensions
 
         public static BaselineFilteringMode GetBaselineFilteringMode(this SarifLog log)
         {
-            if (log == null) { throw new ArgumentNullException("log"); }
+            if (log == null) { throw new ArgumentNullException(nameof(log)); }
 
             BaselineFilteringMode mode;
 
@@ -42,7 +42,7 @@ namespace SarifBaseline.Extensions
 
         public static void SetBaselineFilteringMode(this SarifLog log, BaselineFilteringMode mode)
         {
-            if (log == null) { throw new ArgumentNullException("log"); }
+            if (log == null) { throw new ArgumentNullException(nameof(log)); }
             log.SetProperty<string>(SarifLogExtensions.BaselineFilteringPropertyName, mode.ToString());
         }
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1558,8 +1558,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 // cases will not do this, because the return of 'not applicable' from the CanAnalyze
                 // method will result in Analyze not getting called subsequently for those scan targets.
                 (NotificationsWillBeConvertedToErrorResults
-                    ? Files.Count() - Files.Where((f) => f.Contains("NotApplicable")).Count()
-                    : 0);
+                    ? Files.Count - Files.Count((f) => f.Contains("NotApplicable")) : 0);
 
             public int ExpectedWarningCount =>
                 Files.Where((f) => f.Contains("Warning")).Count();

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/DriverSdkExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/DriverSdkExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             IDictionary<string, ArtifactLocation> uriBaseIds = commonOptionsBase.ConstructUriBaseIdsDictionary();
 
-            uriBaseIds.Count().Should().Be(1);
+            uriBaseIds.Count.Should().Be(1);
             uriBaseIds.Keys.First().Should().Be(name);
             uriBaseIds.Values.First().Uri.LocalPath.Should().Be(path);
         }
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             IDictionary<string, ArtifactLocation> uriBaseIds = commonOptionsBase.ConstructUriBaseIdsDictionary();
 
-            uriBaseIds.Count().Should().Be(1);
+            uriBaseIds.Count.Should().Be(1);
             uriBaseIds.Keys.First().Should().Be(name);
             uriBaseIds.Values.First().Uri.LocalPath.Should().Be(Environment.CurrentDirectory);
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/ExportConfigurationCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/ExportConfigurationCommandBaseTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         private static int NumberOfExportedRules()
         {
             return typeof(ExportConfigurationCommandBaseTests).Assembly.GetTypes()
-                .Count(t => t.GetCustomAttributes(typeof(ExportAttribute)).Count() > 0);
+                .Count(t => t.GetCustomAttributes(typeof(ExportAttribute)).Any());
         }
     }
 }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/SkimmerBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/SkimmerBaseTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Driver.Sdk
         {
             var skimmer = new TestRule();
 
-            skimmer.MessageStrings.Count.Should().Be(new TestRule().MessageStrings.Count());
+            skimmer.MessageStrings.Count.Should().Be(new TestRule().MessageStrings.Count);
             skimmer.MessageStrings["Failed"].Text.Should().Be(SkimmerBaseTestResources.TEST1001_Failed);
             skimmer.MessageStrings["Note"].Text.Should().Be(SkimmerBaseTestResources.TEST1001_Note);
             skimmer.MessageStrings["Pass"].Text.Should().Be(SkimmerBaseTestResources.TEST1001_Pass);

--- a/src/Test.UnitTests.Sarif/Baseline/DefaultBaselineUnitTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/DefaultBaselineUnitTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Unchanged);
-            result.Results.Should().HaveCount(baseline.Results.Count());
+            result.Results.Should().HaveCount(baseline.Results.Count);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+            result.Results.Should().HaveCount(baseline.Results.Count + 1);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count());
+            result.Results.Should().HaveCount(baseline.Results.Count);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+            result.Results.Should().HaveCount(baseline.Results.Count + 1);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Unchanged);
-            result.Results.Should().HaveCount(baseline.Results.Count());
+            result.Results.Should().HaveCount(baseline.Results.Count);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Baseline/StrictBaselineUnitTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/StrictBaselineUnitTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run run = strictBaseliner.CreateBaselinedRun(baseline, next);
 
             run.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Unchanged);
-            run.Results.Should().HaveCount(baseline.Results.Count());
+            run.Results.Should().HaveCount(baseline.Results.Count);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+            result.Results.Should().HaveCount(baseline.Results.Count + 1);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count());
+            result.Results.Should().HaveCount(baseline.Results.Count);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+            result.Results.Should().HaveCount(baseline.Results.Count + 1);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/UriConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/UriConverterTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
             testObject.NonEmptyUri.OriginalString.Should().Be("https://www.example.com/rules/TST0001.html");
             testObject.EmptyUri.OriginalString.Should().BeEmpty();
             testObject.EmptyUriList.Should().BeEmpty();
-            testObject.NonEmptyUriList.Count().Should().Be(2);
+            testObject.NonEmptyUriList.Count.Should().Be(2);
             testObject.NonEmptyUriList.Select(uri => uri.OriginalString).Should().ContainInOrder(
                 "https://www.example.com/page1",
                 "https://www.example.com/page2");

--- a/src/Test.UnitTests.Sarif/Visitors/RebaseUriVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/RebaseUriVisitorTests.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             SarifLog sarifLog = PrereleaseCompatibilityTransformer.UpdateToCurrentVersion(inputText, formatting: Formatting.None, out inputText);
 
-            sarifLog.Runs.Count().Should().Be(1);
+            sarifLog.Runs.Count.Should().Be(1);
 
             var visitor = new RebaseVerifyingVisitor();
             visitor.VisitRun(sarifLog.Runs[0]);

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             };
 
             var sb = new StringBuilder();
-            int argumentsCount = analysisTargetsArguments.Count();
+            int argumentsCount = analysisTargetsArguments.Length;
 
             for (int i = 0; i < argumentsCount; i++)
             {


### PR DESCRIPTION
This change will fix the following warnings from .NET Analyzers:
- [CA1827: Do not use Count/LongCount when Any can be used](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1827)
- [CA1829: Use Length/Count property instead of Enumerable.Count method](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829)
- [CA1836: Prefer IsEmpty over Count when available](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1836)
- [CA1841: Prefer Dictionary Contains methods](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1841)
- [CA1507: Use nameof in place of string
](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507)

It will also fix the HttpClient warning from LGTM.