### PR TITLE
Add test helpers for BadGateway and retrieving default mock object by HTTP status code.

### DIFF
--- a/src/Test.Utilities.Sarif/HttpMockHelper.cs
+++ b/src/Test.Utilities.Sarif/HttpMockHelper.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         public static readonly HttpResponseMessage ForbiddenResponse =
             new HttpResponseMessage(HttpStatusCode.Forbidden);
 
+        public static readonly HttpResponseMessage BadGatewayResponse =
+            new HttpResponseMessage(HttpStatusCode.BadGateway);
+
         public static readonly HttpResponseMessage BadRequestResponse =
             new HttpResponseMessage(HttpStatusCode.BadRequest);
 
@@ -43,6 +46,23 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private readonly List<Tuple<HttpRequestMessage, string, HttpResponseMessage>> mockedResponses =
             new List<Tuple<HttpRequestMessage, string, HttpResponseMessage>>();
+
+        public static HttpResponseMessage GetResponseForStatusCode(HttpStatusCode statusCode)
+        {
+            switch (statusCode)
+            {
+                case HttpStatusCode.OK: { return OKResponse; }
+                case HttpStatusCode.NotFound: { return NotFoundResponse; }
+                case HttpStatusCode.Forbidden: { return ForbiddenResponse; }
+                case HttpStatusCode.BadGateway: { return BadRequestResponse; }
+                case HttpStatusCode.BadRequest: { return BadRequestResponse; }
+                case HttpStatusCode.Unauthorized: { return UnauthorizedResponse; }
+                case HttpStatusCode.InternalServerError: { return InternalServerErrorResponse; }
+                case HttpStatusCode.NonAuthoritativeInformation: { return NonAuthoritativeInformationResponse; }
+            }
+
+            throw new NotImplementedException();
+        }
 
         public void Mock(HttpRequestMessage httpRequestMessage, HttpStatusCode httpStatusCode, HttpContent responseContent)
         {


### PR DESCRIPTION
Implemented as part of ongoing testing of scanning tools that utilize driver framework.