### PR TITLE
Allow per-instance file regions cache to be set on `InsertOptionalDataVisitor`

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## UNRELEASED
+* FEATURE: Allow initialization of file regions cache in `InsertOptionalDataVisitor` (previously initialized exclusively from `FileRegionsCache.Instance`).
+
 ## **v3.1.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.1.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.1.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.1.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.1.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.1.0)
 
 * BUGFIX: Loosen `System.Collections.Immutable` minimum version requirement to 1.5.0. [#2504](https://github.com/microsoft/sarif-sdk/pull/2533)

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             IDictionary<string, ArtifactLocation> originalUriBaseIds = null,
             IFileSystem fileSystem = null,
             GitHelper.ProcessRunner processRunner = null,
-            IEnumerable<string> insertProperties = null)
+            IEnumerable<string> insertProperties = null,
+            FileRegionsCache fileRegionsCache = null)
         {
             _fileSystem = fileSystem ?? FileSystem.Instance;
             _processRunner = processRunner;
@@ -53,6 +54,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             _dataToInsert = dataToInsert;
             _originalUriBaseIds = originalUriBaseIds;
             _insertProperties = insertProperties ?? new List<string>();
+
+            _fileRegionsCache = fileRegionsCache ?? FileRegionsCache.Instance;
         }
 
         public override Run VisitRun(Run node)
@@ -110,8 +113,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 Region expandedRegion;
                 ArtifactLocation artifactLocation = node.ArtifactLocation;
-
-                _fileRegionsCache ??= FileRegionsCache.Instance;
 
                 if (artifactLocation.Uri == null && artifactLocation.Index >= 0)
                 {


### PR DESCRIPTION
We included instance data for a file regions cache on every `InsertOptionalDataVisitor` instance but never implemented a mechanism to initialize it (with the result the visitor always utilized the `FileRegionsCache.Instance` singleton).

@cfaucon 