### PR TITLE
Add boilerplate helper to provide logging when no plugins are configured

### DIFF
--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -15,13 +15,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         // Configuration errors:
         private const string ERR997_MissingFile = "ERR997.MissingFile";
         private const string ERR997_NoRulesLoaded = "ERR997.NoRulesLoaded";
+        private const string ERR997_NoPluginsConfigured = "ERR997.NoPluginsConfigured";
         private const string ERR997_ExceptionLoadingPlugIn = "ERR997.ExceptionLoadingPlugIn";
         private const string ERR997_NoValidAnalysisTargets = "ERR997.NoValidAnalysisTargets";
         private const string ERR997_ExceptionAccessingFile = "ERR997.ExceptionAccessingFile";
-        private const string ERR997_MissingReportingConfiguration = "ERR997.MissingReportingConfiguration";
         private const string ERR997_ExceptionCreatingLogFile = "ERR997.ExceptionCreatingLogFile";
         internal const string ERR997_AllRulesExplicitlyDisabled = "ERR997.AllRulesExplicitlyDisabled";
         private const string ERR997_InvalidInvocationPropertyName = "ERR997.InvalidInvocationPropertyName";
+        private const string ERR997_MissingReportingConfiguration = "ERR997.MissingReportingConfiguration";
         private const string ERR997_ExceptionLoadingAnalysisTarget = "ERR997.ExceptionLoadingAnalysisTarget";
         private const string ERR997_ExceptionInstantiatingSkimmers = "ERR997.ExceptionInstantiatingSkimmers";
         private const string ERR997_OutputFileAlreadyExists = "ERR997.OutputFileAlreadyExists";
@@ -125,6 +126,26 @@ namespace Microsoft.CodeAnalysis.Sarif
                     exception: null,
                     persistExceptionStack: false,
                     messageFormat: null));
+
+            context.RuntimeErrors |= RuntimeConditions.NoRulesLoaded;
+        }
+        public static void LogNoPluginsConfigured(IAnalysisContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // No analysis plugins were configured, therefore no rules loaded.
+            context.Logger.LogConfigurationNotification(
+                    Errors.CreateNotification(
+                        context.TargetUri,
+                        ERR997_NoPluginsConfigured,
+                        ruleId: null,
+                        FailureLevel.Error,
+                        exception: null,
+                        persistExceptionStack: false,
+                        messageFormat: null));
 
             context.RuntimeErrors |= RuntimeConditions.NoRulesLoaded;
         }

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         // Configuration errors:
         private const string ERR997_MissingFile = "ERR997.MissingFile";
         private const string ERR997_NoRulesLoaded = "ERR997.NoRulesLoaded";
-        private const string ERR997_NoPluginsConfigured = "ERR997.NoPluginsConfigured";
+        internal const string ERR997_NoPluginsConfigured = "ERR997.NoPluginsConfigured";
         private const string ERR997_ExceptionLoadingPlugIn = "ERR997.ExceptionLoadingPlugIn";
         private const string ERR997_NoValidAnalysisTargets = "ERR997.NoValidAnalysisTargets";
         private const string ERR997_ExceptionAccessingFile = "ERR997.ExceptionAccessingFile";
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             Assembly assembly = Assembly.GetEntryAssembly();
-            assembly = assembly ?? Assembly.GetExecutingAssembly();
+            assembly ??= Assembly.GetExecutingAssembly();
             string exeName = Path.GetFileName(assembly.Location);
 
             // Check '{0}' was disabled while analyzing '{1}' because the analysis
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string messageFormat,
             params string[] args)
         {
-            messageFormat = messageFormat ?? GetMessageFormatResourceForNotification(notificationId);
+            messageFormat ??= GetMessageFormatResourceForNotification(notificationId);
 
             string message = string.Format(CultureInfo.CurrentCulture, messageFormat, args);
 

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class SdkResources {
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not load the plug-in &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Could not load the plugin &apos;{0}&apos;..
         /// </summary>
         public static string ERR997_ExceptionLoadingPlugIn {
             get {
@@ -201,6 +201,15 @@ namespace Microsoft.CodeAnalysis.Sarif {
         public static string ERR997_MissingReportingConfiguration {
             get {
                 return ResourceManager.GetString("ERR997_MissingReportingConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No plugins were configured or successfully located and so no rules were loaded..
+        /// </summary>
+        public static string ERR997_NoPluginsConfigured {
+            get {
+                return ResourceManager.GetString("ERR997_NoPluginsConfigured", resourceCulture);
             }
         }
         

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -178,7 +178,7 @@
     <value>Could not load analysis target '{0}'.</value>
   </data>
   <data name="ERR997_ExceptionLoadingPlugIn" xml:space="preserve">
-    <value>Could not load the plug-in '{0}'.</value>
+    <value>Could not load the plugin '{0}'.</value>
   </data>
   <data name="ERR997_MissingFile" xml:space="preserve">
     <value>A required file specified on the command line could not be found: '{0}'.</value>
@@ -277,5 +277,8 @@ You can also refer to properties in the result's property bag with 'properties.&
   </data>
   <data name="WRN997_InvalidOption" xml:space="preserve">
     <value>Option '{0}' is invalid for this command.</value>
+  </data>
+  <data name="ERR997_NoPluginsConfigured" xml:space="preserve">
+    <value>No plugins were configured or successfully located and so no rules were loaded.</value>
   </data>
 </root>

--- a/src/Test.UnitTests.Sarif/ErrorsTests.cs
+++ b/src/Test.UnitTests.Sarif/ErrorsTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class ErrorsTests
+    {
+        [Fact]
+        public void Errors_NoPluginsConfigured()
+        {
+            var context = new TestAnalysisContext();
+            var logger = new TestMessageLogger();
+            context.Logger = logger;
+
+            Errors.LogNoPluginsConfigured(context);
+
+            logger.Messages.Should().BeNull();
+            logger.ToolNotifications.Should().BeNull();
+            logger.ConfigurationNotifications.Count.Should().Equals(1);
+            logger.ConfigurationNotifications[0].Descriptor.Id.Should().BeEquivalentTo(Errors.ERR997_NoPluginsConfigured);
+
+            context.RuntimeErrors.Should().Be(RuntimeConditions.NoRulesLoaded);
+        }
+    }
+}


### PR DESCRIPTION
Malformed plugin command-line arguments can result in 'no rules loaded' messages, masking the actual issue, which is that no plugins were properly specified.

This change adds a new helper for this condition. We still return 'no rules loaded' for this case, as it's not clear why we need a more precise return value (we halt because there's no work to do). 

We did not have a unit tests file, I've created one and a boilerplate test,