### PR TITLE
Updating file paths to be relative instead of using $(SolutionDir)

### DIFF
--- a/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
+++ b/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
@@ -20,13 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="$(SolutionDir)\Test.Data\Multitool\ValidationRules\Inputs\*" />
+    <EmbeddedResource Include="..\Test.Data\Multitool\ValidationRules\Inputs\*" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(SolutionDir)\Sarif\Schemata\sarif-external-property-file-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(SolutionDir)\Test.FunctionalTests.Sarif\v2\**\*.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2" />
+    <None Include="..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Sarif\Schemata\sarif-external-property-file-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Test.FunctionalTests.Sarif\v2\**\*.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -25,7 +25,7 @@
 
   <Target Name="CopyFunctionalTestData" AfterTargets="Build">
     <ItemGroup>
-      <TestFiles Include="$(SolutionDir)FunctionalTestData\**\*" />
+      <TestFiles Include="..\FunctionalTestData\**\*" />
     </ItemGroup>
     <Copy SourceFiles="@(TestFiles)" DestinationFolder="$(OutputPath)\FunctionalTestData\%(RecursiveDir)" />
   </Target>

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -340,7 +340,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)\Test.FunctionalTests.Sarif\v2\SpecExamples\Comprehensive.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2\SpecExamples" />
-    <None Include="$(SolutionDir)\Test.FunctionalTests.Sarif\v2\ObsoleteFormats\ComprehensivePrereleaseTwoZeroZero.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2\ObsoleteFormats" />
+    <None Include="..\Test.FunctionalTests.Sarif\v2\SpecExamples\Comprehensive.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2\SpecExamples" />
+    <None Include="..\Test.FunctionalTests.Sarif\v2\ObsoleteFormats\ComprehensivePrereleaseTwoZeroZero.sarif" CopyToOutputDirectory="PreserveNewest" LinkBase="v2\ObsoleteFormats" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This change is updating file paths to be relative to the current project instead of using $(SolutionDir).

## Why do we need this change?

If you use the sarif.sdk project as submodule and you want to include some unit test projects, it won't compile because the $(SolutionDir) will be different from what it expects, generating an issue like:
```
error MSB3030: Could not copy the file "C:\Microsoft\sarif-pattern-matcher-legacy\src\Test.FunctionalTests.Sarif\v2\SpecExamples\Comprehensive.sarif" because it was not f
ound. [C:\Microsoft\sarif-pattern-matcher-legacy\src\sarif-pattern-matcher\Src\sarif-sdk\src\Test.UnitTests.Sarif\Test.UnitTests.Sarif.csproj::TargetFramework=netcoreapp3.1]
```
