### PR TITLE
Expose internal data for unit-testing.

### DIFF
--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public static readonly FileRegionsCache Instance = new FileRegionsCache();
         public const int DefaultCacheCapacity = 100;
         private readonly IFileSystem _fileSystem;
-        private readonly Cache<string, Tuple<string, NewLineIndex>> _cache;
+        internal readonly Cache<string, Tuple<string, NewLineIndex>> _cache;
 
         /// <summary>
         /// Creates a new <see cref="FileRegionsCache"/> object.


### PR DESCRIPTION
@cfaucon, just to facilitate ongoing testing in a tricky area.