### PR TITLE
Fix CodeQL workflow failure

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
# Description
CodeQL workflow failed because workflow platform 'windows-latest' upgraded from win10/2019 to win11/2022 recently and failed with below error:
```
Error: Tracing builds with CodeQL is currently not supported on Windows 11 and Windows Server 2022. 
Please modify your Actions workflow to use an earlier version of Windows for this job, for example by setting `runs-on: windows-2019`.
```

# Fix:
CodeQL doesn't run on windows 11/2022 platform according to release note: https://github.com/github/codeql-cli-binaries/releases
Have to specify platform 'windows-2019' explicitly to avoid the build error.