### PR TITLE
Beta2

### DIFF
--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -10,10 +10,10 @@
 $Frameworks = @{}
 
 # .NET Framework versions for which we build.
-# net45 is the minimal framework we build the SDK against.
-# net461 is required to build the work items assemblies
+# net462 is this minimal support .NET framework. We allow linkage
+# to net461 for compatibility reasons.
 # and any upstream consumer of them.
-$Frameworks.NetFx = @("net45", "net461")
+$Frameworks.NetFx = @("net461")
 
 # Frameworks for which we build libraries.
 $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,8 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## 3.0.0-beta1 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.0.0-beta1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.0.0-beta1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.0.0-beta1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.0.0-beta1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.0.0-beta1)
+## 3.0.0-beta2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.0.0-beta2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.0.0-beta2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.0.0-beta2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.0.0-beta2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.0.0-beta2)
 * BUGFIX: Loosen Newtonsoft.JSON minimum version requirement to 6.0.8 (for .NET framework) or 9.0.1 (for all other compilations) for Sarif.Sdk. Sarif.Converts requires 8.0.1, minimally, for .NET framework compilations.
-* BUGFIX: Broaden set of supported .NET frameworks for compatibility reasons. Sarif.Sdk now supports net45 forward. Sarif.Driver and Sarif.WorkItems requires net461 due to other dependencies.
+* BUGFIX: Broaden set of supported .NET frameworks for compatibility reasons. Sarif.Sdk, Sarif.Driver and Sarif.WorkItems requires net461.
 * BUGFIX: Set default stack limit in Newtonsoft.JSON utilization (if `JsonConvert.Defaults` is not already configured) to address GitHub advisory [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
 
 ## **v2.4.16** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.4.16) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.4.16) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.4.16) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.4.16) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.4.16)

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -9,7 +9,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <!-- We must require at least net461 in order to use System.Threading.Channels -->
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Sarif.WorkItems/Sarif.WorkItems.csproj
+++ b/src/Sarif.WorkItems/Sarif.WorkItems.csproj
@@ -9,7 +9,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <!-- We require net461 as a minimum version due to a dependency on the core WorkItems assembly -->
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -19,12 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public class PropertyBagHolder : IPropertyBagHolder
     {
-        static PropertyBagHolder()
-        {
-            // Mitigation for Newtonsoft.Json v12 vulnerability GHSA-5crp-9r3c-p9vr
-            JsonConvert.DefaultSettings ??= () => new JsonSerializerSettings { MaxDepth = 64 };
-        }
-
         protected PropertyBagHolder()
         {
             Tags = new TagsCollection(this);

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>3.0.0-beta1</VersionPrefix>
-    <PreviousVersionPrefix>2.4.16</PreviousVersionPrefix>
+    <VersionPrefix>3.0.0-beta2</VersionPrefix>
+    <PreviousVersionPrefix>3.0.0-beta1</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
- Reversion to beta2. 
- Drop SARIF SDK NETFX support to net461 (as this is the minimal version that can be compiled with a downloadable Microsoft dev pack).
- Drop proactive security mitigation fix for the core SDK assembly (as updating this code in the static constructor causes type load exceptions on executing this static constructor in some test scenarios, where the assemblies are loaded into a new AppDomain where binding redirects appear not to be applied in an expected way).

@cfaucon  @EasyRhinoMSFT @marmegh @shaopeng-gh @eddynaka 