### PR TITLE
BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application and remove [Serializable] for it.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,9 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## Unreleased
+
+* BUGFIX: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
+
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 
 * FEATURE: `MultithreadCommandBase` will use cache when hashing is enabled. [#2388](https://github.com/microsoft/sarif-sdk/pull/2388)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BUGFIX: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
+* BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -584,6 +585,16 @@ namespace Microsoft.CodeAnalysis.Sarif
                 // Consume the end element
                 xmlReader.Read();
             }
+        }
+
+        public static bool Add<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key, T value)
+        {
+            return concurrentDictionary.TryAdd(key, value);
+        }
+
+        public static bool Remove<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key)
+        {
+            return concurrentDictionary.TryRemove(key, out _);
         }
     }
 }

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -587,14 +587,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
         }
 
-        public static bool Add<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key, T value)
+        public static void Add<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key, T value)
         {
-            return concurrentDictionary.TryAdd(key, value);
+            ((IDictionary<string, T>)concurrentDictionary).Add(key, value);
         }
 
-        public static bool Remove<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key)
+        public static void Remove<T>(this ConcurrentDictionary<string, T> concurrentDictionary, string key)
         {
-            return concurrentDictionary.TryRemove(key, out _);
+            ((IDictionary<string, T>)concurrentDictionary).Remove(key);
         }
     }
 }

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Xml;
 
 using Newtonsoft.Json;
@@ -34,11 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif
             PropertiesDictionary initializer,
             IEqualityComparer<string> comparer)
             : base(initializer, comparer)
-        {
-        }
-
-        protected PropertiesDictionary(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
 

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (cacheDescription)
             {
-                SettingNameToDescriptionsMap = SettingNameToDescriptionsMap ?? new Dictionary<string, string>();
+                SettingNameToDescriptionsMap ??= new ConcurrentDictionary<string, string>();
                 SettingNameToDescriptionsMap[setting.Name] = setting.Description;
             }
 

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -15,7 +15,6 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
-    [Serializable]
     [JsonConverter(typeof(TypedPropertiesDictionaryConverter))]
     public class PropertiesDictionary : TypedPropertiesDictionary<object>
     {

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -71,10 +71,19 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 object property = propertyBag[key];
 
+                if (settingNameToDescriptionMap != null)
+                {
+                    string description;
+
+                    if (settingNameToDescriptionMap.TryGetValue(key, out description))
+                    {
+                        writer.WriteComment(description);
+                    }
+                }
+
                 StringSet stringSet = property as StringSet;
                 if (stringSet != null)
                 {
-                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     SaveSet(writer, stringSet, key);
                     continue;
                 }
@@ -82,7 +91,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                 IntegerSet integerSet = property as IntegerSet;
                 if (integerSet != null)
                 {
-                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     SaveSet(writer, integerSet, key);
                     continue;
                 }
@@ -90,12 +98,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 IDictionary pb = property as IDictionary;
                 if (pb != null)
                 {
-                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     ((IDictionary)pb).SavePropertiesToXmlStream(writer, settings, key, settingNameToDescriptionMap);
                     continue;
                 }
-
-                SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
 
                 writer.WriteStartElement(PROPERTY_ID);
                 writer.WriteAttributeString(KEY_ID, key);
@@ -113,19 +118,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                 writer.WriteEndElement(); // KeyValuePair
             }
             writer.WriteEndElement(); // Properties
-        }
-
-        private static void SaveSettingNameToDescriptionMap(XmlWriter writer, string key, ConcurrentDictionary<string, string> settingNameToDescriptionMap)
-        {
-            if (settingNameToDescriptionMap != null)
-            {
-                string description;
-
-                if (settingNameToDescriptionMap.TryGetValue(key, out description))
-                {
-                    writer.WriteComment(description);
-                }
-            }
         }
 
         private static string NormalizeTypeName(string typeName)

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 StringSet stringSet = property as StringSet;
                 if (stringSet != null)
                 {
+                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     SaveSet(writer, stringSet, key);
                     continue;
                 }
@@ -81,6 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 IntegerSet integerSet = property as IntegerSet;
                 if (integerSet != null)
                 {
+                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     SaveSet(writer, integerSet, key);
                     continue;
                 }
@@ -88,19 +90,12 @@ namespace Microsoft.CodeAnalysis.Sarif
                 IDictionary pb = property as IDictionary;
                 if (pb != null)
                 {
+                    SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
                     ((IDictionary)pb).SavePropertiesToXmlStream(writer, settings, key, settingNameToDescriptionMap);
                     continue;
                 }
 
-                if (settingNameToDescriptionMap != null)
-                {
-                    string description;
-
-                    if (settingNameToDescriptionMap.TryGetValue(key, out description))
-                    {
-                        writer.WriteComment(description);
-                    }
-                }
+                SaveSettingNameToDescriptionMap(writer, key, settingNameToDescriptionMap);
 
                 writer.WriteStartElement(PROPERTY_ID);
                 writer.WriteAttributeString(KEY_ID, key);
@@ -118,6 +113,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                 writer.WriteEndElement(); // KeyValuePair
             }
             writer.WriteEndElement(); // Properties
+        }
+
+        private static void SaveSettingNameToDescriptionMap(XmlWriter writer, string key, ConcurrentDictionary<string, string> settingNameToDescriptionMap)
+        {
+            if (settingNameToDescriptionMap != null)
+            {
+                string description;
+
+                if (settingNameToDescriptionMap.TryGetValue(key, out description))
+                {
+                    writer.WriteComment(description);
+                }
+            }
         }
 
         private static string NormalizeTypeName(string typeName)

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             XmlWriter writer,
             XmlWriterSettings settings,
             string name,
-            ConcurrentDictionary<string, string> settingNameToDescriptionMap)
+            IDictionary<string, string> settingNameToDescriptionMap)
         {
             if (propertyBag == null)
             {

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             XmlWriter writer,
             XmlWriterSettings settings,
             string name,
-            Dictionary<string, string> settingNameToDescriptionMap)
+            ConcurrentDictionary<string, string> settingNameToDescriptionMap)
         {
             if (propertyBag == null)
             {

--- a/src/Sarif/TypedPropertiesDictionary.cs
+++ b/src/Sarif/TypedPropertiesDictionary.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (value == null && this.ContainsKey(setting.Name))
             {
-                this.TryRemove(setting.Name, out T Value);
+                this.Remove(setting.Name);
                 return;
             }
 

--- a/src/Sarif/TypedPropertiesDictionary.cs
+++ b/src/Sarif/TypedPropertiesDictionary.cs
@@ -30,6 +30,16 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
         }
 
+        public void Add(string key, T value)
+        {
+            ((IDictionary<string, T>)this).Add(key, value);
+        }
+
+        public void Remove(string key)
+        {
+            ((IDictionary<string, T>)this).Remove(key);
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         protected ConcurrentDictionary<string, string> SettingNameToDescriptionsMap { get; set; }
 
@@ -63,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (value == null && this.ContainsKey(setting.Name))
             {
-                this.Remove(setting.Name);
+                this.TryRemove(setting.Name, out T Value);
                 return;
             }
 

--- a/src/Sarif/TypedPropertiesDictionary.cs
+++ b/src/Sarif/TypedPropertiesDictionary.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 using Newtonsoft.Json;
 
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
     [Serializable]
     [JsonConverter(typeof(TypedPropertiesDictionaryConverter))]
-    public class TypedPropertiesDictionary<T> : Dictionary<string, T>, IMarker where T : new()
+    public class TypedPropertiesDictionary<T> : ConcurrentDictionary<string, T>, IMarker where T : new()
     {
         public TypedPropertiesDictionary() : this(null, StringComparer.Ordinal)
         {
@@ -28,11 +28,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                     this[key] = (T)initializer[key];
                 }
             }
-        }
-
-        protected TypedPropertiesDictionary(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/src/Sarif/TypedPropertiesDictionary.cs
+++ b/src/Sarif/TypedPropertiesDictionary.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        protected Dictionary<string, string> SettingNameToDescriptionsMap { get; set; }
+        protected ConcurrentDictionary<string, string> SettingNameToDescriptionsMap { get; set; }
 
         public virtual T GetProperty(PerLanguageOption<T> setting)
         {
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (cacheDescription)
             {
-                SettingNameToDescriptionsMap = SettingNameToDescriptionsMap ?? new Dictionary<string, string>();
+                SettingNameToDescriptionsMap ??= new ConcurrentDictionary<string, string>();
                 SettingNameToDescriptionsMap[setting.Name] = setting.Description;
             }
 

--- a/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
+++ b/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
@@ -171,6 +171,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             PropertiesDictionary_TestCacheDescription_Helper(GenerateIntegerSetProperty, INTEGERSET_NONDEFAULT);
             PropertiesDictionary_TestCacheDescription_Helper(GeneratePropertiesDictionaryProperty, PROPERTIES_NONDEFAULT);
         }
+
         private void PropertiesDictionary_TestCacheDescription_Helper(Func<int, string, IOption> GeneratePropertyMethod, object value)
         {
             string textLoaded = string.Empty;

--- a/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
+++ b/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                     // repeatedly set to different fields
                     taskList.Add(Task.Factory.StartNew(() =>
-                    properties.SetProperty(GetStringSetProperty(i), new StringSet(new string[] { i.ToString() }))));
+                    properties.SetProperty(GenerateStringSetProperty(i), new StringSet(new string[] { i.ToString() }))));
 
                     // repeatedly read from same field
                     taskList.Add(Task.Factory.StartNew(() =>
@@ -150,14 +150,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                     // repeatedly read from different fields
                     taskList.Add(Task.Factory.StartNew(() =>
-                    properties.GetProperty(GetStringSetProperty(i))));
+                    properties.GetProperty(GenerateStringSetProperty(i))));
                 }
 
                 Task.WaitAll(taskList.ToArray());
             });
             Assert.Null(exception);
         }
-
 
         private void ValidateProperties(PropertiesDictionary actual, PropertiesDictionary expected)
         {
@@ -227,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             new PerLanguageOption<StringSet>(
                 FEATURE, nameof(StringSetProperty), defaultValue: () => { return STRINGSET_DEFAULT; });
 
-        public static PerLanguageOption<StringSet> GetStringSetProperty(int i) =>
+        public static PerLanguageOption<StringSet> GenerateStringSetProperty(int i) =>
             new PerLanguageOption<StringSet>(
                 FEATURE, nameof(StringSetProperty) + i, defaultValue: () => { return STRINGSET_DEFAULT; });
 


### PR DESCRIPTION
# Description:

Bug: `InvalidOperationException` when using PropertiesDictionary in a multithreaded application.
It is caused by use of Dictionary type instead of ConcurrentDictionary type.

# Fixes:

Change TypedPropertiesDictionary to use ConcurrentDictionary.
also found a existing issue with method SavePropertiesToXmlStream, fix by the way.

**BREAKING: removed [Serializable] for TypedPropertiesDictionary. 
[Serializable] is not for json and xml serialization, it is only for BinaryFormatter serialization. 
For SDK user that is currently using BinaryFormatter on TypedPropertiesDictionary object, 
will result in error: 
`SerializationException`: Type PropertiesDictionary is not marked as serializable**

# Error Details:

InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
at Microsoft.CodeAnalysis.Sarif.PropertiesDictionary.TryGetProperty[T](String key, T& value)
at Microsoft.CodeAnalysis.Sarif.PropertiesDictionary.GetProperty[T](PerLanguageOption`1 setting, Boolean cacheDefault)
at Microsoft.CodeAnalysis.Sarif.PropertiesDictionary.GetProperty[T](PerLanguageOption`1 setting)
at Microsoft.CodeAnalysis.IL.Rules.EnableSpectreMitigations.AnalyzePortableExecutableAndPdb(BinaryAnalyzerContext context) in D:\a\r1\a\src\BinSkim.Rules\PERules\BA2024.EnableSpectreMitigations.cs:line 139
at Microsoft.CodeAnalysis.IL.Rules.WindowsBinaryAndPdbSkimmerBase.Analyze(BinaryAnalyzerContext context) in D:\a\r1\a\src\BinSkim.Rules\PERules\WindowsBinaryAndPdbSkimmerBase.cs:line 63
at Microsoft.CodeAnalysis.Sarif.Driver.MultithreadedAnalyzeCommandBase`2.AnalyzeTargetHelper(TContext context, IEnumerable`1 skimmers, ISet`1 disabledSkimmers)