### PR TITLE
Update WorkItemsResources.resx

### DIFF
--- a/src/Sarif.WorkItems/WorkItemsResources.resx
+++ b/src/Sarif.WorkItems/WorkItemsResources.resx
@@ -143,6 +143,6 @@
     <value> (and other locations)</value>
   </data>
   <data name="WorkItemBodyTemplateText" xml:space="preserve">
-    <value>This work item contains {0} {1} issue(s) detected in {2}{3}. Click the 'Scans' tab to review results.If the 'Scans' tab is not present, please open the attached SARIF in one of the viewers below.</value>
+    <value>This work item contains {0} {1} issue(s) detected in {2}{3}. Click the 'Scans' tab to review results. If the 'Scans' tab is not present, please open the attached SARIF in one of the viewers below.</value>
   </data>
 </root>

--- a/src/Sarif.WorkItems/WorkItemsResources.resx
+++ b/src/Sarif.WorkItems/WorkItemsResources.resx
@@ -143,6 +143,6 @@
     <value> (and other locations)</value>
   </data>
   <data name="WorkItemBodyTemplateText" xml:space="preserve">
-    <value>This work item contains {0} {1} issue(s) detected in {2}{3}. Click the 'Scans' tab to review results.</value>
+    <value>This work item contains {0} {1} issue(s) detected in {2}{3}. Click the 'Scans' tab to review results.If the 'Scans' tab is not present, please open the attached SARIF in one of the viewers below.</value>
   </data>
 </root>


### PR DESCRIPTION
When users do not have a Scans tab available they are unclear how to discover more information. Directing them to view the Sarif file will allow them to discover more details