### PR TITLE
Updating jschema version

### DIFF
--- a/src/Sarif/ToDotNet/ToDotNet.targets
+++ b/src/Sarif/ToDotNet/ToDotNet.targets
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(OS) == 'Windows_NT'">
-    <JsonSchemaToDotNetPath>$(MSBuildProjectDirectory)\..\packages\Microsoft.Json.Schema.ToDotNet.1.1.0\tools\net461\Microsoft.Json.Schema.ToDotNet.Cli.exe</JsonSchemaToDotNetPath>
+    <JsonSchemaToDotNetPath>$(MSBuildProjectDirectory)\..\packages\Microsoft.Json.Schema.ToDotNet.1.1.3\tools\net461\Microsoft.Json.Schema.ToDotNet.Cli.exe</JsonSchemaToDotNetPath>
     <ExecCommand>&quot;$(NuGetPath)\NuGet.exe&quot; restore &quot;$(MSBuildThisFileDirectory)packages.config&quot; -PackagesDirectory &quot;$(MSBuildThisFileDirectory)\..\..\packages&quot; -ConfigFile &quot;$(NuGetConfigPath)&quot; -Verbosity quiet</ExecCommand>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS) != 'Windows_NT'">
-    <JsonSchemaToDotNetPath>$(MSBuildProjectDirectory)\..\packages\Microsoft.Json.Schema.ToDotNet.1.1.0\tools\netcoreapp2.0\Microsoft.Json.Schema.ToDotNet.Cli.dll</JsonSchemaToDotNetPath>
+    <JsonSchemaToDotNetPath>$(MSBuildProjectDirectory)\..\packages\Microsoft.Json.Schema.ToDotNet.1.1.3\tools\netcoreapp3.1\Microsoft.Json.Schema.ToDotNet.Cli.dll</JsonSchemaToDotNetPath>
     <ExecCommand>nuget restore &quot;$(MSBuildThisFileDirectory)packages.config&quot; -PackagesDirectory &quot;$(MSBuildThisFileDirectory)\..\..\packages&quot; -ConfigFile &quot;$(NuGetConfigPath)&quot; -Verbosity quiet</ExecCommand>
   </PropertyGroup>
 

--- a/src/Sarif/ToDotNet/packages.config
+++ b/src/Sarif/ToDotNet/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Json.Schema.ToDotNet" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Json.Schema.ToDotNet" version="1.1.3" targetFramework="net461" />
 </packages>

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
@@ -15,7 +15,7 @@
               },
               "messageStrings": {
                 "default": {
-                  "text": "at \"{0}\": JSON syntax error: {1}"
+                  "text": "{0}: JSON syntax error: {1}"
                 }
               },
               "defaultConfiguration": {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
@@ -11,11 +11,11 @@
               "id": "JSON1002",
               "name": "RequiredPropertyMissing",
               "fullDescription": {
-                "text": "A property required by the schema's \"required\" property is missing."
+                "text": "A property required by the schema's 'required' property is missing."
               },
               "messageStrings": {
                 "default": {
-                  "text": "at \"{0}\": The required property \"{1}\" is missing."
+                  "text": "{0}: The required property '{1}' is missing."
                 }
               },
               "defaultConfiguration": {

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -132,7 +132,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Json.Schema" Version="1.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.13.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Json.Schema" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="1.1.3" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />


### PR DESCRIPTION
This change is updating the jschema packages to be compatible with the UNIX environments.
Previously, we were using an unsupported version (netcoreapp2.0).