### PR TITLE
FEATURE: Add `ignore-non-fatal-runtime-conditions` argument that allows program to exit as code `0` instead of `1`.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,6 +6,7 @@
 * BUGFIX: Remove duplicated rule definitions when executing `match-results-forward` commands for results with sub-rule ids. [#2486](https://github.com/microsoft/sarif-sdk/pull/2486)
 * BUGFIX: Update `merge` command to properly produce runs by tool and version when passed the `--merge-runs` argument. [#2488](https://github.com/microsoft/sarif-sdk/pull/2488)
 * BUGFIX: Eliminate `IOException` and `DirectoryNotFoundException` exceptions thrown by `merge` command when splitting by rule (due to invalid file characters in rule ids).
+* FEATURE: Add `ignore-non-fatal-runtime-conditions` argument that allows program to exit as code `0` instead of `1`. Initial supported value `NoValidAnalysisTargets`. [#2542](https://github.com/microsoft/sarif-sdk/pull/2542)
 
 ## **v3.1.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.1.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.1.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.1.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.1.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.1.0)
 

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -270,7 +270,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (targets.Count == 0)
             {
                 bool ignoreNoValidAnalysisTargets = analyzeOptions is AnalyzeOptionsBase analyzeOptionsBase
-                && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions != null
+                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(context, !ignoreNoValidAnalysisTargets);
 

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             //    access all analysis targets. Helper will return
             //    a list that potentially filters out files which
             //    did not exist, could not be accessed, etc.
-            targets = ValidateTargetsExist(_rootContext, targets, options);
+            targets = ValidateTargetsExist(_rootContext, targets);
 
             // 5. Initialize report file, if configured.
             InitializeOutputFile(options, _rootContext);
@@ -265,13 +265,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             return targets;
         }
 
-        private ISet<string> ValidateTargetsExist(TContext context, ISet<string> targets, TOptions analyzeOptions)
+        private ISet<string> ValidateTargetsExist(TContext context, ISet<string> targets)
         {
             if (targets.Count == 0)
             {
-                bool ignoreNoValidAnalysisTargets = analyzeOptions is AnalyzeOptionsBase analyzeOptionsBase
-                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions != null
-                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                bool ignoreNoValidAnalysisTargets = context is IAnalysisContext analysisContext
+                    && analysisContext.IgnoreNonFatalRunTimeConditions != null
+                    && analysisContext.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(context, !ignoreNoValidAnalysisTargets);
 

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -270,8 +270,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (targets.Count == 0)
             {
                 bool ignoreNoValidAnalysisTargets = context is IAnalysisContext analysisContext
-                    && analysisContext.IgnoreNonFatalRunTimeConditions != null
-                    && analysisContext.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                    && analysisContext.IgnoreNonFatalRuntimeConditions != null
+                    && analysisContext.IgnoreNonFatalRuntimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(context, !ignoreNoValidAnalysisTargets);
 
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             };
 
             context.MaxFileSizeInKilobytes = options.MaxFileSizeInKilobytes;
-            context.IgnoreNonFatalRunTimeConditions = options.IgnoreNonFatalRunTimeConditions;
+            context.IgnoreNonFatalRuntimeConditions = options.IgnoreNonFatalRuntimeConditions;
 
             if (filePath != null)
             {

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -120,5 +120,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             HelpText = "The maximum file size (in kilobytes) that will be analyzed.",
             Default = 1024)]
         public int MaxFileSizeInKilobytes { get; internal set; } = 1024;
+
+        [Option(
+            "ignoreNonFatalRunTimeConditions",
+            Separator = ';',
+            Default = null,
+            HelpText = "Non-Fatal RunTime Conditions, expressed as a semicolon-delimited list, " +
+                       "that should be ignored and will not cause the program to return 1 as failure. " +
+                       "Valid values: NoValidAnalysisTargets.")]
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -122,11 +122,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public int MaxFileSizeInKilobytes { get; internal set; } = 1024;
 
         [Option(
-            "ignoreNonFatalRunTimeConditions",
+            "ignore-non-fatal-runtime-conditions",
             Separator = ';',
             Default = null,
             HelpText = "Non-Fatal RunTime Conditions, expressed as a semicolon-delimited list, " +
-                       "that should be ignored and will not cause the program to return 1 as failure. " +
+                       "that should be ignored and will not cause the program to return failure code 1. " +
                        "Valid values: NoValidAnalysisTargets.")]
         public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
     }

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -125,9 +125,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "ignore-non-fatal-runtime-conditions",
             Separator = ';',
             Default = null,
-            HelpText = "Non-Fatal RunTime Conditions, expressed as a semicolon-delimited list, " +
+            HelpText = "Non-Fatal Runtime Conditions, expressed as a semicolon-delimited list, " +
                        "that should be ignored and will not cause the program to return failure code 1. " +
                        "Valid values: NoValidAnalysisTargets.")]
-        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRuntimeConditions { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -441,9 +441,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (_fileContextsCount == 0)
             {
-                bool ignoreNoValidAnalysisTargets = options is AnalyzeOptionsBase analyzeOptionsBase
-                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions != null
-                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                bool ignoreNoValidAnalysisTargets = rootContext is IAnalysisContext analysisContext
+                    && analysisContext.IgnoreNonFatalRunTimeConditions != null
+                    && analysisContext.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(rootContext, !ignoreNoValidAnalysisTargets);
 
@@ -594,6 +594,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             };
 
             context.MaxFileSizeInKilobytes = options.MaxFileSizeInKilobytes;
+            context.IgnoreNonFatalRunTimeConditions = options.IgnoreNonFatalRunTimeConditions;
 
             if (filePath != null)
             {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -442,8 +442,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (_fileContextsCount == 0)
             {
                 bool ignoreNoValidAnalysisTargets = rootContext is IAnalysisContext analysisContext
-                    && analysisContext.IgnoreNonFatalRunTimeConditions != null
-                    && analysisContext.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                    && analysisContext.IgnoreNonFatalRuntimeConditions != null
+                    && analysisContext.IgnoreNonFatalRuntimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(rootContext, !ignoreNoValidAnalysisTargets);
 
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             };
 
             context.MaxFileSizeInKilobytes = options.MaxFileSizeInKilobytes;
-            context.IgnoreNonFatalRunTimeConditions = options.IgnoreNonFatalRunTimeConditions;
+            context.IgnoreNonFatalRuntimeConditions = options.IgnoreNonFatalRuntimeConditions;
 
             if (filePath != null)
             {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -442,7 +442,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (_fileContextsCount == 0)
             {
                 bool ignoreNoValidAnalysisTargets = options is AnalyzeOptionsBase analyzeOptionsBase
-                && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions != null
+                    && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
 
                 Errors.LogNoValidAnalysisTargets(rootContext, !ignoreNoValidAnalysisTargets);
 

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -441,8 +441,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (_fileContextsCount == 0)
             {
-                Errors.LogNoValidAnalysisTargets(rootContext);
-                ThrowExitApplicationException(rootContext, ExitReason.NoValidAnalysisTargets);
+                bool ignoreNoValidAnalysisTargets = options is AnalyzeOptionsBase analyzeOptionsBase
+                && analyzeOptionsBase.IgnoreNonFatalRunTimeConditions.Contains(RuntimeConditions.NoValidAnalysisTargets);
+
+                Errors.LogNoValidAnalysisTargets(rootContext, !ignoreNoValidAnalysisTargets);
+
+                if (!ignoreNoValidAnalysisTargets)
+                {
+                    ThrowExitApplicationException(rootContext, ExitReason.NoValidAnalysisTargets);
+                }
             }
 
             return true;

--- a/src/Sarif.Multitool.Library/SarifValidationContext.cs
+++ b/src/Sarif.Multitool.Library/SarifValidationContext.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         public int MaxFileSizeInKilobytes { get; set; }
 
-        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRuntimeConditions { get; set; }
 
         public void Dispose()
         {

--- a/src/Sarif.Multitool.Library/SarifValidationContext.cs
+++ b/src/Sarif.Multitool.Library/SarifValidationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Newtonsoft.Json.Linq;
@@ -97,6 +98,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public DefaultTraces Traces { get; set; }
 
         public int MaxFileSizeInKilobytes { get; set; }
+
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
 
         public void Dispose()
         {

--- a/src/Sarif.Multitool/AnalyzeTestContext.cs
+++ b/src/Sarif.Multitool/AnalyzeTestContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         public int MaxFileSizeInKilobytes { get; set; }
 
-        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRuntimeConditions { get; set; }
 
         public void Dispose() { }
     }

--- a/src/Sarif.Multitool/AnalyzeTestContext.cs
+++ b/src/Sarif.Multitool/AnalyzeTestContext.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
@@ -31,6 +32,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public DefaultTraces Traces { get; set; }
 
         public int MaxFileSizeInKilobytes { get; set; }
+
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
 
         public void Dispose() { }
     }

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             context.RuntimeErrors |= RuntimeConditions.NoRulesLoaded;
         }
 
-        public static void LogNoValidAnalysisTargets(IAnalysisContext context)
+        public static void LogNoValidAnalysisTargets(IAnalysisContext context, bool addToRuntimeErrors)
         {
             if (context == null)
             {
@@ -168,7 +168,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                     persistExceptionStack: false,
                     messageFormat: null));
 
-            context.RuntimeErrors |= RuntimeConditions.NoValidAnalysisTargets;
+            if (addToRuntimeErrors)
+            {
+                context.RuntimeErrors |= RuntimeConditions.NoValidAnalysisTargets;
+            }
         }
 
         public static void LogExceptionCreatingLogFile(IAnalysisContext context, string fileName, Exception exception)

--- a/src/Sarif/IAnalysisContext.cs
+++ b/src/Sarif/IAnalysisContext.cs
@@ -33,6 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         int MaxFileSizeInKilobytes { get; set; }
 
-        IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
+        IEnumerable<RuntimeConditions> IgnoreNonFatalRuntimeConditions { get; set; }
     }
 }

--- a/src/Sarif/IAnalysisContext.cs
+++ b/src/Sarif/IAnalysisContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
@@ -31,5 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         DefaultTraces Traces { get; set; }
 
         int MaxFileSizeInKilobytes { get; set; }
+
+        IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
     }
 }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 analyzeOptions: options,
                 expectedExitReason: ExitReason.NoValidAnalysisTargets);
 
-            options.IgnoreNonFatalRuntimeConditions = 
+            options.IgnoreNonFatalRuntimeConditions =
                 new List<RuntimeConditions>() { RuntimeConditions.NoValidAnalysisTargets };
 
             ExceptionTestHelper(

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 analyzeOptions: options,
                 expectedExitReason: ExitReason.NoValidAnalysisTargets);
 
-            options.IgnoreNonFatalRunTimeConditions = 
+            options.IgnoreNonFatalRuntimeConditions = 
                 new List<RuntimeConditions>() { RuntimeConditions.NoValidAnalysisTargets };
 
             ExceptionTestHelper(

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -192,6 +192,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 RuntimeConditions.NoValidAnalysisTargets,
                 analyzeOptions: options,
                 expectedExitReason: ExitReason.NoValidAnalysisTargets);
+
+            options.IgnoreNonFatalRunTimeConditions = 
+                new List<RuntimeConditions>() { RuntimeConditions.NoValidAnalysisTargets };
+
+            ExceptionTestHelper(
+                RuntimeConditions.None,
+                analyzeOptions: options,
+                expectedExitReason: ExitReason.None);
         }
 
         [Fact]

--- a/src/Test.Utilities.Sarif/TestAnalysisContext.cs
+++ b/src/Test.Utilities.Sarif/TestAnalysisContext.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public int MaxFileSizeInKilobytes { get; set; }
 
-        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRuntimeConditions { get; set; }
 
         public void Dispose()
         {

--- a/src/Test.Utilities.Sarif/TestAnalysisContext.cs
+++ b/src/Test.Utilities.Sarif/TestAnalysisContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
 
@@ -36,6 +37,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         public bool Disposed { get; private set; }
 
         public int MaxFileSizeInKilobytes { get; set; }
+
+        public IEnumerable<RuntimeConditions> IgnoreNonFatalRunTimeConditions { get; set; }
 
         public void Dispose()
         {


### PR DESCRIPTION
## Problem description

Today, when we run Binskim in AzureDevOps, if the target folder is empty, it will generate a runtime error called `NoValidAnalysisTargets`.

With that, it will return exit code as `1`.
This means that it will 'break' the run since for Guardian, everything that isn't returning `0` is a failure.

## Proposal

Similar to what we have last time for `ExceptionLoadingPdb`: 
Log the issue in the SARIF and return code `0`.

This time we will use a more generic flag so that we don't need to add another flag if there is new similar request.
`--ignore-non-fatal-runtime-conditions NoValidAnalysisTargets;XXX`

## Current behavior

Log the issue in the SARIF and return code `1`.
