### PR TITLE
Fix `ArgumentException` when recurse is enabled and two file target specifiers generates the same file paths

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,7 +6,7 @@
 * BUGFIX: Adjust Json Serialization field order for ReportingDescriptor and skip emit empty AutomationDetails node. [#2420](https://github.com/microsoft/sarif-sdk/pull/2420)
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
 * BREAKING: `SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
-* BUGFIX: Fix `ArgumentException` when recurse is enabled and two file target specifiers generates the same file path. [#2438](https://github.com/microsoft/sarif-sdk/pull/2438)
+* BUGFIX: Fix `ArgumentException` when `--recurse` is enabled and two file target specifiers generates the same file path. [#2438](https://github.com/microsoft/sarif-sdk/pull/2438)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,6 +6,7 @@
 * BUGFIX: Adjust Json Serialization field order for ReportingDescriptor and skip emit empty AutomationDetails node. [#2420](https://github.com/microsoft/sarif-sdk/pull/2420)
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
 * BREAKING: `SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
+* BUGFIX: Fix `ArgumentException` when recurse is enabled and two file target specifiers generates the same file path. [#2438](https://github.com/microsoft/sarif-sdk/pull/2438)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -488,7 +488,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         paths.Add(localPath);
                         context.Hashes = hashData;
-                        _pathToHashDataMap?.Add(localPath, hashData);
+
+                        if (_pathToHashDataMap != null && !_pathToHashDataMap.ContainsKey(localPath))
+                        {
+                            _pathToHashDataMap.Add(localPath, hashData);
+                        }
                     }
 
                     await _fileEnumerationChannel.Writer.WriteAsync(index);

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1562,8 +1562,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                 mockFileSystem.Setup(x => x.FileOpenRead(It.Is<string>(f => f == fullyQualifiedName)))
                     .Returns(new NonDisposingDelegatingStream(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension))));
-                    //.Callback(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
-                        //.Returns(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
+                //.Callback(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
+                //.Returns(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
             }
             return mockFileSystem.Object;
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1562,8 +1562,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                 mockFileSystem.Setup(x => x.FileOpenRead(It.Is<string>(f => f == fullyQualifiedName)))
                     .Returns(new NonDisposingDelegatingStream(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension))));
-                //.Callback(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
-                //.Returns(new MemoryStream(Encoding.UTF8.GetBytes(generateSameInput ? logFileContents : fileNameWithoutExtension)));
             }
             return mockFileSystem.Object;
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1210,19 +1210,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 $@"{Environment.CurrentDirectory}\NoIssues.dll",
             };
 
-            var testCases = new[]
-            {
-                new
-                {
-                    IsMultithreaded = false
-                },
-                new
-                {
-                    IsMultithreaded = true
-                }
-            };
-
-            foreach (var testCase in testCases)
+            foreach (bool multithreaded in new bool[] { false, true })
             {
                 var resultsCachingTestCase = new ResultsCachingTestCase
                 {
@@ -1241,7 +1229,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     DataToInsert = new OptionallyEmittedData[] { OptionallyEmittedData.Hashes },
                 };
 
-                Run run = RunAnalyzeCommand(options, resultsCachingTestCase, multithreaded: testCase.IsMultithreaded);
+                Run run = RunAnalyzeCommand(options, resultsCachingTestCase, multithreaded: multithreaded);
 
                 // Hashes is enabled and we should expect to see two artifacts because we have:
                 // one result with Error level and one result with Warning level.
@@ -1259,21 +1247,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 $@"{Environment.CurrentDirectory}\Error.dll"
             };
 
-            var testCases = new[]
-            {
-                new
-                {
-                    IsMultithreaded = false
-                },
-                new
-                {
-                    IsMultithreaded = true
-                }
-            };
-
             Action action = () =>
             {
-                foreach (var testCase in testCases)
+                foreach (bool multithreaded in new bool[] { false, true })
                 {
                     var resultsCachingTestCase = new ResultsCachingTestCase
                     {
@@ -1296,7 +1272,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     RunAnalyzeCommand(options,
                                       resultsCachingTestCase.FileSystem,
                                       resultsCachingTestCase.ExpectedReturnCode,
-                                      multithreaded: testCase.IsMultithreaded);
+                                      multithreaded: multithreaded);
                 }
             };
 


### PR DESCRIPTION
# Description

If you pass two targets like `c:\path1\1.dll`, `c:\path1\path2\1.dll` and recurse is enabled, the `MultithreadedAnalyzeCommandBase` would generate the following searches:
c:\path1\ -> search using recurse looking for 1.dll
c:\path1\path2\ -> search using recurse looking for 1.dll

This would generate path duplications, causing an ArgumentException when hashing:
```
error ERR999.UnhandledEngineException : System.ArgumentException: The key already existed in the dictionary.
at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
at Microsoft.CodeAnalysis.Sarif.Driver.MultithreadedAnalyzeCommandBase`2.HashAsync() in /_/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs:line 494
ArgumentException: The key already existed in the dictionary.
at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
at Microsoft.CodeAnalysis.Sarif.Driver.MultithreadedAnalyzeCommandBase`2.HashAsync()
```

# Tests

Created a test where I'm passing two target specifiers that will list the same file. When that happens, no exception should occur since we will start checking if we already added the item to the `IDictionary`.