### PR TITLE
CodeQL Fix "This cast is redundant because the expression already has type"

### DIFF
--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Artifacts = _files.OrderBy(d => d.Value.Item2)
                                   .Select(p => p.Value)
                                   .Select(t => t.Item1)
-                                  .ToList() as IList<Artifact>,
+                                  .ToList(),
                 Tool = new Tool
                 {
                     Driver = new ToolComponent

--- a/src/Sarif.Converters/StringReference.cs
+++ b/src/Sarif.Converters/StringReference.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <returns>true if <c>Object.ReferenceEquals(left, right)</c>; otherwise, false.</returns>
         public static bool AreEqual(string left, string right)
         {
-            Debug.Assert(((object)left) == ((object)right) || !string.Equals(left, right, StringComparison.Ordinal),
+            Debug.Assert(left == ((object)right) || !string.Equals(left, right, StringComparison.Ordinal),
                 "Object comparison used for non-atomized string \"" + left + "\".");
-            return ((object)left) == ((object)right);
+            return left == ((object)right);
         }
 
         /// <summary>Do not call this function. Prevents typo StringReference.Equals from compiling.</summary>

--- a/src/Sarif/Baseline/V2/TrustMap.cs
+++ b/src/Sarif/Baseline/V2/TrustMap.cs
@@ -43,11 +43,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
                 {
                     // Simplification of (Match / Unique) * (Unique / Use)
                     // The product of how many values match and how many unique values there were
-                    return Math.Max(DefaultTrust, ((float)value.MatchCount) / (float)value.UseCount);
+                    return Math.Max(DefaultTrust, value.MatchCount / (float)value.UseCount);
                 }
                 else
                 {
-                    return Math.Max(DefaultTrust, ((float)value.UniqueValues.Count) / (float)value.UseCount);
+                    return Math.Max(DefaultTrust, value.UniqueValues.Count / (float)value.UseCount);
                 }
             }
 

--- a/src/Sarif/Map/JsonMapBuilder.cs
+++ b/src/Sarif/Map/JsonMapBuilder.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
         {
             long arraySizeBytes = node.End - node.Start;
             double sizeBudget = arraySizeBytes * settings.CurrentSizeRatio;
-            double countBudget = (double)((sizeBudget - JsonMapSettings.NodeSizeEstimateBytes) / JsonMapSettings.ArrayStartSizeEstimateBytes);
+            double countBudget = (sizeBudget - JsonMapSettings.NodeSizeEstimateBytes) / JsonMapSettings.ArrayStartSizeEstimateBytes;
 
             if (arraySizeBytes < settings.MinimumSizeForNode || node.Count < 2 || countBudget < 2)
             {
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
                 // If not every item, build a new array with every Nth item
                 if (every > 1)
                 {
-                    int newCount = (int)(node.Count / every);
+                    int newCount = node.Count / every;
                     List<long> newStarts = new List<long>(newCount);
 
                     for (int i = 0; i * every < node.Count; ++i)

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 IDictionary pb = property as IDictionary;
                 if (pb != null)
                 {
-                    ((IDictionary)pb).SavePropertiesToXmlStream(writer, settings, key, settingNameToDescriptionMap);
+                    pb.SavePropertiesToXmlStream(writer, settings, key, settingNameToDescriptionMap);
                     continue;
                 }
 

--- a/src/Sarif/Query/Evaluators/EvaluatorFactory.cs
+++ b/src/Sarif/Query/Evaluators/EvaluatorFactory.cs
@@ -46,27 +46,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Query.Evaluators
             }
             else if (fieldType == typeof(int))
             {
-                return new LongEvaluator<int>(value => (long)value, term);
+                return new LongEvaluator<int>(value => value, term);
             }
             else if (fieldType == typeof(uint))
             {
-                return new LongEvaluator<uint>(value => (long)value, term);
+                return new LongEvaluator<uint>(value => value, term);
             }
             else if (fieldType == typeof(short))
             {
-                return new LongEvaluator<short>(value => (long)value, term);
+                return new LongEvaluator<short>(value => value, term);
             }
             else if (fieldType == typeof(ushort))
             {
-                return new LongEvaluator<ushort>(value => (long)value, term);
+                return new LongEvaluator<ushort>(value => value, term);
             }
             else if (fieldType == typeof(byte))
             {
-                return new LongEvaluator<byte>(value => (long)value, term);
+                return new LongEvaluator<byte>(value => value, term);
             }
             else if (fieldType == typeof(sbyte))
             {
-                return new LongEvaluator<sbyte>(value => (long)value, term);
+                return new LongEvaluator<sbyte>(value => value, term);
             }
             else if (fieldType == typeof(string))
             {

--- a/src/Sarif/Readers/SerializedPropertyInfoConverter.cs
+++ b/src/Sarif/Readers/SerializedPropertyInfoConverter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static void Write(JsonWriter writer, SerializedPropertyInfo value)
         {
-            SerializedPropertyInfo spi = (SerializedPropertyInfo)value;
+            SerializedPropertyInfo spi = value;
 
             if (spi == null || spi.SerializedValue == null)
             {

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
 
             ITestAnalyzeCommand command = multithreaded
-                ? (ITestAnalyzeCommand)new TestMultithreadedAnalyzeCommand()
+                ? new TestMultithreadedAnalyzeCommand()
                 : (ITestAnalyzeCommand)new TestAnalyzeCommand();
 
             command.DefaultPluginAssemblies = plugInAssemblies;

--- a/src/Test.UnitTests.WorkItems/Logging/MetricsLogValuesTests.cs
+++ b/src/Test.UnitTests.WorkItems/Logging/MetricsLogValuesTests.cs
@@ -75,8 +75,8 @@ namespace Microsoft.WorkItems.Logging
             EventId eventId = new EventId(1);
             Dictionary<string, object> customDimensions = new Dictionary<string, object>();
             customDimensions.Add("Empty", "");
-            customDimensions.Add("Null1", (string)null);
-            customDimensions.Add("Null2", (object)null);
+            customDimensions.Add("Null1", null);
+            customDimensions.Add("Null2", null);
             customDimensions.Add("HasValue", 3);
 
             MetricsLogValues values = new MetricsLogValues(message, eventId, customDimensions);
@@ -84,10 +84,10 @@ namespace Microsoft.WorkItems.Logging
             values.Count.Should().Be(customDimensions.Count);
 
             string sentinelValue = "<empty>";
-            ((IEnumerable<KeyValuePair<string, object>>)values).Single(v => v.Key == "Empty").Value.Should().Be(sentinelValue);
-            ((IEnumerable<KeyValuePair<string, object>>)values).Single(v => v.Key == "Null1").Value.Should().Be(sentinelValue);
-            ((IEnumerable<KeyValuePair<string, object>>)values).Single(v => v.Key == "Null2").Value.Should().Be(sentinelValue);
-            ((IEnumerable<KeyValuePair<string, object>>)values).Single(v => v.Key == "HasValue").Value.Should().Be(3);
+            values.Single(v => v.Key == "Empty").Value.Should().Be(sentinelValue);
+            values.Single(v => v.Key == "Null1").Value.Should().Be(sentinelValue);
+            values.Single(v => v.Key == "Null2").Value.Should().Be(sentinelValue);
+            values.Single(v => v.Key == "HasValue").Value.Should().Be(3);
         }
     }
 }


### PR DESCRIPTION
# Description:

CodeQL reports "This cast is redundant because the expression already has type"

# Fixes:

remove the redundant cast