### PR TITLE
SARIF SDK - Fix Ubuntu test pipeline

### DIFF
--- a/ado-build.yml
+++ b/ado-build.yml
@@ -6,7 +6,7 @@ jobs:
   strategy:
     matrix:
       linux:
-        imageName: 'ubuntu-latest'
+        imageName: 'ubuntu-20.04'
       mac:
         imageName: 'macOS-latest'
       windows:


### PR DESCRIPTION
New change from GitHub image, the latest now `22.04`, was `20.04`.
`22.04` image only have .NET 6 installed.
Change back to use `20.04`.
https://github.com/actions/runner-images/issues/6399