### PR TITLE
BUGFIX: Properly report `JSON1006.ValueTooLarge` in the `results` node when validating Sarif file with `id` of `location` greater than Int32.MaxValue.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -7,6 +7,7 @@
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
 * BREAKING: `SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
 * BUGFIX: Fix `ArgumentException` when `--recurse` is enabled and two file target specifiers generates the same file path. [#2438](https://github.com/microsoft/sarif-sdk/pull/2438)
+* BUGFIX: Properly report `JSON1006.ValueTooLarge` in the `results` node when validating Sarif file with `id` of `location` greater than Int32.MaxValue. [#2439](https://github.com/microsoft/sarif-sdk/pull/2439)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -7,7 +7,7 @@
 * BREAKING: Fix `InvalidOperationException` when using PropertiesDictionary in a multithreaded application, and remove `[Serializable]` from it. Now use of BinaryFormatter on it will result in `SerializationException`: Type `PropertiesDictionary` is not marked as serializable. [#2415](https://github.com/microsoft/sarif-sdk/pull/2415)
 * BREAKING: `SarifLogger` now emits an artifacts table entry if `artifactLocation` is not null for tool configuration and tool execution notifications. [#2437](https://github.com/microsoft/sarif-sdk/pull/2437)
 * BUGFIX: Fix `ArgumentException` when `--recurse` is enabled and two file target specifiers generates the same file path. [#2438](https://github.com/microsoft/sarif-sdk/pull/2438)
-* BUGFIX: Properly report `JSON1006.ValueTooLarge` in the `results` node when validating Sarif file with `id` of `location` greater than Int32.MaxValue. [#2439](https://github.com/microsoft/sarif-sdk/pull/2439)
+* BUGFIX: Properly report `JSON1006.ValueTooLarge` in the `results` node when validating Sarif file with `id` of `location` greater than Int32.MaxValue. [#2440](https://github.com/microsoft/sarif-sdk/pull/2440)
 
 ## **v2.4.12** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.12) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.12) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.12) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.12) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.12)
 

--- a/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
+++ b/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
@@ -1292,6 +1292,7 @@
           "description": "Value that distinguishes this location from all other locations within a single result object.",
           "type": "integer",
           "minimum": -1,
+          "maximum": 2147483647,
           "default": -1
         },
 

--- a/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         protected override string IntermediateTestFolder => @"Multitool";
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             string testName = parameter as string;
 
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 Console.WriteLine(validateCommand.ExecutionException.ToString());
             }
 
-            returnCode.Should().Be(0);
+            returnCode.Should().Be(expectedReturnCode);
 
             string actualLogFileContents = File.ReadAllText(this.IsInline ? baselineFilePath : outputLogFilePath);
             SarifLog actualLog = JsonConvert.DeserializeObject<SarifLog>(actualLogFileContents);

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -48,6 +48,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             => RunTest("JSON1002.DeserializationError.sarif");
 
         [Fact]
+        public void JSON1006_ValueTooLarge_LocationId_Valid()
+            => RunTest("JSON1006.ValueTooLarge_LocationId_Valid.sarif", expectedReturnCode: SUCCESS);
+
+        [Fact]
+        public void JSON1006_ValueTooLarge_LocationId_Invalid()
+            => RunTest("JSON1006.ValueTooLarge_LocationId_Invalid.sarif", expectedReturnCode: FAILURE);
+
+        [Fact]
+        public void JSON1008_ValueTooSmall_LocationId_Valid()
+            => RunTest("JSON1008.ValueTooSmall_LocationId_Valid.sarif", expectedReturnCode: SUCCESS);
+
+        [Fact]
+        public void JSON1008_ValueTooSmall_LocationId_Invalid()
+            => RunTest("JSON1008.ValueTooSmall_LocationId_Invalid.sarif", expectedReturnCode: SUCCESS);
+
+        [Fact]
         public void SARIF1001_RuleIdentifiersMustBeValid_Valid()
             => RunValidTestForRule(RuleId.RuleIdentifiersMustBeValid);
 
@@ -447,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         private string MakeTestFileName(ReportingDescriptor rule, string testFileNameSuffix)
             => $"{rule.Id}.{rule.Name}{testFileNameSuffix}";
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             string v2LogText = GetResourceText(inputResourceName);
 
@@ -508,7 +524,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     Console.WriteLine(validateCommand.ExecutionException.ToString());
                 }
 
-                returnCode.Should().Be(0);
+                returnCode.Should().Be(expectedReturnCode);
             }
 
             string actualLogFileContents = File.ReadAllText(actualLogFilePath);

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1006.ValueTooLarge_LocationId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1006.ValueTooLarge_LocationId_Invalid.sarif
@@ -1,0 +1,437 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing",
+          "rules": [
+            {
+              "id": "JSON1006",
+              "name": "ValueTooLarge",
+              "fullDescription": {
+                "text": "A numeric value is greater than the maximum value permitted by the schema's \"maximum\" property."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "at \"{0}\": The value {1} is greater than the maximum value of {2}."
+                }
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              }
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "toolExecutionNotifications": [
+            {
+              "message": {
+                "text": "Newtonsoft.Json.JsonReaderException: JSON integer 2147483648 is too large or small for an Int32. Path 'runs[0].results[0].locations[0].id', line 21, position 30.\r\n   at Newtonsoft.Json.JsonTextReader.ParseReadNumber(ReadType readType, Char firstChar, Int32 initialPosition)\r\n   at Newtonsoft.Json.JsonTextReader.ReadNumberValue(ReadType readType)\r\n   at Newtonsoft.Json.JsonTextReader.ReadAsInt32()\r\n   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)\r\n   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)\r\n   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)\r\n   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)\r\n   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)\r\n   at Microsoft.CodeAnalysis.Sarif.Multitool.ValidateCommand.Deserialize(String logContents) in /_/src/Sarif.Multitool.Library/ValidateCommand.cs:line 85\r\n   at Microsoft.CodeAnalysis.Sarif.Multitool.ValidateCommand.AnalyzeTarget(IEnumerable`1 skimmers, SarifValidationContext context, ISet`1 disabledSkimmers) in /_/src/Sarif.Multitool.Library/ValidateCommand.cs:line 70\r\n   at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.DetermineApplicabilityAndAnalyze(TOptions options, IEnumerable`1 skimmers, TContext rootContext, String target, ISet`1 disabledSkimmers) in /_/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs:line 649\r\n   at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.AnalyzeTargets(TOptions options, IEnumerable`1 skimmers, TContext rootContext, IEnumerable`1 targets) in /_/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs:line 575\r\n   at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Analyze(TOptions options, AggregatingLogger logger) in /_/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs:line 191\r\n   at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Run(TOptions options) in /_/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs:line 87"
+              },
+              "level": "error",
+              "exception": {
+                "kind": "JsonReaderException",
+                "message": "JSON integer 2147483648 is too large or small for an Int32. Path 'runs[0].results[0].locations[0].id', line 21, position 30.",
+                "stack": {
+                  "frames": [
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonTextReader.ParseReadNumber(ReadType readType, Char firstChar, Int32 initialPosition)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonTextReader.ReadNumberValue(ReadType readType)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonTextReader.ReadAsInt32()"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Multitool.ValidateCommand.Deserialize(String logContents)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Multitool.ValidateCommand.AnalyzeTarget(IEnumerable`1 skimmers, SarifValidationContext context, ISet`1 disabledSkimmers)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.DetermineApplicabilityAndAnalyze(TOptions options, IEnumerable`1 skimmers, TContext rootContext, String target, ISet`1 disabledSkimmers)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.AnalyzeTargets(TOptions options, IEnumerable`1 skimmers, TContext rootContext, IEnumerable`1 targets)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Analyze(TOptions options, AggregatingLogger logger)"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Run(TOptions options)"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "innerExceptions": []
+              },
+              "descriptor": {
+                "id": "ERR999.UnhandledEngineException"
+              }
+            }
+          ],
+          "executionSuccessful": false
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/Inputs.JSON1006.ValueTooLarge_LocationId_Invalid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "JSON1006",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "default",
+            "arguments": [
+              "runs[0].results[0].locations[0].id",
+              "2147483648",
+              "2147483647"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 21,
+                  "startColumn": 30
+                }
+              }
+            }
+          ],
+          "properties": {
+            "jsonPath": "runs[0].results[0].locations[0].id"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1006.ValueTooLarge_LocationId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1006.ValueTooLarge_LocationId_Valid.sarif
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing"
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/Inputs.JSON1006.ValueTooLarge_LocationId_Valid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1008.ValueTooSmall_LocationId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1008.ValueTooSmall_LocationId_Invalid.sarif
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing",
+          "rules": [
+            {
+              "id": "JSON1008",
+              "name": "ValueTooSmall",
+              "fullDescription": {
+                "text": "A numeric value is less than the minimum value permitted by the schema's \"minimum\" property."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "at \"{0}\": The value {1} is less than the minimum value of {2}."
+                }
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              }
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/Inputs.JSON1008.ValueTooSmall_LocationId_Invalid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "JSON1008",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "default",
+            "arguments": [
+              "runs[0].results[0].locations[0].id",
+              "-2",
+              "-1"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 21,
+                  "startColumn": 22
+                }
+              }
+            }
+          ],
+          "properties": {
+            "jsonPath": "runs[0].results[0].locations[0].id"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1008.ValueTooSmall_LocationId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1008.ValueTooSmall_LocationId_Valid.sarif
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing"
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/Inputs.JSON1008.ValueTooSmall_LocationId_Valid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1006.ValueTooLarge_LocationId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1006.ValueTooLarge_LocationId_Invalid.sarif
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif Functional Testing",
+          "informationUri": "https://www.example.com",
+          "version": "1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Locations that specify file paths."
+          },
+          "locations": [
+            {
+              "id": 2147483648,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file1.cs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "workingDirectory": {
+            "uri": "https://www.example.com"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1006.ValueTooLarge_LocationId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1006.ValueTooLarge_LocationId_Valid.sarif
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif Functional Testing",
+          "informationUri": "https://www.example.com",
+          "version": "1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Locations that specify file paths."
+          },
+          "locations": [
+            {
+              "id": 2147483647,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file1.cs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "workingDirectory": {
+            "uri": "https://www.example.com"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1008.ValueTooSmall_LocationId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1008.ValueTooSmall_LocationId_Invalid.sarif
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif Functional Testing",
+          "informationUri": "https://www.example.com",
+          "version": "1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Locations that specify file paths."
+          },
+          "locations": [
+            {
+              "id": -2,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file1.cs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "workingDirectory": {
+            "uri": "https://www.example.com"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1008.ValueTooSmall_LocationId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/JSON1008.ValueTooSmall_LocationId_Valid.sarif
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif Functional Testing",
+          "informationUri": "https://www.example.com",
+          "version": "1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Locations that specify file paths."
+          },
+          "locations": [
+            {
+              "id": 0,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file1.cs"
+                }
+              }
+            },
+            {
+              "id": 1,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file2.cs"
+                }
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file3.cs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "workingDirectory": {
+            "uri": "https://www.example.com"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/Writers/FilterByPredicateTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Writers/FilterByPredicateTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             RunTest("FilterByPredicate.sarif", "RuleIdPredicate.sarif", predicate);
         }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             var predicate = (FilteringVisitor.IncludeResultPredicate)parameter;
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             RunTest("DuplicatedResults.sarif");
         }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             const string InputFolderPath = @"C:\input";
             string targetFileSpecifier = Path.Combine(InputFolderPath, inputResourceName);
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             var mergeCommand = new MergeCommand(fileSystem);
 
             int returnCode = mergeCommand.Run(options);
-            returnCode.Should().Be(0);
+            returnCode.Should().Be(expectedReturnCode);
 
             return File.ReadAllText(outputFilePath);
         }

--- a/src/Test.UnitTests.Sarif.Multitool.Library/RebaseUriCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/RebaseUriCommandTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             };
         }
 
-        protected override string ConstructTestOutputFromInputResource(string testFilePath, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string testFilePath, object parameter, int expectedReturnCode = SUCCESS)
         {
             return RunRebaseUriCommand(testFilePath, this.options);
         }

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubIngestionVisitorTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     {
         public GitHubIngestionVisitorTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             string logContents = GetResourceText(inputResourceName);
             SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);

--- a/src/Test.UnitTests.Sarif/Visitors/InsertOptionalDataVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/InsertOptionalDataVisitorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
         }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             SarifLog actualLog = PrereleaseCompatibilityTransformer.UpdateToCurrentVersion(
                 GetResourceText(inputResourceName),

--- a/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Visitors
         public SarifCurrentToVersionOneVisitorTests(ITestOutputHelper outputHelper)
             : base(outputHelper, testProducesSarifCurrentVersion: false) { }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResource, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResource, object parameter, int expectedReturnCode = SUCCESS)
         {
             string v2LogText = GetResourceText(inputResource);
             PrereleaseCompatibilityTransformer.UpdateToCurrentVersion(v2LogText, formatting: Formatting.Indented, out v2LogText);

--- a/src/Test.UnitTests.Sarif/Visitors/SarifVersionOneToCurrentVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/SarifVersionOneToCurrentVisitorTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Visitors
     {
         public SarifVersionOneToCurrentVisitorTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             string v1LogText = GetResourceText(inputResourceName);
             SarifLogVersionOne v1Log = JsonConvert.DeserializeObject<SarifLogVersionOne>(v1LogText, SarifTransformerUtilities.JsonSettingsV1Indented);

--- a/src/Test.UnitTests.Sarif/Writers/PrereleaseCompatibilityTransformerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/PrereleaseCompatibilityTransformerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public PrereleaseCompatibilityTransformerTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter, int expectedReturnCode = SUCCESS)
         {
             string inputResourceText = GetResourceText(inputResourceName);
 

--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             JToken actualToken = JsonConvert.DeserializeObject<JToken>(actualSarif);
 
             // When running DeepEquals for the failed cases,
-            // skip compare the toolExecutionNotifications which contains detail debugging info,
+            // skip comparing the toolExecutionNotifications that contains detail debugging info,
             // which could varies in each run.
             if (expectedReturnCode == FAILURE)
             {
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             JToken roundTrippedToken = JsonConvert.DeserializeObject<JToken>(roundTrippedSarif);
 
             // When running DeepEquals for the failed cases,
-            // skip compare the toolExecutionNotifications which contains detail debugging info,
+            // skip comparing the toolExecutionNotifications that contains detail debugging info,
             // which could varies in each run.
             if (expectedReturnCode == FAILURE)
             {


### PR DESCRIPTION
# Description:

request from GitHub,

Below is the conversation:
Hi gang, do you maintain the sarif validator? One thing that seems to slip through is that the ID field accepts an integer but there's a max limit on the GitHub side, we're asking for the limit to be documented but it might be a small addition to the validator to ensure that the ID value is > max_value. If you maintain it I can circle back once I know the max ID value.

I've attached an example invalid sarif file. On line 85, you'll see:
"id":311971300974507712963699621624531493277,
That number is way larger than an integer. I think the max value depends on the language/compiler, but it looks like the general integer max value is 2,147,483,647.


# Fixes:

1. Because Deserialize() will result in error,
We already have a rule `JSON1006.ValueTooLarge`, the `JSONXXXX` rules runs before we try to Deserialize(),
so it is a good place to do the validate.
The Schema will need to add the max value for this to happen.

2. added tests for when we expect it to success and fail, 
current code does not support the case of fail so a few modification made for it.



