### PR TITLE
Update pipeline for multithreaded analysis.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.1.0** UNRELEASED
 * BRK: `MultithreadedAnalyzeCommandBase` IDispose implementation now manages logging dispose. Be sure to call `base.Dispose()` in any derived type implementations. [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
+* BRK: Eliminate `MulthreadedAnalyzeCommandBase.EngineException` and `IAnalysisContext.RuntimeException` properties in favor of `IAnalysisContext.RuntimeExceptions`. [#2627](https://github.com/microsoft/sarif-sdk/pull/2627)
 * BRK: Rename `LogFilePersistenceOptions` to `FilePersistenceOptions` (due to its general applicability in other file persistence contexts other than output logs).[#2625](https://github.com/microsoft/sarif-sdk/pull/2625)
 * BRK: Many breaking changes in `IAnalysisContext` and `AnalyzeContextBase`. [#2625](https://github.com/microsoft/sarif-sdk/pull/2625)
 * BUG: Eliminate per-context allocations contributing to unnecessary memory use. [#2625](https://github.com/microsoft/sarif-sdk/pull/2625)

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 {
                     Notes.LogFileSkippedDueToSize(context, artifact.Uri.GetFilePath(), (long)artifact.SizeInBytes);
                 }
-                
+
                 //TBD resolve type mismatch
                 _ignoredFilesCount += (uint)context.TargetsProvider.Skipped.Count;
             }
@@ -603,7 +603,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 }
             }
         }
-         
+
         protected virtual void ValidateOptions(TOptions options, TContext context)
         {
             bool succeeded = true;

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -13,8 +13,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-using CommandLine;
-
 using Microsoft.CodeAnalysis.Sarif.Writers;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver
@@ -133,10 +131,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 return;
             }
 
-            if (ex is TaskCanceledException tce)
+            if (ex is OperationCanceledException oce)
             {
-                Errors.LogAnalysisCanceled(globalContext, tce);
-                globalContext.RuntimeExceptions.Add(new ExitApplicationException<ExitReason>(SdkResources.ERR999_AnalysisCanceled, tce)
+                Errors.LogAnalysisCanceled(globalContext, oce);
+                globalContext.RuntimeExceptions.Add(new ExitApplicationException<ExitReason>(SdkResources.ERR999_AnalysisCanceled, oce)
                 {
                     ExitReason = ExitReason.AnalysisCanceled
                 });

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -219,13 +219,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        protected virtual void PostLogFile(IAnalysisContext context)
+        protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
+            if (globalContext.PostUri == null) { return; }
+
             try
             {
                 using (var httpClient = new HttpClient())
                 {
-                    PostLogFile(context.PostUri, context.OutputFilePath, context.FileSystem, httpClient)
+                    PostLogFile(globalContext.PostUri, globalContext.OutputFilePath, globalContext.FileSystem, httpClient)
                         .GetAwaiter()
                         .GetResult();
                 }
@@ -233,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             catch (Exception ex)
             {
                 Console.WriteLine(ex.ToString());
-                context.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
+                globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
                 throw new ExitApplicationException<ExitReason>(DriverResources.MSG_UnexpectedApplicationExit, ex)
                 {
                     ExitReason = ExitReason.ExceptionPostingLogFile

--- a/src/Sarif.Multitool.Library/SarifValidationContext.cs
+++ b/src/Sarif.Multitool.Library/SarifValidationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Newtonsoft.Json.Linq;
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         public override RuntimeConditions RuntimeErrors { get; set; }
 
-        public override Exception RuntimeException { get; set; }
+        public override IList<Exception> RuntimeExceptions { get; set; }
 
         public bool UpdateInputsToCurrentSarif { get; set; }
 

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public virtual IEnumeratedArtifact CurrentTarget { get; set; }
         public virtual string MimeType { get; set; }
         public virtual HashData Hashes { get; set; }
-        public virtual Exception RuntimeException { get; set; }
+        public virtual IList<Exception> RuntimeExceptions { get; set; }
         public virtual bool IsValidAnalysisTarget { get; set; }
         public virtual ReportingDescriptor Rule { get; set; }
         public PropertiesDictionary Policy { get; set; }

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         // Parse errors:
         private const string ERR1000_ParseError = "ERR1000.ParseError";
 
-        public static void LogExceptionLoadingTarget(IAnalysisContext context)
+        public static void LogExceptionLoadingTarget(IAnalysisContext context, Exception exception)
         {
             if (context == null)
             {
@@ -52,8 +52,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             context.RuntimeErrors |= RuntimeConditions.ExceptionLoadingTargetFile;
 
-            // TBD: pass exception as an explicit arg?
-            Exception exception = context.RuntimeExceptions[0];
             string message = exception.Message;
             string exceptionType = exception.GetType().Name;
 

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -52,8 +52,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             context.RuntimeErrors |= RuntimeConditions.ExceptionLoadingTargetFile;
 
-            string message = context.RuntimeException.Message;
-            string exceptionType = context.RuntimeException.GetType().Name;
+            // TBD: pass exception as an explicit arg?
+            Exception exception = context.RuntimeExceptions[0];
+            string message = exception.Message;
+            string exceptionType = exception.GetType().Name;
 
             // Could not load analysis target '{0}' ({1} : '{2}').
             context.Logger.LogConfigurationNotification(
@@ -62,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     ERR997_ExceptionLoadingAnalysisTarget,
                     ruleId: null,
                     FailureLevel.Error,
-                    context.RuntimeException,
+                    exception,
                     persistExceptionStack: true,
                     messageFormat: null,
                     context.CurrentTarget.Uri.GetFileName(),
@@ -646,7 +648,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                             .GetValue(obj: null, index: null);
         }
 
-        internal static void LogAnalysisCanceled<TContext>(TContext context) where TContext : IAnalysisContext, new()
+        internal static void LogAnalysisCanceled<TContext>(TContext context, OperationCanceledException ex) where TContext : IAnalysisContext, new()
         {
             if (context.RuntimeErrors.HasFlag(RuntimeConditions.AnalysisCanceled))
             {
@@ -665,7 +667,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                             ERR999_AnalysisCanceled,
                             ruleId: null,
                             FailureLevel.Error,
-                            exception: null,
+                            exception: ex,
                             persistExceptionStack: false,
                             messageFormat: null));
 

--- a/src/Sarif/IAnalysisContext.cs
+++ b/src/Sarif/IAnalysisContext.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         HashData Hashes { get; set; }
 
-        Exception RuntimeException { get; set; }
+        IList<Exception> RuntimeExceptions { get; set; }
 
         bool IsValidAnalysisTarget { get; }
 

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 var context = new SarifValidationContext { FileSystem = mockFileSystem.Object };
                 int returnCode = validateCommand.Run(validateOptions, ref context);
-                context.RuntimeException.Should().BeNull();
+                context.RuntimeExceptions.Should().BeNull();
                 (context.RuntimeErrors & ~RuntimeConditions.Nonfatal).Should().Be(0);
                 returnCode.Should().Be(0);
             }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -755,7 +755,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public void AnalyzeCommandBase_EndToEndAnalysisWithPostUri()
         {
             PostUriTestHelper(@"https://example.com", TestMultithreadedAnalyzeCommand.SUCCESS, RuntimeConditions.None);
-            PostUriTestHelper(@"https://httpbin.org/post", TestMultithreadedAnalyzeCommand.SUCCESS, RuntimeConditions.None);
             PostUriTestHelper(@"https://httpbin.org/get", TestMultithreadedAnalyzeCommand.FAILURE, RuntimeConditions.ExceptionPostingLogFile);
             PostUriTestHelper(@"https://host.does.not.exist", TestMultithreadedAnalyzeCommand.FAILURE, RuntimeConditions.ExceptionPostingLogFile);
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -101,18 +101,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (expectedExitReason != ExitReason.None)
             {
-                command.ExecutionException.Should().NotBeNull();
+                context.RuntimeExceptions.Should().NotBeEmpty();
 
                 if (expectedExitReason != ExitReason.UnhandledExceptionInEngine)
                 {
-                    var eax = command.ExecutionException as ExitApplicationException<ExitReason>;
+                    var eax = context.RuntimeExceptions[0] as ExitApplicationException<ExitReason>;
                     eax.Should().NotBeNull();
                     eax.ExitReason.Should().Be(expectedExitReason);
                 }
             }
             else
             {
-                command.ExecutionException.Should().BeNull();
+                context.RuntimeExceptions.Should().BeNull();
             }
             TestRule.s_testRuleBehaviors = TestRuleBehaviors.None;
         }
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 var context = new TestAnalysisContext { FileSystem = mockFileSystem.Object };
                 int result = command.Run(options, ref context);
 
-                command.ExecutionException?.InnerException.Should().BeNull();
+                context.RuntimeExceptions?[0].InnerException.Should().BeNull();
 
                 result.Should().Be(CommandBase.SUCCESS, $"Iteration: {i}, Seed: {TestRule.s_seed}");
             }
@@ -1843,7 +1843,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (exitReason != ExitReason.None)
             {
-                var exception = command.ExecutionException as ExitApplicationException<ExitReason>;
+                var exception = context.RuntimeExceptions[0] as ExitApplicationException<ExitReason>;
                 exception.Should().NotBeNull();
                 exception.ExitReason.Should().Be(exitReason);
             }

--- a/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
+++ b/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
@@ -45,9 +45,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             TestRuleBehaviors behaviors = context.Policy.GetProperty(TestRule.Behaviors);
             context.IsValidAnalysisTarget = !behaviors.HasFlag(TestRuleBehaviors.RegardAnalysisTargetAsInvalid);
 
-            context.RuntimeException =
+            context.RuntimeExceptions =
                 behaviors.HasFlag(TestRuleBehaviors.RegardAnalysisTargetAsCorrupted)
-               ? new InvalidOperationException()
+               ? new List<Exception>(new[] { new InvalidOperationException() })
                : null;
 
             return context;

--- a/src/Test.UnitTests.Sarif.Multitool.Library/BaselineOptionTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/BaselineOptionTests.cs
@@ -62,9 +62,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 BaselineFilePath = baseLineFilePath,
             };
 
-            int returnCode = validateCommand.Run(options);
+            SarifValidationContext context = null;
+            int returnCode = validateCommand.Run(options, ref context);
             returnCode.Should().Be(1);
-            validateCommand.ExecutionException.Should().BeOfType<ExitApplicationException<ExitReason>>();
+            context.RuntimeExceptions[0].Should().BeOfType<ExitApplicationException<ExitReason>>();
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.ComponentModel.Design.Serialization;
 using System.IO;
 
 using FluentAssertions;
@@ -89,9 +90,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 Level = new List<FailureLevel> { FailureLevel.Warning, FailureLevel.Error }
             };
 
-            int returnCode = validateCommand.Run(options);
+            SarifValidationContext context = null;
+            int returnCode = validateCommand.Run(options, ref context);
             returnCode.Should().Be(1);
-            validateCommand.ExecutionException.Should().BeOfType<ExitApplicationException<ExitReason>>();
+            context.RuntimeExceptions[0].Should().BeOfType<ExitApplicationException<ExitReason>>();
         }
 
         [Fact]


### PR DESCRIPTION
This change deprecates a duplicative single exception for runtime failures expressed as `MulthreadedAnalyzeCommandBase.EngineException` and `IAnalysisContext.RuntimeException`, in favor of a new property, `IAnalysisContext.RuntimeExceptions`, that can hold multiple exceptions.

This allows for tracking errors across multiple threads, e.g., an unhandled exception in a rule as well as a timeout exception.

Otherwise, this change cleans up error handling in the core threading model.