### PR TITLE
`SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -5,7 +5,7 @@
 * BREAKING: `AnalyzeCommandBase` previously persisted all scan target artifacts to SARIF logs rather than only persisting artifacts referenced by an analysis result, when an option to persist hashes, text file or binary information was set. `MultithreadedAnalyzeCommandBase` previously persisted all scan targets artifacts to SARIF logs in cases when hash insertion was eenabled rather than only persisting artifacts referenced by an analysis result. [#2433](https://github.com/microsoft/sarif-sdk/pull/2433)
 * BUGFIX: Adjust Json Serialization field order for ReportingDescriptor and skip emit empty AutomationDetails node. [#2420](https://github.com/microsoft/sarif-sdk/pull/2420)
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
-* BUGFIX: Notifications should emit an artifact if artifactLocation is not null. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
+* BREAKING: `SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -5,6 +5,7 @@
 * BREAKING: `AnalyzeCommandBase` previously persisted all scan target artifacts to SARIF logs rather than only persisting artifacts referenced by an analysis result, when an option to persist hashes, text file or binary information was set. `MultithreadedAnalyzeCommandBase` previously persisted all scan targets artifacts to SARIF logs in cases when hash insertion was eenabled rather than only persisting artifacts referenced by an analysis result. [#2433](https://github.com/microsoft/sarif-sdk/pull/2433)
 * BUGFIX: Adjust Json Serialization field order for ReportingDescriptor and skip emit empty AutomationDetails node. [#2420](https://github.com/microsoft/sarif-sdk/pull/2420)
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
+* BUGFIX: Notifications should emit an artifact if artifactLocation is not null. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -476,6 +476,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             _run.Invocations[0].ToolExecutionNotifications = _run.Invocations[0].ToolExecutionNotifications ?? new List<Notification>();
             _run.Invocations[0].ToolExecutionNotifications.Add(notification);
             _run.Invocations[0].ExecutionSuccessful &= notification.Level != FailureLevel.Error;
+
+            CaptureFilesInNotification(notification);
         }
 
         public void LogConfigurationNotification(Notification notification)
@@ -493,6 +495,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             _run.Invocations[0].ToolConfigurationNotifications = _run.Invocations[0].ToolConfigurationNotifications ?? new List<Notification>();
             _run.Invocations[0].ToolConfigurationNotifications.Add(notification);
             _run.Invocations[0].ExecutionSuccessful &= notification.Level != FailureLevel.Error;
+
+            CaptureFilesInNotification(notification);
+        }
+
+        private void CaptureFilesInNotification(Notification notification)
+        {
+            if (notification.Locations != null)
+            {
+                foreach (Location location in notification.Locations)
+                {
+                    if (location.PhysicalLocation != null)
+                    {
+                        CaptureArtifact(location.PhysicalLocation.ArtifactLocation);
+                    }
+                }
+            }
         }
 
         private static string Redact(string text, IEnumerable<string> tokensToRedact)

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -54,17 +54,15 @@ namespace Microsoft.CodeAnalysis.Sarif
             MemoryStream memoryStream = new MemoryStream();
             var streamWriter = new StreamWriter(memoryStream);
 
-            using (var logger = new SarifLogger(
-                streamWriter,
-                logFilePersistenceOptions: LogFilePersistenceOptions.PrettyPrint,
-                dataToRemove: OptionallyEmittedData.NondeterministicProperties,
-                closeWriterOnDispose: closeWriterOnDispose,
-                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                kinds: new List<ResultKind> { ResultKind.Fail }))
+            using (var logger = new SarifLogger(streamWriter,
+                                                logFilePersistenceOptions: LogFilePersistenceOptions.PrettyPrint,
+                                                dataToRemove: OptionallyEmittedData.NondeterministicProperties,
+                                                closeWriterOnDispose: closeWriterOnDispose,
+                                                levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                kinds: new List<ResultKind> { ResultKind.Fail }))
             {
-                logger.Log(
-                    new ReportingDescriptor { Id = "MyId" },
-                    new Result { Message = new Message { Text = "My text" }, RuleId = "MyId" });
+                logger.Log(new ReportingDescriptor { Id = "MyId" },
+                           new Result { Message = new Message { Text = "My text" }, RuleId = "MyId" });
             }
 
             // Important. Force streamwriter to commit everything.
@@ -171,14 +169,13 @@ namespace Microsoft.CodeAnalysis.Sarif
                     Assert.False(true, pathToExe + " " + commandLine);
                 }
 
-                using (_ = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    logFilePersistenceOptions: LogFilePersistenceOptions.None,
-                    invocationTokensToRedact: tokensToRedact,
-                    invocationPropertiesToLog: new List<string> { "CommandLine" },
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail })) { }
+                using (_ = new SarifLogger(textWriter,
+                                           analysisTargets: null,
+                                           logFilePersistenceOptions: LogFilePersistenceOptions.None,
+                                           invocationTokensToRedact: tokensToRedact,
+                                           invocationPropertiesToLog: new List<string> { "CommandLine" },
+                                           levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                           kinds: new List<ResultKind> { ResultKind.Fail })) { }
 
                 string result = sb.ToString();
                 result.Split(new string[] { SarifConstants.RedactedMarker }, StringSplitOptions.None)
@@ -205,12 +202,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 sb.Clear();
                 using (var textWriter = new StringWriter(sb))
                 {
-                    using (var sarifLogger = new SarifLogger(
-                        textWriter,
-                        analysisTargets: analysisTargets,
-                        dataToInsert: OptionallyEmittedData.Hashes,
-                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                        kinds: new List<ResultKind> { ResultKind.Fail }))
+                    using (var sarifLogger = new SarifLogger(textWriter,
+                                                             analysisTargets: analysisTargets,
+                                                             dataToInsert: OptionallyEmittedData.Hashes,
+                                                             levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                             kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                         LogSimpleResult(sarifLogger);
                     }
@@ -229,14 +225,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: new string[] { @"example.cpp" },
-                    logFilePersistenceOptions: LogFilePersistenceOptions.None,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: new string[] { @"example.cpp" },
+                                                         logFilePersistenceOptions: LogFilePersistenceOptions.None,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: null,
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -288,12 +283,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 run.DefaultEncoding = defaultEncoding;
                 run.RedactionTokens = redactionTokens;
 
-                using (_ = new SarifLogger(
-                    textWriter,
-                    run: run,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (_ = new SarifLogger(textWriter,
+                                           run: run,
+                                           invocationPropertiesToLog: null,
+                                           levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                           kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -326,14 +320,13 @@ namespace Microsoft.CodeAnalysis.Sarif
                 file = tempFile.Name;
                 File.WriteAllText(file, "#include \"windows.h\";");
 
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: new string[] { file },
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: new string[] { file },
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: null,
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -378,13 +371,12 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var textWriter = new StringWriter(sb))
                 {
                     // Create a logger that inserts artifact contents.
-                    using (_ = new SarifLogger(
-                        textWriter,
-                        run: run,
-                        analysisTargets: analysisTargets,
-                        dataToInsert: OptionallyEmittedData.TextFiles,
-                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                        kinds: new List<ResultKind> { ResultKind.Fail }))
+                    using (_ = new SarifLogger(textWriter,
+                                               run: run,
+                                               analysisTargets: analysisTargets,
+                                               dataToInsert: OptionallyEmittedData.TextFiles,
+                                               levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                               kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                     }
 
@@ -459,12 +451,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var textWriter = new StringWriter(sb))
                 {
                     // Create a logger that inserts artifact contents.
-                    using (var sarifLogger = new SarifLogger(
-                        textWriter,
-                        run: run,
-                        dataToInsert: OptionallyEmittedData.TextFiles,
-                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                        kinds: new List<ResultKind> { ResultKind.Fail }))
+                    using (var sarifLogger = new SarifLogger(textWriter,
+                                                             run: run,
+                                                             dataToInsert: OptionallyEmittedData.TextFiles,
+                                                             levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                             kinds: new List<ResultKind> { ResultKind.Fail }))
                     {
                         sarifLogger.Log(rule, result);
                     }
@@ -491,15 +482,14 @@ namespace Microsoft.CodeAnalysis.Sarif
                 file = tempFile.Name;
                 File.WriteAllText(file, fileText);
 
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: new string[] { file },
-                    dataToInsert: OptionallyEmittedData.TextFiles,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    defaultFileEncoding: "ImaginaryEncoding",
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: new string[] { file },
+                                                         dataToInsert: OptionallyEmittedData.TextFiles,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: null,
+                                                         defaultFileEncoding: "ImaginaryEncoding",
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -520,14 +510,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: null,
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: null,
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     string ruleId = "RuleId";
                     var rule = new ReportingDescriptor { Id = ruleId };
@@ -558,16 +547,16 @@ namespace Microsoft.CodeAnalysis.Sarif
                                 {
                                    new ArtifactChange
                                    {
-                                    ArtifactLocation = new ArtifactLocation
-                                    {
-                                        Uri = new Uri(@"file:///file2.cpp")
-                                    },
-                                    Replacements = new[]
-                                    {
-                                        new Replacement {
-                                            DeletedRegion = new Region { StartLine = 1}
+                                        ArtifactLocation = new ArtifactLocation
+                                        {
+                                            Uri = new Uri(@"file:///file2.cpp")
+                                        },
+                                        Replacements = new[]
+                                        {
+                                            new Replacement {
+                                                DeletedRegion = new Region { StartLine = 1}
+                                            }
                                         }
-                                    }
                                    }
                                 },
                             }
@@ -657,81 +646,19 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         [Fact]
-        public void SarifLogger_DoesNotScrapeFilesFromNotifications()
-        {
-            var sb = new StringBuilder();
-
-            using (var textWriter = new StringWriter(sb))
-            {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
-                {
-                    var toolNotification = new Notification
-                    {
-                        Locations = new List<Location>
-                        {
-                            new Location
-                            {
-                                PhysicalLocation = new PhysicalLocation { ArtifactLocation = new ArtifactLocation { Uri = new Uri(@"file:///file.cpp") } }
-                            }
-                        },
-                        Message = new Message { Text = "A notification was raised." }
-                    };
-                    sarifLogger.LogToolNotification(toolNotification);
-
-                    var configurationNotification = new Notification
-                    {
-                        Locations = new List<Location>
-                        {
-                            new Location
-                            {
-                                PhysicalLocation = new PhysicalLocation { ArtifactLocation = new ArtifactLocation { Uri = new Uri(@"file:///file.cpp") } }
-                            }
-                        },
-                        Message = new Message { Text = "A notification was raised." }
-                    };
-                    sarifLogger.LogConfigurationNotification(configurationNotification);
-
-                    string ruleId = "RuleId";
-                    var rule = new ReportingDescriptor { Id = ruleId };
-
-                    var result = new Result
-                    {
-                        RuleId = ruleId,
-                        Message = new Message { Text = "Some testing occurred." }
-                    };
-
-                    sarifLogger.Log(rule, result);
-                }
-            }
-
-            string logText = sb.ToString();
-            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
-
-            sarifLog.Runs[0].Artifacts.Should().BeNull();
-        }
-
-        [Fact]
         public void SarifLogger_LogsStartAndEndTimesByDefault()
         {
             var sb = new StringBuilder();
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: null,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: null,
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: null,
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -758,14 +685,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: new[] { "WorkingDirectory", "ProcessId" },
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: null,
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: new[] { "WorkingDirectory", "ProcessId" },
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -796,14 +722,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (var sarifLogger = new SarifLogger(
-                    textWriter,
-                    analysisTargets: null,
-                    dataToInsert: OptionallyEmittedData.Hashes,
-                    invocationTokensToRedact: null,
-                    invocationPropertiesToLog: new[] { "WORKINGDIRECTORY", "prOCessID" },
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         analysisTargets: null,
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         invocationTokensToRedact: null,
+                                                         invocationPropertiesToLog: new[] { "WORKINGDIRECTORY", "prOCessID" },
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     LogSimpleResult(sarifLogger);
                 }
@@ -827,8 +752,8 @@ namespace Microsoft.CodeAnalysis.Sarif
             using (var textWriter = new StringWriter(sb))
             {
                 using (var sarifLogger = new SarifLogger(textWriter: textWriter,
-                                                            levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                                                            kinds: new List<ResultKind> { ResultKind.Fail }))
+                                                         levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                         kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                     var rule = new ReportingDescriptor { Id = "RuleId" };
                     var result = new Result { RuleId = "RuleId/1" };
@@ -849,11 +774,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (_ = new SarifLogger(
-                    textWriter,
-                    run: run,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (_ = new SarifLogger(textWriter,
+                                           run: run,
+                                           levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                           kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -895,12 +819,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var textWriter = new StringWriter(sb))
             {
-                using (_ = new SarifLogger(
-                    textWriter,
-                    run: run,
-                    analysisTargets: analysisTargets,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (_ = new SarifLogger(textWriter,
+                                           run: run,
+                                           analysisTargets: analysisTargets,
+                                           levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                           kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -930,12 +853,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             using (var textWriter = new StringWriter(sb))
             {
                 // Create a logger that uses that run but specifies a different encoding.
-                using (_ = new SarifLogger(
-                    textWriter,
-                    run: run,
-                    defaultFileEncoding: Utf7,
-                    levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                    kinds: new List<ResultKind> { ResultKind.Fail }))
+                using (_ = new SarifLogger(textWriter,
+                                           run: run,
+                                           defaultFileEncoding: Utf7,
+                                           levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                           kinds: new List<ResultKind> { ResultKind.Fail }))
                 {
                 }
             }
@@ -969,8 +891,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             using (var writer = new StringWriter(sb))
             using (var sarifLogger = new SarifLogger(writer,
-                                                        levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
-                                                        kinds: new List<ResultKind> { ResultKind.Fail }))
+                                                     kinds: new List<ResultKind> { ResultKind.Fail },
+                                                     levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }))
             {
                 var rule = new ReportingDescriptor
                 {
@@ -1087,8 +1009,8 @@ namespace Microsoft.CodeAnalysis.Sarif
             IEnumerable<ResultKind> nonEmptyResultKinds = Enum.GetValues(typeof(ResultKind)).Cast<ResultKind>().Where(rk => rk != ResultKind.None).ToList();
             IEnumerable<FailureLevel> nonEmptyFailureLevels = Enum.GetValues(typeof(FailureLevel)).Cast<FailureLevel>().Where(fl => fl != FailureLevel.None).ToList();
 
-            List<Result> allKindLevelCombinations = new List<Result>();
-            ReportingDescriptor rule = new ReportingDescriptor { Id = "RuleId" };
+            var allKindLevelCombinations = new List<Result>();
+            var rule = new ReportingDescriptor { Id = "RuleId" };
 
             foreach (ResultKind rk in nonEmptyResultKinds)
             {
@@ -1130,6 +1052,58 @@ namespace Microsoft.CodeAnalysis.Sarif
             desiredFailureLevels = new List<FailureLevel> { FailureLevel.Error };
             sarifLog = CreateSarifLog(allKindLevelCombinations, rule, desiredFailureLevels, desiredResultKinds);
             VerifySarifLogHonoredKindAndLevel(desiredFailureLevels, desiredResultKinds, sarifLog);
+        }
+
+        [Fact]
+        public void SarifLogger_ShouldWriteToArtifactsIfNotificationHasLocation()
+        {
+            const string filePath = @"C:\example\example.sarif";
+
+            var sb = new StringBuilder();
+
+            using (var writer = new StringWriter(sb))
+            using (var sarifLogger = new SarifLogger(writer,
+                                                     levels: new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error },
+                                                     kinds: new List<ResultKind> { ResultKind.Fail }))
+            {
+                var emptyNotification = new Notification();
+
+                // Logging empty notification
+                sarifLogger.LogToolNotification(emptyNotification);
+                sarifLogger.LogConfigurationNotification(emptyNotification);
+
+                var notificationWithLocation = new Notification
+                {
+                    Locations = new[]
+                    {
+                        new Location
+                        {
+                            PhysicalLocation = new PhysicalLocation
+                            {
+                                ArtifactLocation = new ArtifactLocation
+                                {
+                                    Uri = new Uri(filePath)
+                                }
+                            }
+                        }
+                    }
+                };
+
+                sarifLogger.LogToolNotification(notificationWithLocation);
+                sarifLogger.LogConfigurationNotification(notificationWithLocation);
+            }
+
+            string output = sb.ToString();
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(output);
+            sarifLog.Runs[0].Artifacts.Should().NotBeNull();
+            sarifLog.Runs[0].Artifacts.Should().HaveCount(1);
+
+            Invocation invocation = sarifLog.Runs[0].Invocations[0];
+            invocation.ToolExecutionNotifications.Should().HaveCount(2);
+            invocation.ToolExecutionNotifications.Where(notification => notification.Locations != null).Should().HaveCount(1);
+
+            invocation.ToolConfigurationNotifications.Should().HaveCount(2);
+            invocation.ToolConfigurationNotifications.Where(notification => notification.Locations != null).Should().HaveCount(1);
         }
 
         private static void VerifySarifLogHonoredKindAndLevel(List<FailureLevel> desiredFailureLevels, List<ResultKind> desiredResultKinds, SarifLog sarifLog)


### PR DESCRIPTION
# Description
After we merged this [PR](https://github.com/microsoft/sarif-sdk/pull/2433) when we log a notification, we stopped it from logging to the artifacts. But, this is a bug, since a notification is also a result and that result might have an `artifactLocation` which can point to the artifacts table.

# Test
Let's create notifications with/without locations and check if the artifacts table is being updated.