### PR TITLE
HDF Desc in SARIF FullDescription

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.1.0** UNRELEASED
+* BUG: Store HDF `desc` in SARIF's `FullDescription`, not `ShortDescription`. [#2634](https://github.com/microsoft/sarif-sdk/pull/2634)
 * BRK: `MultithreadedAnalyzeCommandBase` IDispose implementation now manages logging dispose. Be sure to call `base.Dispose()` in any derived type implementations. [#2614](https://github.com/microsoft/sarif-sdk/pull/2614)
 * BRK: Eliminate `MulthreadedAnalyzeCommandBase.EngineException` and `IAnalysisContext.RuntimeException` properties in favor of `IAnalysisContext.RuntimeExceptions`. [#2627](https://github.com/microsoft/sarif-sdk/pull/2627)
 * BRK: Rename `LogFilePersistenceOptions` to `FilePersistenceOptions` (due to its general applicability in other file persistence contexts other than output logs).[#2625](https://github.com/microsoft/sarif-sdk/pull/2625)

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 Id = execJsonControl.Id,
                 Name = execJsonControl.Title,
-                ShortDescription = new MultiformatMessageString
+                FullDescription = new MultiformatMessageString
                 {
                     Text = AppendPeriod(execJsonControl.Desc),
                 },

--- a/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
@@ -1219,7 +1219,7 @@
             {
               "id": "10104",
               "name": "User Agent Fuzzer",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response."
               },
               "relationships": [
@@ -1252,7 +1252,7 @@
             {
               "id": "10016",
               "name": "Web Browser XSS Protection Not Enabled",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server."
               },
               "relationships": [
@@ -1285,7 +1285,7 @@
             {
               "id": "90027.1",
               "name": "Cookie Slack Detector",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced."
               },
               "relationships": [
@@ -1318,7 +1318,7 @@
             {
               "id": "90027.2",
               "name": "Cookie Slack Detector",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced."
               },
               "relationships": [
@@ -1351,7 +1351,7 @@
             {
               "id": "40025.1",
               "name": "Proxy Disclosure",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "1 proxy server(s) were detected or fingerprinted. This information helps a potential attacker to determine  - A list of targets for an attack against the application. - Potential vulnerabilities on the proxy servers that service the application. - The presence or absence of any proxy-based components that might cause attacks against the application to be detected, prevented, or mitigated. ."
               },
               "defaultConfiguration": {
@@ -1387,7 +1387,7 @@
             {
               "id": "10021",
               "name": "X-Content-Type-Options Header Missing",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing."
               },
               "relationships": [
@@ -1420,7 +1420,7 @@
             {
               "id": "40024",
               "name": "SQL Injection - SQLite",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "SQL injection may be possible."
               },
               "defaultConfiguration": {
@@ -1456,7 +1456,7 @@
             {
               "id": "10020",
               "name": "X-Frame-Options Header Not Set",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks."
               },
               "relationships": [
@@ -1489,7 +1489,7 @@
             {
               "id": "40025.2",
               "name": "Proxy Disclosure",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "1 proxy server(s) were detected or fingerprinted. This information helps a potential attacker to determine  - A list of targets for an attack against the application. - Potential vulnerabilities on the proxy servers that service the application. - The presence or absence of any proxy-based components that might cause attacks against the application to be detected, prevented, or mitigated. ."
               },
               "relationships": [
@@ -1522,7 +1522,7 @@
             {
               "id": "40027",
               "name": "SQL Injection - MsSQL",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "SQL injection may be possible."
               },
               "defaultConfiguration": {
@@ -1558,7 +1558,7 @@
             {
               "id": "6",
               "name": "Path Traversal",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "The Path Traversal attack technique allows an attacker access to files, directories, and commands that potentially reside outside the web document root directory. An attacker may manipulate a URL in such a way that the web site will execute or reveal the contents of arbitrary files anywhere on the web server. Any device that exposes an HTTP-based interface is potentially vulnerable to Path Traversal.Most web sites restrict user access to a specific portion of the file-system, typically called the \"web document root\" or \"CGI root\" directory. These directories contain the files intended for user access and the executable necessary to drive web application functionality. To access files or execute commands anywhere on the file-system, Path Traversal attacks will utilize the ability of special-characters sequences.The most basic Path Traversal attack uses the \"../\" special-character sequence to alter the resource location requested in the URL. Although most popular web servers will prevent this technique from escaping the web document root, alternate encodings of the \"../\" sequence may help bypass the security filters. These method variations include valid and invalid Unicode-encoding (\"..%u2216\" or \"..%c0%af\") of the forward slash character, backslash characters (\"..\\\") on Windows-based servers, URL encoded characters \"%2e%2e%2f\"), and double URL encoding (\"..%255c\") of the backslash character.Even if the web server properly restricts Path Traversal attempts in the URL path, a web application itself may still be vulnerable due to improper handling of user-supplied input. This is a common problem of web applications that use template mechanisms or load static text from files. In variations of the attack, the original URL parameter value is substituted with the file name of one of the web application's dynamic scripts. Consequently, the results can reveal source code because the file is interpreted as text instead of an executable script. These techniques often employ additional special characters such as the dot (\".\") to reveal the listing of the current working directory, or \"%00\" NULL characters in order to bypass rudimentary file extension checks."
               },
               "defaultConfiguration": {
@@ -1594,7 +1594,7 @@
             {
               "id": "7",
               "name": "Remote File Inclusion",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "Remote File Include (RFI) is an attack technique used to exploit \"dynamic file include\" mechanisms in web applications. When web applications take user input (URL, parameter value, etc.) and pass them into file include commands, the web application might be tricked into including remote files with malicious code.Almost all web application frameworks support file inclusion. File inclusion is mainly used for packaging common code into separate files that are later referenced by main application modules. When a web application references an include file, the code in this file may be executed implicitly or explicitly by calling specific procedures. If the choice of module to load is based on elements from the HTTP request, the web application might be vulnerable to RFI.An attacker can use RFI for:    * Running malicious code on the server: any code in the included malicious files will be run by the server. If the file include is not executed using some wrapper, code in include files is executed in the context of the server user. This could lead to a complete system compromise.    * Running malicious code on clients: the attacker's malicious code can manipulate the content of the response sent to the client. The attacker can embed malicious code in the response that will be run by the client (for example, Javascript to steal the client session cookies).PHP is particularly vulnerable to RFI attacks due to the extensive use of \"file includes\" in PHP programming and due to default server configurations that increase susceptibility to an RFI attack."
               },
               "defaultConfiguration": {
@@ -1630,7 +1630,7 @@
             {
               "id": "30002",
               "name": "Format String Error",
-              "shortDescription": {
+              "fullDescription": {
                 "text": "A Format String error occurs when the submitted data of an input string is evaluated as a command by the application. ."
               },
               "relationships": [


### PR DESCRIPTION
Store HDF Desc in SARIF FullDescription, not ShortDescription.

According to https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317845
> A reportingDescriptor object MAY contain a property named shortDescription whose value is a localizable multiformatMessageString object (§3.12, §3.12.2) that provides a concise description of the reporting item. The shortDescription property SHOULD be a single sentence that is understandable when visible space is limited to a single line of text.

The HDF Desc tends to be a lot longer than a single sentence, oftentimes multiple sentences, sometimes multiple paragraphs. Therefore it is more appropriate for SARIF's FullDescription, according to https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317846
> A reportingDescriptor object SHOULD contain a property named fullDescription whose value is a localizable multiformatMessageString object (§3.12, §3.12.2) that comprehensively describes the reporting item.
>
> The fullDescription property SHOULD, as far as possible, provide details sufficient to enable resolution of any problem indicated by the reporting item.
>
> The beginning of fullDescription (for example, its first sentence) SHOULD provide a concise description of the reporting item, suitable for display in cases where available space is limited. Tools that construct fullDescription in this way do not need to provide a value for shortDescription (§3.49.9). Tools that do not construct fullDescription in this way SHOULD provide a value for shortDescription.