### PR TITLE
If HDF CodeDesc is empty, use Desc as Message

### DIFF
--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     RuleId = execJsonControl.Id,
                     Message = new Message
                     {
-                        Text = AppendPeriod(controlResult.CodeDesc),
+                        Text = AppendPeriod(string.IsNullOrWhiteSpace(controlResult.CodeDesc) ? execJsonControl.Desc : controlResult.CodeDesc),
                     },
                     Level = SarifLevelFromHdfImpact(execJsonControl.Impact),
                     Rank = SarifRankFromHdfImpact(execJsonControl.Impact),


### PR DESCRIPTION
Sometimes, the HDF CodeDesc is empty. Currently, that results in the SARIF Message being set to "." which isn't good.

To fix that issue, if CodeDesc is empty, use the Desc.

I've reported one case where the HDF `code_desc` is set to the empty string at https://github.com/mitre/saf/issues/1163