### PR TITLE
Releasing v3.2.0

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## **v3.2.0** (UNRELEASED)
+## **v3.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.2.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.2.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.2.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.2.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.2.0)
 * BRK: `SarifLogger` no longer allows providing a `Tool` instance. Use the `run` parameter instead (and populate it with any custom `Tool` object). [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
 * BRK: `SarifLogger` updates version details differently. [#2611](https://github.com/microsoft/sarif-sdk/pull/2611)
 * BRK: Add `ToolComponent` argument to `IAnalysisLogger.Log(ReportingDescriptor, Result)` method. [#2611](https://github.com/microsoft/sarif-sdk/pull/2611)

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>3.1.0</VersionPrefix>
-    <PreviousVersionPrefix>3.1.0-beta1</PreviousVersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
+    <PreviousVersionPrefix>3.1.0</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
# SARIF Package Release History (SDK, Driver, Converters, and Multitool)

## **v3.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/3.2.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/3.2.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/3.2.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/3.2.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/3.2.0)
* BRK: `SarifLogger` no longer allows providing a `Tool` instance. Use the `run` parameter instead (and populate it with any custom `Tool` object). [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
* BRK: `SarifLogger` updates version details differently. [#2611](https://github.com/microsoft/sarif-sdk/pull/2611)
* BRK: Add `ToolComponent` argument to `IAnalysisLogger.Log(ReportingDescriptor, Result)` method. [#2611](https://github.com/microsoft/sarif-sdk/pull/2611)
* BRK: Rename `--normalize-for-github` argument to `--normalize-for-ghas` for `convert` command and mark `--normalize-for-github` as obsolete. [#2581](https://github.com/microsoft/sarif-sdk/pull/2581)
* BRK: Update `IAnalysisContext.LogToolNotification` method to add `ReportingDescriptor` parameter. This is required in order to populated `AssociatedRule` data in `Notification` instances. The new method has an option value of null for the `associatedRule` parameter to maximize build compatibility. [#2604](https://github.com/microsoft/sarif-sdk/pull/2604)
* BRK: Correct casing of `LogMissingreportingConfiguration` helper to `LogMissingReportingConfiguration`. [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* BRK: Change type of `MaxFileSizeInKilobytes` from int to long in `IAnalysisContext` and other classes.  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* BRK: For `Guid` properties defined in SARIF spec, updated Json schema to use `uuid`, and updated C# object model to use `Guid?` instead of `string`. [#2555](https://github.com/microsoft/sarif-sdk/pull/2555)
* BRK: Mark `AnalyzeCommandBase` as obsolete. This type will be removed in the next significant update.  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* BRK: `LogUnhandledEngineException` no longer has a return value (and updates the `RuntimeErrors` context property directly as other helpers do).  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* BUG: Populate missing context region data for small, single-line scan targets. [#2616](https://github.com/microsoft/sarif-sdk/pull/2616)
* BUG: Increase parallelism in `MultithreadedAnalyzeCommandBase` by correcting task creation. []#2618](https://github.com/microsoft/sarif-sdk/pull/2618)
* BUG: Resolve hangs due to unhandled exceptions during multithreaded analysis file enumeration phase.  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* BUG: Resolve hangs due to unhandled exceptions during multithreaded analysis file hashing phase.  [#2600](https://github.com/microsoft/sarif-sdk/pull/2600)
* BUG: Another attempt to resolve 'InvalidOperationException' with message `Collection was modified; enumeration operation may not execute` in `MultithreadedAnalyzeCommandBase`, raised when analyzing with the `--hashes` switch. [#2459](https://github.com/microsoft/sarif-sdk/pull/2549). There was a previous attempt to fix this in [#2447](https://github.com/microsoft/sarif-sdk/pull/2447).
* BUG: Resolve issue where `match-results-forward` command fails to generate VersionControlDetails data. [#2487](https://github.com/microsoft/sarif-sdk/pull/2487)
* BUG: Remove duplicated rule definitions when executing `match-results-forward` commands for results with sub-rule ids. [#2486](https://github.com/microsoft/sarif-sdk/pull/2486)
* BUG: Update `merge` command to properly produce runs by tool and version when passed the `--merge-runs` argument. [#2488](https://github.com/microsoft/sarif-sdk/pull/2488)
* BUG: Eliminate `IOException` and `DirectoryNotFoundException` exceptions thrown by `merge` command when splitting by rule (due to invalid file characters in rule ids). [#2513](https://github.com/microsoft/sarif-sdk/pull/2513)
* BUG: Fix classes inside NotYetAutoGenerated folder missing `virtual` keyword for public methods and properties, by regenerate and manually sync the changes. [#2537](https://github.com/microsoft/sarif-sdk/pull/2537)
* BUG: MSBuild Converter now accepts case insensitive keywords and supports PackageValidator msbuild log output. [#2579](https://github.com/microsoft/sarif-sdk/pull/2579)
* BUG: Eliminate `NullReferenceException` when file hashing fails (due to file locked or other errors reading the file). [#2596](https://github.com/microsoft/sarif-sdk/pull/2596)
* NEW: Provide `PluginDriver` property (`AdditionalOptionsProvider`) that allows additional options to be exported (typically for command-line arguments).  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* NEW: Provide `LogFileSkippedDueToSize` that fires a warning notification if any file is skipped due to exceeding size threshold. [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* NEW: Provide overridable `ShouldEnqueue` predicate method to filter files from driver processing.  [#2599](https://github.com/microsoft/sarif-sdk/pull/2599)
* NEW: Provide overridable `ShouldComputeHashes` predicate method to prevent files from hashing.  [#2601](https://github.com/microsoft/sarif-sdk/pull/2601)
* NEW: Allow external set of `MaxFileSizeInKilobytes`, which will allow SDK users to change the value. (Default value is 1024) [#2578](https://github.com/microsoft/sarif-sdk/pull/2578)
* NEW: Add a Github validation rule `GH1007`, which requires flattened result message so GHAS code scanning can ingest the log. [#2580](https://github.com/microsoft/sarif-sdk/issues/2580)
* NEW: Provide mechanism to populate `SarifLogger` with a `FileRegionsCache` instance.
* NEW: Allow initialization of file regions cache in `InsertOptionalDataVisitor` (previously initialized exclusively from `FileRegionsCache.Instance`).
* NEW: Provide 'RuleScanTime` trace and emitted timing data. Provide `ScanExecution` trace with no utilization.
* NEW: Populate associated rule data in `LogToolNotification` as called from `SarifLogger`. [#2604](https://github.com/microsoft/sarif-sdk/pull/2604)
* NEW: Add `--normalize-for-ghas` argument to the `rewrite` command to ensure rewritten SARIF is compatible with GitHub Advanced Security (GHAS) ingestion requirements. [#2581](https://github.com/microsoft/sarif-sdk/pull/2581)
* NEW: Allow per-line rolling (partial) hash computation for a file. [#2605](https://github.com/microsoft/sarif-sdk/pull/2605)
* NEW: `SarifLogger` now supports extensions rules data when logging (by providing a `ToolComponent` instance to the result logging method). [#2661](https://github.com/microsoft/sarif-sdk/pull/2611)
* NEW: `SarifLogger` provides a `ComputeHashData` callback to provide hash data for in-memory scan targets. [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
* NEW: Provide	`HashUtilities.ComputeHashes(Stream)` and `ComputeHashesForText(string) helpers. [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
