### PR TITLE
If HDF CodeDesc is empty, use Desc as Message

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -4,6 +4,7 @@
 * BRK: Eliminate `MulthreadedAnalyzeCommandBase.EngineException` and `IAnalysisContext.RuntimeException` properties in favor of `IAnalysisContext.RuntimeExceptions`. [#2627](https://github.com/microsoft/sarif-sdk/pull/2627)
 * BRK: Rename `LogFilePersistenceOptions` to `FilePersistenceOptions` (due to its general applicability in other file persistence contexts other than output logs).[#2625](https://github.com/microsoft/sarif-sdk/pull/2625)
 * BRK: Many breaking changes in `IAnalysisContext` and `AnalyzeContextBase`. [#2625](https://github.com/microsoft/sarif-sdk/pull/2625)
+* BUG: In `HDFConverter` if `code_desc` is empty, use `desc` as the SARIF `message`. [#2632](https://github.com/microsoft/sarif-sdk/pull/2632)
 * BUG: Eliminate creation of extremely large context region snippets (now always restricted to 512 chars). https://github.com/microsoft/sarif-sdk/pull/2629
 * BUG: Eliminate per-context allocations contributing to unnecessary memory use. [#2625](https://github.com/microsoft/sarif-sdk/pull/2625)
 * NEW: Rewrite  `MultithreadedAnalyzeCommandBase` pipeline to allow for timeout, cancellation, and better API-driven use. [#2625](https://github.com/microsoft/sarif-sdk/pull/2625)

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     RuleId = execJsonControl.Id,
                     Message = new Message
                     {
-                        Text = AppendPeriod(controlResult.CodeDesc),
+                        Text = AppendPeriod(string.IsNullOrWhiteSpace(controlResult.CodeDesc) ? execJsonControl.Desc : controlResult.CodeDesc),
                     },
                     Level = SarifLevelFromHdfImpact(execJsonControl.Impact),
                     Rank = SarifRankFromHdfImpact(execJsonControl.Impact),


### PR DESCRIPTION
Sometimes, the HDF CodeDesc is empty. Currently, that results in the SARIF Message being set to "." which isn't good.

To fix that issue, if CodeDesc is empty, use the Desc.

I've reported one case where the HDF `code_desc` is set to the empty string at https://github.com/mitre/saf/issues/1163