### PR TITLE
Update MSBuild Converter regex to support more MSBuild log variants

### DIFF
--- a/src/Sarif.Converters/MSBuildConverter.cs
+++ b/src/Sarif.Converters/MSBuildConverter.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         private const string ErrorLinePattern = @"
+            (?i)                               # Case insensitive
             ^
             \s*
             (                                  # EITHER
@@ -83,9 +84,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             \s*:\s*
             (?<qualifiedLevel>
               (?<levelQualification>.*)        # For example, 'fatal'.
-              (?<level>error|warning|note|info|pass|review|open|notapplicable)
+              (?<level>error|err|warning|wrn|note|info|pass|review|open|notapplicable)
             )
-            \s+
+            \s*:?\s*
             (?<ruleId>[^\s:]+)
             \s*:\s*
             (?<message>.*)

--- a/src/Test.UnitTests.Sarif.Converters/MSBuildConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/MSBuildConverterTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Writers;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Converters
+{
+    public class MSBuildConverterTests : ConverterTestsBase<MSBuildConverter>
+    {
+        [Fact]
+        public void Converter_RequiresInputStream()
+        {
+            var converter = new MSBuildConverter();
+            Action action = () => converter.Convert(input: null, output: new ResultLogObjectWriter(), dataToInsert: OptionallyEmittedData.None);
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Converter_RequiresResultLogWriter()
+        {
+            var converter = new MSBuildConverter();
+            Action action = () => converter.Convert(input: new MemoryStream(), output: null, dataToInsert: OptionallyEmittedData.None);
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Converter_WhenInputIsEmpty_ReturnsNoResults()
+        {
+            string input = s_extractor.GetResourceInputText("Empty.ERR");
+            string expectedOutput = s_extractor.GetResourceExpectedOutputsText("NoResults.sarif");
+            RunTestCase(input, expectedOutput);
+        }
+
+        [Fact]
+        public void Converter_WhenResultRowIsInvalid_ReturnsNoResults()
+        {
+            string input = s_extractor.GetResourceInputText("InvalidResult.ERR");
+            string expectedOutput = s_extractor.GetResourceExpectedOutputsText("NoResults.sarif");
+            RunTestCase(input, expectedOutput);
+        }
+
+        [Fact]
+        public void Converter_WhenInputContainsValidResults_ReturnsExpectedOutput()
+        {
+            string input = s_extractor.GetResourceInputText("ValidResults.ERR");
+            string expectedOutput = s_extractor.GetResourceExpectedOutputsText("ValidResults.sarif");
+            RunTestCase(input, expectedOutput);
+        }
+
+        private static readonly TestAssetResourceExtractor s_extractor = new TestAssetResourceExtractor(typeof(MSBuildConverterTests));
+    }
+}

--- a/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
+++ b/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
@@ -46,6 +46,11 @@
     <None Remove="TestData\HdfConverter\Inputs\Empty.json" />
     <None Remove="TestData\HdfConverter\Inputs\InvalidResult.json" />
     <None Remove="TestData\HdfConverter\Inputs\ValidResults.json" />
+    <None Remove="TestData\MSBuildConverter\ExpectedOutputs\NoResults.sarif" />
+    <None Remove="TestData\MSBuildConverter\ExpectedOutputs\ValidResults.sarif" />
+    <None Remove="TestData\MSBuildConverter\Inputs\Empty.ERR" />
+    <None Remove="TestData\MSBuildConverter\Inputs\InvalidResult.ERR" />
+    <None Remove="TestData\MSBuildConverter\Inputs\ValidResults.ERR" />
   </ItemGroup>
 
   <ItemGroup>
@@ -69,6 +74,11 @@
     <EmbeddedResource Include="TestData\HdfConverter\Inputs\Empty.json" />
     <EmbeddedResource Include="TestData\HdfConverter\Inputs\InvalidResult.json" />
     <EmbeddedResource Include="TestData\HdfConverter\Inputs\ValidResults.json" />
+    <EmbeddedResource Include="TestData\MSBuildConverter\ExpectedOutputs\NoResults.sarif" />
+    <EmbeddedResource Include="TestData\MSBuildConverter\ExpectedOutputs\ValidResults.sarif" />
+    <EmbeddedResource Include="TestData\MSBuildConverter\Inputs\Empty.ERR" />
+    <EmbeddedResource Include="TestData\MSBuildConverter\Inputs\InvalidResult.ERR" />
+    <EmbeddedResource Include="TestData\MSBuildConverter\Inputs\ValidResults.ERR" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/ExpectedOutputs/NoResults.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/ExpectedOutputs/NoResults.sarif
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [],
+      "tool": {
+        "driver": {
+          "name": "MSBuild"
+        }
+      },
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/ExpectedOutputs/ValidResults.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/ExpectedOutputs/ValidResults.sarif
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [
+        {
+          "ruleId": "MSB1003",
+          "level": "error",
+          "message": {
+            "text": "Specify a project or solution file. The current working directory does not contain a project or solution file."
+          }
+        },
+        {
+          "ruleId": "PV1002",
+          "message": {
+            "text": "Package sense1ds[1.1000.1] is missing the content manifest. For more information, see https://osgwiki.com/wiki/PackageValidator#PV1002"
+          }
+        },
+        {
+          "ruleId": "PV1000",
+          "message": {
+            "text": "Package diagtrackservice.vb_release.x86[0.0.0] is missing provenance data. For more information, see https://osgwiki.com/wiki/PackageValidator#PV1000"
+          }
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "MSBuild"
+        }
+      },
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/Inputs/InvalidResult.ERR
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/Inputs/InvalidResult.ERR
@@ -1,0 +1,9 @@
+----- Catalog construction errors -----
+Error #1
+Microsoft.VisualStudio.Composition.PartDiscoveryException: ReflectionTypeLoadException while enumerating types in assembly "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\EXTENSIONS\MICROSOFT\GRAPHICS\DEBUGGER\VsGraphicsDebuggerPkg.dll". Results will be incomplete. ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
+   at System.Reflection.RuntimeModule.GetTypes()
+   at System.Reflection.Assembly.GetTypes()
+   at Microsoft.VisualStudio.Composition.PartDiscovery.CombinedPartDiscovery.GetTypes(Assembly assembly)
+   at Microsoft.VisualStudio.Composition.PartDiscovery.<>c__DisplayClass32_0.<CreateAssemblyDiscoveryBlockChain>b__0(Assembly a)
+   --- End of inner exception stack trace ---

--- a/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/Inputs/ValidResults.ERR
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/MSBuildConverter/Inputs/ValidResults.ERR
@@ -1,0 +1,10 @@
+----- non msbuild error -----
+System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.UniversalApps.Deployment, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
+File name: 'Microsoft.UniversalApps.Deployment, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
+
+----- VS msbuild error -----
+msbuild : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.
+
+----- Package Validator build error -----
+%object_root%\amcore\wcd\source\communicator\sense1ds\dll\$(o)\vpack : ERROR: PV1002: Package sense1ds[1.1000.1] is missing the content manifest. For more information, see https://osgwiki.com/wiki/PackageValidator#PV1002
+%object_root%\onecore\base\telemetry\utc\tests\functionaltests\vpacks\diagtrackservice.vb_release\$(o)\vpack : ERROR: PV1000: Package diagtrackservice.vb_release.x86[0.0.0] is missing provenance data. For more information, see https://osgwiki.com/wiki/PackageValidator#PV1000


### PR DESCRIPTION
# Description

The information regarding MSBuild log format https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022
```
{Origin} : {Subcategory (optional)} {Category} {Code} : {Text}
```

- Update regex to accept case insensitive error level keywords.
- Support the format of PackageValidator log: a colon between {Category} and {Code}.
- Add test cases.