### PR TITLE
Fix release pipeline error

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -38,8 +38,6 @@
           target="tools\netcoreapp3.1\any" />
     <file src="bld\bin\Signing\netstandard2.0\**"
           target="tools\netcoreapp3.1\any" />
-    <file src="bld\bin\Signing\netstandard2.1\**"
-          target="tools\netcoreapp3.1\any" />
 
     <file src="triskelion.png" />
     <file src="src\ReleaseHistory.md" />


### PR DESCRIPTION
The release pipeline is failing while running `scripts\BuildPackagesFromSigningDirectory.ps1` with this error:
```
2022-08-03T23:27:08.2825834Z Could not find a part of the path 'D:\a\r1\a\bld\bin\Signing\netstandard2.1'.
2022-08-03T23:27:08.3945948Z BuildPackagesFromSigningDirectory: Sarif.Multitool NuGet package creation failed.
2022-08-03T23:27:08.3949421Z BuildPackagesFromSigningDirectory FAILED.
2022-08-03T23:27:08.4872582Z ##[error]PowerShell exited with code '1'.
```
The same error is reproducible locally and resolves with updating the below nuspec file to remove the obsolete reference.

![image](https://user-images.githubusercontent.com/30842915/182737304-56f66243-9a51-4c01-abca-86c77de8b510.png)

This change is limited to fixing the nuget release pipeline.