### PR TITLE
Fix a test which fails randomly

### DIFF
--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -91,12 +91,17 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
         [Fact]
         public void SarifLog_SplitPerRun()
         {
-            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output, seed: 1529710912);
+
             SarifLog sarifLog = RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, 1);
-            sarifLog.Split(SplittingStrategy.PerRun).Should().HaveCount(1);
+
+            int expectedLogCount = sarifLog.Runs.First().Results.Any() ? 1 : 0;
+            sarifLog.Split(SplittingStrategy.PerRun).Should().HaveCount(expectedLogCount);
 
             sarifLog = RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, 3);
-            sarifLog.Split(SplittingStrategy.PerRun).Should().HaveCount(3);
+
+            expectedLogCount = sarifLog.Runs.Count(run => run.Results.Any());
+            sarifLog.Split(SplittingStrategy.PerRun).Should().HaveCount(expectedLogCount);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
         [Fact]
         public void SarifLog_SplitPerRun()
         {
-            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output, seed: 1529710912);
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
 
             SarifLog sarifLog = RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, 1);
 


### PR DESCRIPTION
# Description
Test `SarifLogTests.SarifLog_SplitPerRun` fails randomly. Can be reproduced using random seed 1529710912.

This is because the `RandomSarifLogGenerator` may generate test Sarif log run contains 0 result. But test assumes all runs have non-empty results.