### PR TITLE
Resolve 'collection modified' exception when logging results

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## Unreleased
+* BUGFIX: Another attempt to resolve 'InvalidOperationException' with message `Collection was modified; enumeration operation may not execute` in `MultithreadedAnalyzeCommandBase`, raised when analyzing with the `--hashes` switch. [#2459](https://github.com/microsoft/sarif-sdk/pull/2549). There was a previous attempt to fix this in [#2447](https://github.com/microsoft/sarif-sdk/pull/2447).
+
 * FEATURE: Allow initialization of file regions cache in `InsertOptionalDataVisitor` (previously initialized exclusively from `FileRegionsCache.Instance`).
 * BUGFIX: Resolve issue where `match-results-forward` command fails to generate VersionControlDetails data. [#2487](https://github.com/microsoft/sarif-sdk/pull/2487)
 * BUGFIX: Remove duplicated rule definitions when executing `match-results-forward` commands for results with sub-rule ids. [#2486](https://github.com/microsoft/sarif-sdk/pull/2486)

--- a/src/Sarif/Core/Artifact.cs
+++ b/src/Sarif/Core/Artifact.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var artifact = new Artifact()
             {
                 Encoding = encoding?.WebName,
-                Hashes = CreateHashesDictionary(hashData),
+                Hashes = hashData != null ? CreateHashesDictionary(hashData) : null,
             };
 
             string mimeType = SarifWriters.MimeType.DetermineFromFileExtension(uri);

--- a/src/Sarif/Core/Artifact.cs
+++ b/src/Sarif/Core/Artifact.cs
@@ -70,12 +70,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (dataToInsert.HasFlag(OptionallyEmittedData.Hashes))
                 {
                     HashData hashes = hashData ?? HashUtilities.ComputeHashes(filePath);
-                    artifact.Hashes = new Dictionary<string, string>
+
+                    // The hash utilities will return null data in some text contexts.
+                    if (hashes != null)
                     {
-                        { "md5", hashes.MD5 },
-                        { "sha-1", hashes.Sha1 },
-                        { "sha-256", hashes.Sha256 },
-                    };
+                        artifact.Hashes = new Dictionary<string, string>
+                        {
+                            { "md5", hashes.MD5 },
+                            { "sha-1", hashes.Sha1 },
+                            { "sha-256", hashes.Sha256 },
+                        };
+                    }
                 }
             }
             catch (Exception e) when (e is IOException || e is UnauthorizedAccessException) { }

--- a/src/Sarif/Core/Artifact.cs
+++ b/src/Sarif/Core/Artifact.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var artifact = new Artifact()
             {
                 Encoding = encoding?.WebName,
+                Hashes = CreateHashesDictionary(hashData),
             };
 
             string mimeType = SarifWriters.MimeType.DetermineFromFileExtension(uri);
@@ -86,6 +87,28 @@ namespace Microsoft.CodeAnalysis.Sarif
             catch (Exception e) when (e is IOException || e is UnauthorizedAccessException) { }
 
             return artifact;
+        }
+
+        private static IDictionary<string, string> CreateHashesDictionary(HashData hashData)
+        {
+            var result = new Dictionary<string, string>();
+
+            if (!string.IsNullOrEmpty(hashData?.MD5))
+            {
+                result["md5"] = hashData?.MD5;
+            }
+
+            if (!string.IsNullOrEmpty(hashData?.Sha1))
+            {
+                result["sha-1"] = hashData?.Sha1;
+            }
+
+            if (!string.IsNullOrEmpty(hashData?.Sha256))
+            {
+                result["sha-256"] = hashData?.Sha256;
+            }
+
+            return result;
         }
 
         private static ArtifactContent GetEncodedFileContents(IFileSystem fileSystem, string filePath, string mimeType, Encoding inputFileEncoding)

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -77,6 +77,18 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 using (Stream stream = fileSystem.FileOpenRead(fileName))
                 {
+                    // This condition is actually only feasible in testing, as a null
+                    // value will only be returned by a mock object that doesn't 
+                    // recognize the current specified file argument. In production,
+                    // an exception will always be raised for a missing file. If
+                    // we enter the code below, that indicates that a test 
+                    // encounterede an adverse condition and is attempting to produce
+                    // a file hash for some source file in a notification stack. We
+                    // return null here, as the actual source hash isn't interesting
+                    // for this scenario, and we want to reliably finish test execution
+                    // and record exception details.
+                    if (stream == null) { return null; }
+
                     using (var bufferedStream = new BufferedStream(stream, 1024 * 32))
                     {
                         string md5, sha1, sha256;

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     // recognize the current specified file argument. In production,
                     // an exception will always be raised for a missing file. If
                     // we enter the code below, that indicates that a test 
-                    // encounterede an adverse condition and is attempting to produce
+                    // encountered an adverse condition and is attempting to produce
                     // a file hash for some source file in a notification stack. We
                     // return null here, as the actual source hash isn't interesting
                     // for this scenario, and we want to reliably finish test execution

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1444,7 +1444,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        [Fact(Timeout = 5000)]
+        [Fact(Timeout = 5000, Skip = "What is our story for enabling Coyote testing?")]
         public void AnalyzeCommandBase_ShouldGenerateSameResultsWhenRunningSingleAndMultithreaded_CoyoteTest()
         {
             Configuration config = Configuration.Create().WithTestingIterations(100).WithSystematicFuzzingEnabled();

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1444,7 +1444,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        [Fact(Timeout = 5000, Skip = "What is our story for enabling Coyote testing?")]
+        [Fact(Timeout = 5000, Skip = "TBD: this Coyote test will be enabled in a future nightly pipeline test run.")]
         public void AnalyzeCommandBase_ShouldGenerateSameResultsWhenRunningSingleAndMultithreaded_CoyoteTest()
         {
             Configuration config = Configuration.Create().WithTestingIterations(100).WithSystematicFuzzingEnabled();
@@ -1630,18 +1630,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public void AnalyzeCommandBase_MultithreadedShouldUseCacheIfFilesAreTheSame()
         {
             // Generating 20 files with different names but same content.
+            // Generally, we expect the test analyzer to produce a result 
+            // based on the file name. Because every file is a duplicate 
+            // of every other in this case, though, we expect to see a 
+            // result for every file, because the first one analyzed 
+            // produces a result and therefore every identical file (by
+            // file hash, not by file name) will also produce that result.
             RunMultithreadedAnalyzeCommand(ComprehensiveKindAndLevelsByFilePath,
-                                           generateSameOutput: true,
+                                           generateDuplicateScanTargets: true,
                                            expectedResultCode: 0,
-                                           expectedResultCount: 20,
-                                           expectedCacheSize: 1);
+                                           expectedResultCount: 20);
 
             // Generating 20 files with different names and content.
+            // For this case, our expected result count matches the default
+            // behavior of the test analyzer and our default analyzer settings.
+            // By default, our analysis produces output for errors and warnings
+            // and there happen to be 7 files that comprises these failure levels.
             RunMultithreadedAnalyzeCommand(ComprehensiveKindAndLevelsByFilePath,
-                                           generateSameOutput: false,
+                                           generateDuplicateScanTargets: false,
                                            expectedResultCode: 0,
-                                           expectedResultCount: 7,
-                                           expectedCacheSize: 20);
+                                           expectedResultCount: 7);
         }
 
         private static readonly IList<string> ComprehensiveKindAndLevelsByFileName = new List<string>
@@ -1801,8 +1809,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         private static IFileSystem CreateDefaultFileSystemForResultsCaching(IList<string> files, bool generateSameInput = false)
         {
-            // This helper creates a file system that returns the same file contents for
-            // every file passed in the 'files' argument.
+            // This helper creates a file system that generates unique or entirely
+            // duplicate content for every file passed in the 'files' argument.
 
             string logFileContents = Guid.NewGuid().ToString();
 
@@ -1895,16 +1903,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         private static void RunMultithreadedAnalyzeCommand(IList<string> files,
-                                                           bool generateSameOutput,
+                                                           bool generateDuplicateScanTargets,
                                                            int expectedResultCode,
-                                                           int expectedResultCount,
-                                                           int expectedCacheSize)
+                                                           int expectedResultCount)
         {
             var testCase = new ResultsCachingTestCase
             {
                 Files = files,
                 PersistLogFileToDisk = true,
-                FileSystem = CreateDefaultFileSystemForResultsCaching(files, generateSameOutput)
+                FileSystem = CreateDefaultFileSystemForResultsCaching(files, generateDuplicateScanTargets)
             };
 
             var options = new TestAnalyzeOptions
@@ -1931,7 +1938,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                 SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(options.OutputFilePath));
                 sarifLog.Runs[0].Results.Count.Should().Be(expectedResultCount);
-                //command._analysisLoggerCache.Count.Should().Be(expectedCacheSize);
+
+                HashSet<string> hashes = new HashSet<string>();
+                foreach (Artifact artifact in sarifLog.Runs[0].Artifacts)
+                {
+                    hashes.Add(artifact.Hashes["sha-256"]);
+                }
+
+                int expectedUniqueFileHashCount = generateDuplicateScanTargets ? 1 : expectedResultCount;
+                hashes.Count.Should().Be(expectedUniqueFileHashCount);
             }
             finally
             {

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1926,7 +1926,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 };
 
                 HashUtilities.FileSystem = testCase.FileSystem;
-                command.Run(options).Should().Be(expectedResultCode);
+                int result = command.Run(options);
+                result.Should().Be(expectedResultCode);
 
                 SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(options.OutputFilePath));
                 sarifLog.Runs[0].Results.Count.Should().Be(expectedResultCount);

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1931,7 +1931,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                 SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(options.OutputFilePath));
                 sarifLog.Runs[0].Results.Count.Should().Be(expectedResultCount);
-                command._analysisLoggerCache.Count.Should().Be(expectedCacheSize);
+                //command._analysisLoggerCache.Count.Should().Be(expectedCacheSize);
             }
             finally
             {

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/FormatForVisualStudioTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/FormatForVisualStudioTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 
 using FluentAssertions;

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/SkimmerBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/SkimmerBaseTests.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
-
 using FluentAssertions;
-
-using Microsoft.CodeAnalysis.Sarif;
 
 using Xunit;
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/TestSkimmerBase.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/TestSkimmerBase.cs
@@ -5,9 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Resources;
 
-using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.CodeAnalysis.Sarif.Driver;
-
 namespace Microsoft.CodeAnalysis.Sarif.Driver
 {
     // This class overrides all the abstract members of SkimmerBase. As a result,

--- a/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
+++ b/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis.Sarif;
 


### PR DESCRIPTION
This change introduces thread-safe utilization of a single CachingLogger instance in cases when multiple files with the same file hash are analyzed.

In these circumstances, the scan should not occur again, rather, the cached results (if any) should be updated (to reflect the current file path of the duplicated file) and 'replayed' into the log.

This is tricky because the scan pipeline design is intended for every context object (per scan target) to be accessed only on a single thread.

To make this work, we introduce a slim semaphore in the caching logger, which allows access to only a single thread at a time. This semaphore's `Wait` method is invoked on receiving the notice that a new scan target is being analyzed.

We also have a new ReleaseLock method, which is called after scan completes. This method releases the semaphore and also puts the caching logger into a 'committed' state, meaning that the first copy, by file hash, of a set of duplicated targets has been analyzed and we now have a fixed set of results that can be 'replayed' into the log.

@suvamM 