### PR TITLE
Artifacts should only be logged in the SARIF if we have results

### DIFF
--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -307,12 +307,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (results?.Count > 0)
             {
-                if (_computeHashes)
-                {
-                    _run?.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
-                                       dataToInsert: _dataToInsert,
-                                       hashData: context.Hashes);
-                }
+                _run?.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
+                                   dataToInsert: _dataToInsert,
+                                   hashData: _computeHashes ? context.Hashes : null);
 
                 foreach (KeyValuePair<ReportingDescriptor, IList<Result>> kv in results)
                 {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 _run?.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
                                    dataToInsert: _dataToInsert,
-                                   hashData: _computeHashes ? context.Hashes : null);
+                                   hashData: context.Hashes);
 
                 foreach (KeyValuePair<ReportingDescriptor, IList<Result>> kv in results)
                 {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -307,6 +307,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (results?.Count > 0)
             {
+                if (_computeHashes)
+                {
+                    _run?.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
+                                       dataToInsert: _dataToInsert,
+                                       hashData: context.Hashes);
+                }
+
                 foreach (KeyValuePair<ReportingDescriptor, IList<Result>> kv in results)
                 {
                     foreach (Result result in kv.Value)
@@ -484,10 +491,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                             paths = new List<string>();
                             _hashToFilesMap[hashData.Sha256] = paths;
                         }
-
-                        _run?.GetFileIndex(new ArtifactLocation { Uri = context.TargetUri },
-                                           dataToInsert: _dataToInsert,
-                                           hashData: hashData);
 
                         paths.Add(localPath);
                         context.Hashes = hashData;

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -32,12 +32,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             throw new InvalidOperationException("Author this code along with tests for originalUriBaseIds that are nested");
         }
 
-        public int GetFileIndex(
-            ArtifactLocation fileLocation,
-            bool addToFilesTableIfNotPresent = true,
-            OptionallyEmittedData dataToInsert = OptionallyEmittedData.None,
-            Encoding encoding = null,
-            HashData hashData = null)
+        public int GetFileIndex(ArtifactLocation fileLocation,
+                                bool addToFilesTableIfNotPresent = true,
+                                OptionallyEmittedData dataToInsert = OptionallyEmittedData.None,
+                                Encoding encoding = null,
+                                HashData hashData = null)
         {
             if (fileLocation == null) { throw new ArgumentNullException(nameof(fileLocation)); }
 

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
     {
         private readonly Run _run;
         private readonly TextWriter _textWriter;
-        private readonly bool _persistArtifacts;
         private readonly bool _closeWriterOnDispose;
         private readonly LogFilePersistenceOptions _logFilePersistenceOptions;
         private readonly JsonTextWriter _jsonTextWriter;
@@ -115,11 +114,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     RuleToIndexMap[_run.Tool.Driver.Rules[i]] = i;
                 }
             }
-
-            _persistArtifacts =
-                (_dataToInsert & OptionallyEmittedData.Hashes) != 0 ||
-                (_dataToInsert & OptionallyEmittedData.TextFiles) != 0 ||
-                (_dataToInsert & OptionallyEmittedData.BinaryFiles) != 0;
         }
 
         private SarifLogger(
@@ -417,8 +411,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             // Ensure Artifact is in Run.Artifacts and ArtifactLocation.Index is set to point to it
             int index = _run.GetFileIndex(
                 fileLocation,
-                addToFilesTableIfNotPresent: _persistArtifacts,
-                _dataToInsert,
+                addToFilesTableIfNotPresent: true,
+                dataToInsert: _dataToInsert,
                 encoding,
                 hashData);
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1313,8 +1313,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
-        public void AnalyzeCommmandBase_SingleThreaded_ShouldOnlyLogArtifactsWhenHashesIsEnabled()
+        public void AnalyzeCommandBase_SingleThreaded_ShouldOnlyLogArtifactsWhenHashesIsEnabled()
         {
+            const int expectedNumberOfResultsWithErrors = 5;
+            const int expectedNumberOfResultsWithWarnings = 2;
+            int totalNumber = expectedNumberOfResultsWithErrors + expectedNumberOfResultsWithWarnings;
+
             var testCase = new ResultsCachingTestCase
             {
                 Files = ComprehensiveKindAndLevelsByFileName,
@@ -1336,15 +1340,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             // Hashes is enabled and we should expect to see seven artifacts because we have seven distinct results
             // of which five are error and two are warnings.
-            runSingleThread.Results.Should().HaveCount(7);
             runSingleThread.Artifacts.Should().NotBeEmpty();
-            runSingleThread.Artifacts.Should().HaveCount(7);
+            runSingleThread.Results.Should().HaveCount(totalNumber);
+            runSingleThread.Artifacts.Should().HaveCount(totalNumber);
 
             // Hashes is disabled so no artifacts are expected.
             options.DataToInsert = new List<OptionallyEmittedData>();
             runSingleThread = RunAnalyzeCommand(options, testCase, multithreaded: false);
             runSingleThread.Artifacts.Should().BeNull();
-            runSingleThread.Results.Should().HaveCount(7);
+            runSingleThread.Results.Should().HaveCount(totalNumber);
         }
 
         private static readonly IList<string> ComprehensiveKindAndLevelsByFileName = new List<string>

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1258,7 +1258,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
-        public void AnalyzeCommandBase_Multithreaded_ShouldOnlyLogArtifactsWhenHashesIsEnabled()
+        public void AnalyzeCommandBase_Multithreaded_ShouldOnlyLogArtifactsWhenResultsAreFound()
         {
             const int expectedNumberOfArtifacts = 2;
             const int expectedNumberOfResultsWithErrors = 1;
@@ -1300,20 +1300,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             run.Artifacts.Should().HaveCount(expectedNumberOfArtifacts);
             run.Results.Count(r => r.Level == FailureLevel.Error).Should().Be(expectedNumberOfResultsWithErrors);
             run.Results.Count(r => r.Level == FailureLevel.Warning).Should().Be(expectedNumberOfResultsWithWarnings);
-
-            options.DataToInsert = new List<OptionallyEmittedData>();
-
-            run = RunAnalyzeCommand(options, testCase, multithreaded: true);
-
-            // Hashes is disabled so no artifacts are expected.
-            run.Artifacts.Should().BeNull();
-            run.Results.Should().HaveCount(expectedNumberOfArtifacts);
-            run.Results.Count(r => r.Level == FailureLevel.Error).Should().Be(expectedNumberOfResultsWithErrors);
-            run.Results.Count(r => r.Level == FailureLevel.Warning).Should().Be(expectedNumberOfResultsWithWarnings);
         }
 
         [Fact]
-        public void AnalyzeCommandBase_SingleThreaded_ShouldOnlyLogArtifactsWhenHashesIsEnabled()
+        public void AnalyzeCommandBase_SingleThreaded_ShouldOnlyLogArtifactsWhenResultsAreFound()
         {
             const int expectedNumberOfResultsWithErrors = 5;
             const int expectedNumberOfResultsWithWarnings = 2;
@@ -1343,12 +1333,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             runSingleThread.Artifacts.Should().NotBeEmpty();
             runSingleThread.Results.Should().HaveCount(totalNumber);
             runSingleThread.Artifacts.Should().HaveCount(totalNumber);
-
-            // Hashes is disabled so no artifacts are expected.
-            options.DataToInsert = new List<OptionallyEmittedData>();
-            runSingleThread = RunAnalyzeCommand(options, testCase, multithreaded: false);
-            runSingleThread.Artifacts.Should().BeNull();
-            runSingleThread.Results.Should().HaveCount(totalNumber);
         }
 
         private static readonly IList<string> ComprehensiveKindAndLevelsByFileName = new List<string>


### PR DESCRIPTION
# Description
During some analysis, we saw that we are emitting an artifact even if we don't have a result. This is not good because it will make the SARIF gigantic in case you analyze hundreds/thousands of files.

# Proposal
We will only emit an artifact if we have a result.

# Tests
Created one 'file' of each level/kind and checked the SARIF output. It should only generate a list of artifacts equal to the locations you have in the results.