### PR TITLE
Update Code generation `SerializedPropertyInfo`

### DIFF
--- a/src/Sarif/Autogenerated/AddressEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AddressEqualityComparer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ArtifactChangeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactChangeEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ArtifactContentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactContentEqualityComparer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ArtifactEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactEqualityComparer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ArtifactLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactLocationEqualityComparer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/AttachmentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AttachmentEqualityComparer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ConfigurationOverrideEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ConfigurationOverrideEqualityComparer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ConversionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ConversionEqualityComparer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/EdgeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeEqualityComparer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/EdgeTraversalEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeTraversalEqualityComparer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ExternalPropertiesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertiesEqualityComparer.cs
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferenceEqualityComparer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferencesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferencesEqualityComparer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/FixEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FixEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/GraphEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/GraphEqualityComparer.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/GraphTraversalEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/GraphTraversalEqualityComparer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/LocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LocationEqualityComparer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/LocationRelationshipEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LocationRelationshipEqualityComparer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/MessageEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/MessageEqualityComparer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/MultiformatMessageStringEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/MultiformatMessageStringEqualityComparer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/NodeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NodeEqualityComparer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/RectangleEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RectangleEqualityComparer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/RegionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RegionEqualityComparer.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ReportingConfigurationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingConfigurationEqualityComparer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ReportingDescriptorReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorReferenceEqualityComparer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ResultEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultEqualityComparer.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_4.Value, value_5))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_4.Value, value_5))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ResultProvenanceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultProvenanceEqualityComparer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/RunAutomationDetailsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunAutomationDetailsEqualityComparer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/SpecialLocationsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SpecialLocationsEqualityComparer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/StackEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ThreadFlowEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowEqualityComparer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ToolComponentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentEqualityComparer.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ToolComponentReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentReferenceEqualityComparer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/ToolEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/TranslationMetadataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/TranslationMetadataEqualityComparer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/VersionControlDetailsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/VersionControlDetailsEqualityComparer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_0.Value, value_1))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_4.Value, value_5))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_4.Value, value_5))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -5,7 +5,7 @@
       "arguments": {
         "valueTypeName": "SerializedPropertyInfo",
         "namespaceName": "Microsoft.CodeAnalysis.Sarif.Readers",
-        "comparisonKind": "ObjectEquals",
+        "comparisonKind": "EqualityComparerEquals",
         "hashKind": "ScalarReferenceType",
         "initializationKind": "SimpleAssign"
       }
@@ -517,7 +517,7 @@
       "arguments": {
         "valueTypeName": "SerializedPropertyInfo",
         "namespaceName": "Microsoft.CodeAnalysis.Sarif.Readers",
-        "comparisonKind": "ObjectEquals",
+        "comparisonKind": "EqualityComparerEquals",
         "hashKind": "ScalarReferenceType",
         "initializationKind": "SimpleAssign"
       }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -6,7 +6,7 @@
         "valueTypeName": "SerializedPropertyInfo",
         "namespaceName": "Microsoft.CodeAnalysis.Sarif.Readers",
         "comparisonKind": "EqualityComparerEquals",
-        "hashKind": "ScalarReferenceType",
+        "hashKind": "ObjectModelType",
         "initializationKind": "SimpleAssign"
       }
     },
@@ -518,7 +518,7 @@
         "valueTypeName": "SerializedPropertyInfo",
         "namespaceName": "Microsoft.CodeAnalysis.Sarif.Readers",
         "comparisonKind": "EqualityComparerEquals",
-        "hashKind": "ScalarReferenceType",
+        "hashKind": "ObjectModelType",
         "initializationKind": "SimpleAssign"
       }
     }

--- a/src/Sarif/Core/SerializedPropertyInfo.cs
+++ b/src/Sarif/Core/SerializedPropertyInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.Sarif.Readers;
 
 using Newtonsoft.Json;
@@ -14,6 +16,10 @@ namespace Microsoft.CodeAnalysis.Sarif
     [JsonConverter(typeof(SerializedPropertyInfoConverter))]
     public class SerializedPropertyInfo
     {
+        public static IEqualityComparer<SerializedPropertyInfo> ValueComparer => SerializedPropertyInfoEqualityComparer.Instance;
+
+        public static IComparer<SerializedPropertyInfo> Comparer => SerializedPropertyInfoComparer.Instance;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializedPropertyInfo"/> class.
         /// </summary>

--- a/src/Sarif/Core/SerializedPropertyInfo.cs
+++ b/src/Sarif/Core/SerializedPropertyInfo.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static IComparer<SerializedPropertyInfo> Comparer => SerializedPropertyInfoComparer.Instance;
 
+        public int ValueGetHashCode() => ValueComparer.GetHashCode(this);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializedPropertyInfo"/> class.
         /// </summary>

--- a/src/Sarif/Core/SerializedPropertyInfoComparer.cs
+++ b/src/Sarif/Core/SerializedPropertyInfoComparer.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+using Microsoft.CodeAnalysis.Sarif.Comparers;
+
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
@@ -14,29 +16,21 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public int Compare(SerializedPropertyInfo left, SerializedPropertyInfo right)
         {
-            if (object.ReferenceEquals(left, right))
+            int compareResult = 0;
+
+            if (left.TryReferenceCompares(right, out compareResult))
             {
-                return 0;
+                return compareResult;
             }
 
-            if (left == null)
-            {
-                return -1;
-            }
-
-            if (right == null)
-            {
-                return 1;
-            }
-
-            int compareResult = string.Compare(left.SerializedValue, right.SerializedValue);
+            compareResult = left.IsString.CompareTo(right.IsString);
 
             if (compareResult != 0)
             {
                 return compareResult;
             }
 
-            compareResult = left.IsString.CompareTo(right.IsString);
+            compareResult = string.Compare(left.SerializedValue, right.SerializedValue);
 
             return compareResult;
         }

--- a/src/Sarif/Core/SerializedPropertyInfoComparer.cs
+++ b/src/Sarif/Core/SerializedPropertyInfoComparer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// Defines methods to support the comparison of objects of type SerializedPropertyInfo.
+    /// </summary>
+    internal sealed class SerializedPropertyInfoComparer : IComparer<SerializedPropertyInfo>
+    {
+        internal static readonly SerializedPropertyInfoComparer Instance = new SerializedPropertyInfoComparer();
+
+        public int Compare(SerializedPropertyInfo left, SerializedPropertyInfo right)
+        {
+            if (object.ReferenceEquals(left, right))
+            {
+                return 0;
+            }
+
+            if (left == null)
+            {
+                return -1;
+            }
+
+            if (right == null)
+            {
+                return 1;
+            }
+
+            int compareResult = string.Compare(left.SerializedValue, right.SerializedValue);
+
+            if (compareResult != 0)
+            {
+                return compareResult;
+            }
+
+            compareResult = left.IsString.CompareTo(right.IsString);
+
+            return compareResult;
+        }
+    }
+}

--- a/src/Sarif/Core/SerializedPropertyInfoEqualityComparer.cs
+++ b/src/Sarif/Core/SerializedPropertyInfoEqualityComparer.cs
@@ -24,17 +24,12 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            return left.SerializedValue.Equals(right.SerializedValue);
+            return left.Equals(right);
         }
 
         public int GetHashCode(SerializedPropertyInfo serializedPropertyInfo)
         {
-            if (serializedPropertyInfo.SerializedValue == null)
-            {
-                return 0;
-            }
-
-            return serializedPropertyInfo.SerializedValue.GetHashCode();
+            return serializedPropertyInfo.GetHashCode();
         }
     }
 }

--- a/src/Sarif/NotYetAutoGenerated/ReportingDescriptorEqualityComparer.cs
+++ b/src/Sarif/NotYetAutoGenerated/ReportingDescriptorEqualityComparer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// <summary>
     /// Defines methods to support the comparison of objects of type ReportingDescriptor for equality.
     /// </summary>
-    [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "1.1.0.0")]
+    [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "1.1.3.0")]
     internal sealed class ReportingDescriptorEqualityComparer : IEqualityComparer<ReportingDescriptor>
     {
         internal static readonly ReportingDescriptorEqualityComparer Instance = new ReportingDescriptorEqualityComparer();
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!SerializedPropertyInfo.ValueComparer.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }

--- a/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
+{
+    public class SerializedPropertyInfoTests
+    {
+        [Fact]
+        public void SerializedPropertyInfo_ComparerTests()
+        {
+            Guid testGuid = Guid.NewGuid();
+            DateTime now = DateTime.UtcNow;
+
+            var testCases = new[]
+            {
+                new
+                {
+                    Left = new SerializedPropertyInfo(null, isString:false),
+                    Right = new SerializedPropertyInfo(null, isString:false),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(null, isString:false),
+                    Right = new SerializedPropertyInfo(null, isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(true), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(true), isString:false),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(true), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(false), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(10), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(10), isString:false),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(-1), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(-10), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1 // "-1" < "-10"
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject("abc"), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("abc"), isString:true),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject("abc"), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("cba"), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(testGuid), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(testGuid), isString:true),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(testGuid), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(Guid.Empty), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(now), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(now), isString:true),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(now), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(default(DateTime)), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    // "99" compares "\"99\""
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(99), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("99"), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    // serialzed string: "[\"a\",\"b\",\"c\"]"
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "a", "b", "c" }), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "a", "b", "c" }), isString:false),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "a", "b", "c" }), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "c", "b", "a" }), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    // serialzed string: "{\"a\":1,\"b\":true}"
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = false }), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { b = false, a = 1 }), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                bool equalsResult = SerializedPropertyInfo.ValueComparer.Equals(testCase.Left, testCase.Right);
+                equalsResult.Should().Be(
+                    testCase.ExpectedEqualsResult,
+                    $"left: {testCase.Left.SerializedValue} right: {testCase.Right.SerializedValue}");
+
+                int compareResult = SerializedPropertyInfo.Comparer.Compare(testCase.Left, testCase.Right);
+                compareResult.Should().Be(
+                    testCase.ExpectedCompareResult,
+                    $"left: {testCase.Left.SerializedValue} right: {testCase.Right.SerializedValue}");
+            }
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
@@ -25,6 +25,41 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             {
                 new
                 {
+                    Left = default(SerializedPropertyInfo),
+                    Right = default(SerializedPropertyInfo),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
+                },
+                new
+                {
+                    Left = default(SerializedPropertyInfo),
+                    Right = new SerializedPropertyInfo(null, isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(null, isString:false),
+                    Right = new SerializedPropertyInfo(string.Empty, isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(string.Empty, isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(string.Empty), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(null), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(string.Empty), isString:true),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
                     Left = new SerializedPropertyInfo(null, isString:false),
                     Right = new SerializedPropertyInfo(null, isString:false),
                     ExpectedEqualsResult = true,
@@ -63,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                     Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(-1), isString:false),
                     Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(-10), isString:false),
                     ExpectedEqualsResult = false,
-                    ExpectedCompareResult = -1 // "-1" < "-10"
+                    ExpectedCompareResult = -1
                 },
                 new
                 {
@@ -78,6 +113,20 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                     Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("cba"), isString:true),
                     ExpectedEqualsResult = false,
                     ExpectedCompareResult = -1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject("10"), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("10"), isString:false),
+                    ExpectedEqualsResult = false,
+                    ExpectedCompareResult = 1
+                },
+                new
+                {
+                    Left = new SerializedPropertyInfo(JsonConvert.SerializeObject("\"10\""), isString:true),
+                    Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("\"10\""), isString:true),
+                    ExpectedEqualsResult = true,
+                    ExpectedCompareResult = 0
                 },
                 new
                 {
@@ -109,15 +158,13 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 },
                 new
                 {
-                    // "99" compares "\"99\""
                     Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(99), isString:false),
                     Right = new SerializedPropertyInfo(JsonConvert.SerializeObject("99"), isString:true),
                     ExpectedEqualsResult = false,
-                    ExpectedCompareResult = 1
+                    ExpectedCompareResult = -1
                 },
                 new
                 {
-                    // serialzed string: "[\"a\",\"b\",\"c\"]"
                     Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "a", "b", "c" }), isString:false),
                     Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new[] { "a", "b", "c" }), isString:false),
                     ExpectedEqualsResult = true,
@@ -132,7 +179,6 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 },
                 new
                 {
-                    // serialzed string: "{\"a\":1,\"b\":true}"
                     Left = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
                     Right = new SerializedPropertyInfo(JsonConvert.SerializeObject(new { a = 1, b = true }), isString:false),
                     ExpectedEqualsResult = true,
@@ -159,12 +205,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 bool equalsResult = SerializedPropertyInfo.ValueComparer.Equals(testCase.Left, testCase.Right);
                 equalsResult.Should().Be(
                     testCase.ExpectedEqualsResult,
-                    $"left: {testCase.Left.SerializedValue} right: {testCase.Right.SerializedValue}");
+                    $"left: {testCase.Left?.SerializedValue} right: {testCase.Right?.SerializedValue}");
 
                 int compareResult = SerializedPropertyInfo.Comparer.Compare(testCase.Left, testCase.Right);
                 compareResult.Should().Be(
                     testCase.ExpectedCompareResult,
-                    $"left: {testCase.Left.SerializedValue} right: {testCase.Right.SerializedValue}");
+                    $"left: {testCase.Left?.SerializedValue} right: {testCase.Right?.SerializedValue}");
             }
         }
     }


### PR DESCRIPTION
# Description

Currently there is an issue in JSchema EqualityComparerGenerator that doesn't correctly handle comparison of data model type element of n dictionary. A patch fix was introduced in [src/Sarif/NotYetAutoGenerated/ReportingDescriptorEqualityComparer.cs](https://github.com/microsoft/sarif-sdk/blob/main/src/Sarif/NotYetAutoGenerated/ReportingDescriptorEqualityComparer.cs)

https://github.com/microsoft/sarif-sdk/blob/b2c7e399cfaf1fde47b336bbb4976f723263efa3/src/Sarif/NotYetAutoGenerated/ReportingDescriptorEqualityComparer.cs#L278-L287

Already have a fix in JSchema for this issue. To make it work the way to generate codes related to `SerializedPropertyInfo` needs to be the same way as other Sarif entities.

Sarif.SDK uses JSchema to auto generate SARIF entities using the information in CodeGenHints.json.

`SerializedPropertyInfo` is the type of property bags (`IDictionary<string, SerializedPropertyInfo>`) of all SARIF entities. It's not auto generated by JSchema, its defined in Sarif project, and JSchema generates the code reference to `SerializedPropertyInfo` using the information in CodeGenHints.json.

The change is to make the codeGenHints configurations for 'properties', the dictionary of `SerializedPropertyInfo`, to be the same way as all other dictionaries of Sarif entities.

# Changes

Updated the configurations for 'properties in CodeGenHints.json to correct values, same as all other Sarif entities:
- `comparisonKind` from `ObjectEquals` to `EqualityComparerEquals`.
- `hashKind` from `ScalarReferenceType` to `ObjectModelType`

Added `SerializedPropertyInfoComparer : IComparer<SerializedPropertyInfo>` so that it will be ready for auto generated comparer for all Sarif entities.

Added unit tests.