### PR TITLE
Add suppression support

### DIFF
--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -132,9 +132,11 @@ module.exports = function (results, data) {
                     console.log(err);
                 }
             }
-            if (result.messages.length > 0) {
 
-                result.messages.forEach(message => {
+            const messages = result.messages.concat(result.suppressedMessages);
+
+            if (messages.length > 0) {
+                messages.forEach(message => {
 
                     const sarifRepresentation = {
                         level: getResultLevel(message),
@@ -208,7 +210,7 @@ module.exports = function (results, data) {
                         }
                         if (message.column > 0) {
                             sarifRepresentation.locations[0].physicalLocation.region.startColumn = message.column;
-                        };
+                        }
                     }
 
                     if (message.source) {
@@ -218,6 +220,15 @@ module.exports = function (results, data) {
                         sarifRepresentation.locations[0].physicalLocation.region.snippet = {
                             text: message.source
                         };
+                    }
+
+                    if (message.suppressions) {
+                        sarifRepresentation.suppressions = message.suppressions.map(suppression => {
+                            return {
+                                kind: suppression.kind === "directive" ? "inSource" : "external",
+                                justification: suppression.justification
+                            }
+                        });
                     }
 
                     if (message.ruleId) {

--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -133,7 +133,7 @@ module.exports = function (results, data) {
                 }
             }
 
-            const messages = result.messages.concat(result.suppressedMessages);
+            const messages = result.suppressedMessages ? result.messages.concat(result.suppressedMessages) : result.messages;
 
             if (messages.length > 0) {
                 messages.forEach(message => {
@@ -229,6 +229,8 @@ module.exports = function (results, data) {
                                 justification: suppression.justification
                             }
                         });
+                    } else {
+                        sarifRepresentation.suppressions = [];
                     }
 
                     if (message.ruleId) {

--- a/src/ESLint.Formatter/test/sarif.js
+++ b/src/ESLint.Formatter/test/sarif.js
@@ -127,6 +127,8 @@ describe("formatter:sarif", () => {
             assert(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri.startsWith(uriPrefix));
             assert(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri.endsWith("/" + sourceFilePath1));
             assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.index, 0);
+            assert.isDefined(log.runs[0].results[0].suppressions);
+            assert.lengthOf(log.runs[0].results[0].suppressions, 0);
         });
     });
 
@@ -186,6 +188,34 @@ describe("formatter:sarif", () => {
             assert.strictEqual(log.runs[0].results[0].suppressions[0].justification, code[0].suppressedMessages[0].suppressions[0].justification);
             assert.strictEqual(log.runs[0].results[0].suppressions[1].kind, "inSource");
             assert.strictEqual(log.runs[0].results[0].suppressions[1].justification, code[0].suppressedMessages[0].suppressions[1].justification);
+        });
+    });
+
+    describe("when passed one message and no suppressedMessages array", () => {
+        const code = [{
+            filePath: sourceFilePath1,
+            messages: [{
+                message: "Unexpected value.",
+                severity: 2,
+                ruleId: testRuleId
+            }]
+        }];
+
+        it("should return a log with one file and one result", () => {
+            const log = JSON.parse(formatter(code, { rulesMeta: rules }));
+
+            assert(log.runs[0].artifacts[0].location.uri.startsWith(uriPrefix));
+            assert(log.runs[0].artifacts[0].location.uri, "/" + sourceFilePath1);
+            assert.isDefined(log.runs[0].results);
+            assert.lengthOf(log.runs[0].results, 1);
+            assert.strictEqual(log.runs[0].results[0].level, "error");
+            assert.isDefined(log.runs[0].results[0].message);
+            assert.strictEqual(log.runs[0].results[0].message.text, code[0].messages[0].message);
+            assert(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri.startsWith(uriPrefix));
+            assert(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri.endsWith("/" + sourceFilePath1));
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.index, 0);
+            assert.isDefined(log.runs[0].results[0].suppressions);
+            assert.lengthOf(log.runs[0].results[0].suppressions, 0);
         });
     });
 });
@@ -356,7 +386,7 @@ describe("formatter:sarif", () => {
             const log = JSON.parse(formatter(code, rules));
 
             assert.lengthOf(log.runs[0].results, 2)
-            assert.isUndefined(log.runs[0].results[0].suppressions);
+            assert.lengthOf(log.runs[0].results[0].suppressions, 0);
             assert.lengthOf(log.runs[0].results[1].suppressions, 1);
             assert.strictEqual(log.runs[0].results[1].suppressions[0].kind, "inSource");
             assert.strictEqual(log.runs[0].results[1].suppressions[0].justification, code[0].suppressedMessages[0].suppressions[0].justification);
@@ -487,6 +517,11 @@ describe("formatter:sarif", () => {
             assert.strictEqual(log.runs[0].results[2].locations[0].physicalLocation.region.startLine, 18);
             assert.isUndefined(log.runs[0].results[2].locations[0].physicalLocation.region.startColumn);
             assert.isUndefined(log.runs[0].results[2].locations[0].physicalLocation.region.snippet);
+
+            assert.lengthOf(log.runs[0].results[0].suppressions, 0);
+            assert.lengthOf(log.runs[0].results[1].suppressions, 0);
+            assert.lengthOf(log.runs[0].results[2].suppressions, 0);
+            assert.lengthOf(log.runs[0].results[3].suppressions, 0);
         });
     });
 });
@@ -568,6 +603,9 @@ describe("formatter:sarif", () => {
             assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, 18);
             assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
             assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.snippet);
+
+            assert.lengthOf(log.runs[0].results[0].suppressions, 0);
+            assert.lengthOf(log.runs[0].results[1].suppressions, 0);
         });
     });
 });


### PR DESCRIPTION
This PR is to add suppression support for the sarif formatter of ESLint.

### Suppression support in ESLint

In eslint/eslint#15459, the suppression support feature was merged into ESLint. When disabling suppressions by inline comments, the violations will be put into `suppressedMessages` in the output instead of being discarded. The text after two or more adjacent dashes will be considered as the justification. Detailed spec can be seen in [rfcs/2021-suppression-support](https://github.com/eslint/rfcs/tree/main/designs/2021-suppression-support).

For example:
```js
foo=1 // eslint-disable-line no-undef -- for test
```
```shell
> eslint -f json 1.js
```
```json
[
  {
    ...
    "messages":[],
    "suppressedMessages":[{
      "ruleId":"no-undef",
      "severity":2,
      "message":"'foo' is not defined.",
      "line":1,
      "column":1,
      "nodeType":"Identifier",
      "messageId":"undef",
      "endLine":1,
      "endColumn":4,
      "suppressions":[{"kind":"directive","justification":"for test"}]}],
    ...
  }
]
```
**NOTE**: currently only inline suppressions are supported, so `kind` of `suppressions` is always "directive". Reason for why "directive" not "inSource" could be seen in this [comment](https://github.com/eslint/rfcs/pull/82#discussion_r695306329).

### What this PR does

In this PR, I modify the formatter to convert `suppressedMessages` from ESLint to `results` with the `suppressions` property in the format of SARIF.

As for the example above, if we run `eslint -f @microsoft/sarif 1.js`, we will get:
```json
{
  "version": "2.1.0",
  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "ESLint",
          "informationUri": "https://eslint.org",
          "rules": [
            {
              "id": "no-undef",
              "helpUri": "https://eslint.org/docs/rules/no-undef",
              "properties": {},
              "shortDescription": {
                "text": "disallow the use of undeclared variables unless mentioned in `/*global */` comments"
              }
            }
          ],
          "version": "8.6.0"
        }
      },
      "artifacts": [
        {
          "location": {
            "uri": "file:///D:/test/1.js"
          }
        }
      ],
      "results": [
        {
          "level": "error",
          "message": {
            "text": "'foo' is not defined."
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "file:///D:/test/1.js",
                  "index": 0
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1
                }
              }
            }
          ],
          "ruleId": "no-undef",
          "ruleIndex": 0,
          "suppressions": [
            {
              "kind": "inSource",
              "justification": "for test"
            }
          ]
        }
      ]
    }
  ]
}
```