### PR TITLE
Provide mechanism for sharing file regions cache with SarifLogger instance.

### DIFF
--- a/ado-build.yml
+++ b/ado-build.yml
@@ -22,7 +22,6 @@ jobs:
   inputs:
     packageType: sdk
     version: 3.1.*
-    installationPath: $(Agent.ToolsDirectory)/dotnet
 
   # Build and test
   - task: PowerShell@2

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -6,7 +6,7 @@ jobs:
   strategy:
     matrix:
       linux:
-        imageName: 'ubuntu-latest'
+        imageName: 'ubuntu-22.04'
       mac:
         imageName: 'macOS-latest'
       windows:
@@ -17,12 +17,6 @@ jobs:
     vmImage: $(imageName)
 
   steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: sdk
-    version: 3.1.*
-
   # Build and test
   - task: PowerShell@2
     displayName: Build and Test

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -17,6 +17,12 @@ jobs:
     vmImage: $(imageName)
 
   steps:
+  - task: PowerShell@2
+    displayName: Build and Test
+    inputs:
+      targetType: filePath
+      filePath: ./scripts/BuildAndTest.ps1
+
   # Build and test
   - task: PowerShell@2
     displayName: Build and Test

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -17,11 +17,12 @@ jobs:
     vmImage: $(imageName)
 
   steps:
-  - task: PowerShell@2
-    displayName: Build and Test
-    inputs:
-      targetType: filePath
-      filePath: ./scripts/BuildAndTest.ps1
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 3.1.*
+    installationPath: $(Agent.ToolsDirectory)/dotnet
 
   # Build and test
   - task: PowerShell@2

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,8 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## Unreleased
+## **v3.1.0** (UNRELEASED)
+* FEATURE: Provide mechanism to populate `SarifLogger` with a `FileRegionsCache` instance.
 * BUGFIX: Another attempt to resolve 'InvalidOperationException' with message `Collection was modified; enumeration operation may not execute` in `MultithreadedAnalyzeCommandBase`, raised when analyzing with the `--hashes` switch. [#2459](https://github.com/microsoft/sarif-sdk/pull/2549). There was a previous attempt to fix this in [#2447](https://github.com/microsoft/sarif-sdk/pull/2447).
-
 * FEATURE: Allow initialization of file regions cache in `InsertOptionalDataVisitor` (previously initialized exclusively from `FileRegionsCache.Instance`).
 * BUGFIX: Resolve issue where `match-results-forward` command fails to generate VersionControlDetails data. [#2487](https://github.com/microsoft/sarif-sdk/pull/2487)
 * BUGFIX: Remove duplicated rule definitions when executing `match-results-forward` commands for results with sub-rule ids. [#2486](https://github.com/microsoft/sarif-sdk/pull/2486)

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return region;
         }
 
-        public Region ConstructMultilineContextSnippet(Region inputRegion, Uri uri)
+        public Region ConstructMultilineContextSnippet(Region inputRegion, Uri uri, string fileText = null)
         {
             if (inputRegion?.IsBinaryRegion != false)
             {
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return null;
             }
 
-            NewLineIndex newLineIndex = GetNewLineIndex(uri, fileText: null);
+            NewLineIndex newLineIndex = GetNewLineIndex(uri, fileText);
             if (newLineIndex == null)
             {
                 return null;

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private GitHelper _gitHelper;
 
         private int _ruleIndex;
-        private FileRegionsCache _fileRegionsCache;
+        private readonly FileRegionsCache _fileRegionsCache;
         private readonly OptionallyEmittedData _dataToInsert;
         private readonly IDictionary<string, ArtifactLocation> _originalUriBaseIds;
         private readonly IEnumerable<string> _insertProperties;
@@ -32,8 +32,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private const string Email = nameof(Email);
         private const string CommitSha = nameof(CommitSha);
 
-        public InsertOptionalDataVisitor(OptionallyEmittedData dataToInsert, Run run, IEnumerable<string> insertProperties)
-            : this(dataToInsert, run?.OriginalUriBaseIds, insertProperties: insertProperties)
+        public InsertOptionalDataVisitor(OptionallyEmittedData dataToInsert,
+                                         Run run, 
+                                         IEnumerable<string> insertProperties, 
+                                         FileRegionsCache fileRegionsCache = null)
+            : this(dataToInsert,
+                   originalUriBaseIds: run?.OriginalUriBaseIds, 
+                   insertProperties: insertProperties, 
+                   fileRegionsCache: fileRegionsCache)
         {
             _run = run ?? throw new ArgumentNullException(nameof(run));
         }

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -33,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private const string CommitSha = nameof(CommitSha);
 
         public InsertOptionalDataVisitor(OptionallyEmittedData dataToInsert,
-                                         Run run, 
-                                         IEnumerable<string> insertProperties, 
+                                         Run run,
+                                         IEnumerable<string> insertProperties,
                                          FileRegionsCache fileRegionsCache = null)
             : this(dataToInsert,
-                   originalUriBaseIds: run?.OriginalUriBaseIds, 
-                   insertProperties: insertProperties, 
+                   originalUriBaseIds: run?.OriginalUriBaseIds,
+                   insertProperties: insertProperties,
                    fileRegionsCache: fileRegionsCache)
         {
             _run = run ?? throw new ArgumentNullException(nameof(run));

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         protected BaseLogger(IEnumerable<FailureLevel> failureLevels,
             IEnumerable<ResultKind> resultKinds)
         {
-            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>();
-            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
+            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning }); ;
+            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>(new[] {  ResultKind.Fail });
 
             ValidateParameters();
         }

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -15,14 +15,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         protected BaseLogger(IEnumerable<FailureLevel> failureLevels,
             IEnumerable<ResultKind> resultKinds)
         {
-            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>(); ;
-            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
-
-            if (_failureLevels.Count == 0 && _resultKinds.Count == 0)
+            if (failureLevels == null && resultKinds == null)
             {
                 _failureLevels = new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning }); ;
                 _resultKinds = new List<ResultKind>(new[] { ResultKind.Fail });
             }
+            else
+            {
+                _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>(); ;
+                _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
+            }
+
 
             ValidateParameters();
         }

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (failureLevels == null && resultKinds == null)
             {
-                _failureLevels = new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning }); ;
+                _failureLevels = new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning });
                 _resultKinds = new List<ResultKind>(new[] { ResultKind.Fail });
             }
             else

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -15,8 +15,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         protected BaseLogger(IEnumerable<FailureLevel> failureLevels,
             IEnumerable<ResultKind> resultKinds)
         {
-            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning }); ;
-            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>(new[] {  ResultKind.Fail });
+            _failureLevels = failureLevels?.ToList() ?? new List<FailureLevel>(); ;
+            _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
+
+            if (_failureLevels.Count == 0 && _resultKinds.Count == 0)
+            {
+                _failureLevels = new List<FailureLevel>(new[] { FailureLevel.Error, FailureLevel.Warning }); ;
+                _resultKinds = new List<ResultKind>(new[] { ResultKind.Fail });
+            }
 
             ValidateParameters();
         }

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 _resultKinds = resultKinds?.ToList() ?? new List<ResultKind>();
             }
 
-
             ValidateParameters();
         }
 

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 {
                     RuleToIndexMap[_run.Tool.Driver.Rules[i]] = i;
                 }
-            }            
+            }
         }
 
         private void EnhanceRun(IEnumerable<string> analysisTargets,

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -883,6 +883,61 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         [Fact]
+        public void SarifLogger_ConsumesFileRegionsCache()
+        {
+            var uri = new Uri("file:///test.txt");
+
+            var rule = new ReportingDescriptor
+            {
+                Id = "RuleId"
+            };
+
+            var result = new Result
+            {
+                RuleId = "RuleId",
+                Message = new Message { Text = "A test message." },
+                Locations = new[]
+                {
+                    new Location(){
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            Region = new Region{ StartLine = 2 },
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = uri
+                            }
+                        }
+                    }
+                }
+            };
+
+            var fileRegionsCache = new FileRegionsCache();
+            var region = new Region() { StartLine = 1 };
+            string fileText = $"{Environment.NewLine}Sample file text";
+
+            // This call forces text of file into the fileRegionsCache instance.
+            // If we can successfully populate region data afterwards, this is 
+            // solid proof we are consulting this cache instance.            
+            region.EndLine.Should().Be(0);
+            region = fileRegionsCache.PopulateTextRegionProperties(region, uri, populateSnippet: true, fileText);
+            region.EndLine.Should().Be(1);
+
+            var sb = new StringBuilder();
+            using var writer = new StringWriter(sb);
+
+            OptionallyEmittedData dataToInsert = OptionallyEmittedData.ComprehensiveRegionProperties | OptionallyEmittedData.ContextRegionSnippets;
+            var sarifLogger = new SarifLogger(writer, fileRegionsCache: fileRegionsCache, dataToInsert: dataToInsert);
+            sarifLogger.Log(rule, result);
+
+            region = new Region() { StartLine = 2 };
+            Region expectedRegion = fileRegionsCache.PopulateTextRegionProperties(region, uri, populateSnippet: true, fileText);
+
+            result.Locations[0].PhysicalLocation.Region.CharLength.Should().Be(expectedRegion.CharLength);
+            result.Locations[0].PhysicalLocation.ContextRegion.Should().NotBeNull();
+        }
+
+
+        [Fact]
         public void SarifLogger_ResultAndRuleIdMismatch()
         {
             var sb = new StringBuilder();
@@ -948,6 +1003,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 };
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, e.ToString());
             }
             finally
             {


### PR DESCRIPTION
There is currently no mechanism for an upstream caller to initialize a `SarifLogger` instance with a specific file regions cache.

This limits `SarifLogger` utilization for more unusual API scenarios.

@eddynaka 