### PR TITLE
Zap `FileRegionsCache.Instance` singleton

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,8 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
+* BRK: Add `IAnalysisContext.FileRegionsCache` property. Used for data sharing across analysis phases. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: `fileRegionsCache` parameter is now required for the `InsertOptionalDataVisitor`. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
-* NEW: `SarifLogger.FileRegionsCache` property added (to support sharing this instance with context and other classes). [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: Add `IAnalysisLogger.TargetAnalysisComplete` method. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
@@ -10,6 +10,7 @@
 * BUG: Generate `IAnalysisLogger.AnalyzingTarget` callbacks from `MulthreadedAnalyzeCommandBase`. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BUG: Persist `fileRegionsCache` parameter in `SarifLogger` to support retrieving hash data. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BUG: Allow override of `FailureLevels` and `ResultKinds` in context objects. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* NEW: `SarifLogger.FileRegionsCache` property added (to support sharing this instance with context and other classes). [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * NEW: `MultithreadedAnalyzeCommandBase.Tool` is now public to support in-memory analysis (and logging) of targets. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * NEW: Add `DefaultTraces.TargetsScanned` which is used by `ConsoleLogger` to emit target start and stop analysis messages. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * NEW: Update `FileRegionsCache` to retrieve cached newline indices and hash data via `GetNewLineIndex` and `GetHashData` methods. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
 * BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
+* BRK: `fileRegionsCache` parameter is now required for the `InsertOptionalDataVisitor`. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
+* NEW: `SarifLogger.FileRegionsCache` property added (to support sharing this instance with context and other classes). [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: Add `IAnalysisLogger.TargetAnalysisComplete` method. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
-* BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
+* BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: Add `IAnalysisLogger.TargetAnalysisComplete` method. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
+* BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BRK: Add `IAnalysisLogger.TargetAnalysisComplete` method. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)

--- a/src/Sarif.Driver/Sdk/AggregatingLogger.cs
+++ b/src/Sarif.Driver/Sdk/AggregatingLogger.cs
@@ -29,6 +29,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
+        private FileRegionsCache fileRegionsCache;
+
+        public FileRegionsCache FileRegionsCache
+        {
+            get => fileRegionsCache;
+            set
+            {
+                foreach (IAnalysisLogger logger in Loggers)
+                {
+                    logger.FileRegionsCache = value;
+                }
+                this.fileRegionsCache = value;
+            }
+        }
+
         public void AnalysisStarted()
         {
             foreach (IAnalysisLogger logger in Loggers)

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                             currentResult = clonedResult;
                         }
-
+                        globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache;
                         globalContext.Logger.Log(kv.Key, currentResult, tuple.Item2);
                     }
                 }

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -444,7 +444,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                             globalContext.CurrentTarget = null;
                         }
-                        context.Dispose();
 
                         _fileContexts.TryRemove(currentIndex, out _);
                         _fileContexts.TryGetValue(++currentIndex, out context);

--- a/src/Sarif.Multitool.Library/RebaseUriCommand.cs
+++ b/src/Sarif.Multitool.Library/RebaseUriCommand.cs
@@ -60,7 +60,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                     if (dataToInsert != 0)
                     {
-                        rebaseUriFile.Log = new InsertOptionalDataVisitor(dataToInsert, insertProperties: options.InsertProperties).VisitSarifLog(rebaseUriFile.Log);
+                        rebaseUriFile.Log =
+                            new InsertOptionalDataVisitor(dataToInsert,
+                                                          new FileRegionsCache(),
+                                                          insertProperties: options.InsertProperties).VisitSarifLog(rebaseUriFile.Log);
                     }
 
                     rebaseUriFile.Log = rebaseUriFile.Log.RebaseUri(options.BasePathToken, options.RebaseRelativeUris, baseUri);
@@ -103,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return valid;
         }
 
-        internal string GetOutputFilePath(string inputFilePath, RebaseUriOptions rebaseUriOptions)
+        internal static string GetOutputFilePath(string inputFilePath, RebaseUriOptions rebaseUriOptions)
         {
             if (rebaseUriOptions.Inline) { return inputFilePath; }
 

--- a/src/Sarif.Multitool.Library/RewriteCommand.cs
+++ b/src/Sarif.Multitool.Library/RewriteCommand.cs
@@ -57,7 +57,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 IDictionary<string, ArtifactLocation> originalUriBaseIds = options.ConstructUriBaseIdsDictionary();
 
                 SarifLog reformattedLog = new RemoveOptionalDataVisitor(dataToRemove).VisitSarifLog(actualLog);
-                reformattedLog = new InsertOptionalDataVisitor(dataToInsert, originalUriBaseIds, insertProperties: options.InsertProperties).VisitSarifLog(reformattedLog);
+
+                reformattedLog = new InsertOptionalDataVisitor(dataToInsert,
+                                                               new FileRegionsCache(),
+                                                               originalUriBaseIds,
+                                                               insertProperties: options.InsertProperties).VisitSarifLog(reformattedLog);
 
                 if (options.SortResults)
                 {

--- a/src/Sarif.WorkItems/SarifWorkItemContext.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemContext.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                         assemblyPath = Path.GetFullPath(Path.Combine(thisAssemblyDirectory, assemblyLocation));
                     }
 
-                    Assembly a = Assembly.LoadFrom(assemblyPath);
+                    var a = Assembly.LoadFrom(assemblyPath);
                     loadedAssemblies.Add(a.FullName, a);
                     this.AssemblyLocationMap.Add(a.FullName, Path.GetDirectoryName(Path.GetFullPath(a.Location)));
                 }
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 StringSet assemblyAndTypeNames = this.GetProperty(PluginAssemblyQualifiedNames);
                 foreach (string assemblyAndTypeName in assemblyAndTypeNames)
                 {
-                    Type type = Type.GetType(assemblyAndTypeName);
+                    var type = Type.GetType(assemblyAndTypeName);
 
                     if (type == null)
                     {
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                         }
                     }
 
-                    SarifWorkItemModelTransformer workItemModelTransformer =
+                    var workItemModelTransformer =
                         (SarifWorkItemModelTransformer)Activator.CreateInstance(type);
 
                     workItemModelTransformers.Add(workItemModelTransformer);

--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 if (optionallyEmittedData != OptionallyEmittedData.None)
                 {
                     Logger.LogDebug("Inserting optional data.");
-                    var dataInsertingVisitor = new InsertOptionalDataVisitor(optionallyEmittedData);
+                    var dataInsertingVisitor = new InsertOptionalDataVisitor(optionallyEmittedData, new FileRegionsCache());
                     dataInsertingVisitor.Visit(sarifLog);
                 }
 
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
                     PartitionFunction<string> partitionFunction = null;
 
-                    Stopwatch splittingStopwatch = Stopwatch.StartNew();
+                    var splittingStopwatch = Stopwatch.StartNew();
 
                     switch (splittingStrategy)
                     {
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                             // it should be pulled from the work flow (i.e., not filed).
                             if (updatedSarifWorkItemModel == null)
                             {
-                                Dictionary<string, object> customDimentions = new Dictionary<string, object>();
+                                var customDimentions = new Dictionary<string, object>();
                                 customDimentions.Add("TransformerType", transformer.GetType().FullName);
                                 LogMetricsForProcessedModel(sarifLog, sarifWorkItemModel, FilingResult.Canceled, customDimentions);
                                 return null;
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 {
                     this.Logger.LogError(ex, "An exception was raised filing log '{logId}'.", logId);
 
-                    Dictionary<string, object> customDimentions = new Dictionary<string, object>();
+                    var customDimentions = new Dictionary<string, object>();
                     customDimentions.Add("ExceptionType", ex.GetType().FullName);
                     customDimentions.Add("ExceptionMessage", ex.Message);
                     customDimentions.Add("ExceptionStackTrace", ex.ToString());

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public class FileRegionsCache
     {
-        public static readonly FileRegionsCache Instance = new FileRegionsCache();
         public const int DefaultCacheCapacity = 100;
         private readonly IFileSystem _fileSystem;
 

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             _newLineIndexCache.Clear();
         }
 
-        private Region PopulateTextRegionProperties(NewLineIndex lineIndex, Region inputRegion, string fileText, bool populateSnippet)
+        private static Region PopulateTextRegionProperties(NewLineIndex lineIndex, Region inputRegion, string fileText, bool populateSnippet)
         {
             // A GENERAL NOTE ON THE PROPERTY POPULATION PROCESS:
             //
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return multilineContextSnippet;
         }
 
-        private void PopulatePropertiesFromCharOffsetAndLength(NewLineIndex newLineIndex, Region region)
+        private static void PopulatePropertiesFromCharOffsetAndLength(NewLineIndex newLineIndex, Region region)
         {
             Assert(!region.IsBinaryRegion);
             Assert(region.StartLine == 0);
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Assert(region.EndColumn == endColumn);
         }
 
-        private void PopulatePropertiesFromStartAndEndProperties(NewLineIndex lineIndex, Region region, string fileText)
+        private static void PopulatePropertiesFromStartAndEndProperties(NewLineIndex lineIndex, Region region, string fileText)
         {
             Assert(region.StartLine > 0);
 
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             region.StartColumn = region.StartColumn == 0 ? 1 : region.StartColumn;
         }
 
-        private void PopulateEndColumn(NewLineIndex lineIndex, Region region, string fileText)
+        private static void PopulateEndColumn(NewLineIndex lineIndex, Region region, string fileText)
         {
             // Populated at this point: StartLine, EndLine, StartColumn
             Assert(region.StartLine > 0);
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Assert(region.CharOffset == offset);
         }
 
-        private void PopulateCharLength(NewLineIndex lineIndex, Region region)
+        private static void PopulateCharLength(NewLineIndex lineIndex, Region region)
         {
             // Populated at this point: StartLine, EndLine, StartColumn, EndColumn, CharOffset
             Assert(region.StartLine > 0);

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </remarks>
     public class FileSystem : IFileSystem
     {
-        public static FileSystem Instance = new FileSystem();
+        public readonly static FileSystem Instance = new FileSystem();
 
         /// <summary>
         /// Loads an assembly given its file name or path.
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </returns>
         public long FileInfoLength(string path)
         {
-            FileInfo fileInfo = new FileInfo(path);
+            var fileInfo = new FileInfo(path);
             return fileInfo.Length;
         }
 
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// contain version information, the FileVersionInfo contains only the name of the file requested.</returns>
         public FileVersionInfo FileVersionInfoGetVersionInfo(string fileName)
         {
-            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(fileName);
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(fileName);
             return fileVersionInfo;
         }
     }

--- a/src/Sarif/IAnalysisLogger.cs
+++ b/src/Sarif/IAnalysisLogger.cs
@@ -5,6 +5,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 {
     public interface IAnalysisLogger
     {
+        FileRegionsCache FileRegionsCache { get; set; }
+
         void AnalysisStarted();
 
         void AnalysisStopped(RuntimeConditions runtimeConditions);

--- a/src/Sarif/Processors/Log/SarifLogStageFactory.cs
+++ b/src/Sarif/Processors/Log/SarifLogStageFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
                 {
                     return new GenericMappingAction<SarifLog>(log =>
                     {
-                        MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+                        var visitor = new MakeUrisAbsoluteVisitor();
                         return visitor.VisitSarifLog(log);
                     });
                 }
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
 
                         if (optionalData != 0)
                         {
-                            var visitor = new InsertOptionalDataVisitor(optionalData);
+                            var visitor = new InsertOptionalDataVisitor(optionalData, new FileRegionsCache());
                             return visitor.VisitSarifLog(log);
                         }
                         return log;
@@ -66,10 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
                             return accumulator;
                         }
 
-                        if (accumulator.Runs == null)
-                        {
-                            accumulator.Runs = new List<Run>();
-                        }
+                        accumulator.Runs ??= new List<Run>();
 
                         foreach (Run run in nextLog.Runs)
                         {

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private GitHelper _gitHelper;
 
         private int _ruleIndex;
-        private readonly FileRegionsCache _fileRegionsCache;
         private readonly OptionallyEmittedData _dataToInsert;
         private readonly IDictionary<string, ArtifactLocation> _originalUriBaseIds;
         private readonly IEnumerable<string> _insertProperties;
@@ -31,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private const string Name = nameof(Name);
         private const string Email = nameof(Email);
         private const string CommitSha = nameof(CommitSha);
-
+        
         public InsertOptionalDataVisitor(OptionallyEmittedData dataToInsert,
                                          FileRegionsCache fileRegionsCache,
                                          Run run,
@@ -61,8 +60,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             _originalUriBaseIds = originalUriBaseIds;
             _insertProperties = insertProperties ?? new List<string>();
 
-            _fileRegionsCache = fileRegionsCache;
+            FileRegionsCache = fileRegionsCache;
         }
+
+        public FileRegionsCache FileRegionsCache { get; set; }
 
         public override Run VisitRun(Run node)
         {
@@ -119,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 Uri resolvedUri = GetResolvedArtifactLocationUri(node.ArtifactLocation);
 
-                Region expandedRegion = _fileRegionsCache.PopulateTextRegionProperties(node.Region, resolvedUri, populateSnippet: insertRegionSnippets);
+                Region expandedRegion = FileRegionsCache.PopulateTextRegionProperties(node.Region, resolvedUri, populateSnippet: insertRegionSnippets);
 
                 ArtifactContent originalSnippet = node.Region.Snippet;
 
@@ -134,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                 if (insertContextCodeSnippets && (node.ContextRegion == null || overwriteExistingData))
                 {
-                    node.ContextRegion = _fileRegionsCache.ConstructMultilineContextSnippet(expandedRegion, resolvedUri);
+                    node.ContextRegion = FileRegionsCache.ConstructMultilineContextSnippet(expandedRegion, resolvedUri);
                 }
             }
 
@@ -248,8 +249,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     if (contextRegionSnippet == null)
                     {
                         Region expandedRegion =
-                            _fileRegionsCache.PopulateTextRegionProperties(physicalLocation.Region, resolvedUri, false);
-                        contextRegionSnippet = _fileRegionsCache.ConstructMultilineContextSnippet(expandedRegion, resolvedUri)?.Snippet;
+                            FileRegionsCache.PopulateTextRegionProperties(physicalLocation.Region, resolvedUri, false);
+                        contextRegionSnippet = FileRegionsCache.ConstructMultilineContextSnippet(expandedRegion, resolvedUri)?.Snippet;
                     }
 
                     if (contextRegionSnippet?.Text != null)

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         private const string Name = nameof(Name);
         private const string Email = nameof(Email);
         private const string CommitSha = nameof(CommitSha);
-        
+
         public InsertOptionalDataVisitor(OptionallyEmittedData dataToInsert,
                                          FileRegionsCache fileRegionsCache,
                                          Run run,

--- a/src/Sarif/Writers/CacheByFileHashLogger.cs
+++ b/src/Sarif/Writers/CacheByFileHashLogger.cs
@@ -20,13 +20,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
     {
         private bool cacheLoggingData;
         private string currentFileHash;
-
-        public Dictionary<string, List<Notification>> HashToNotificationsMap { get; private set; }
-        public Dictionary<string, List<Tuple<ReportingDescriptor, Result, int?>>> HashToResultsMap { get; private set; }
-
         public CacheByFileHashLogger(FailureLevelSet levels, ResultKindSet kinds) : base(levels, kinds)
         {
         }
+
+        public Dictionary<string, List<Notification>> HashToNotificationsMap { get; private set; }
+
+        public Dictionary<string, List<Tuple<ReportingDescriptor, Result, int?>>> HashToResultsMap { get; private set; }
+
+        public FileRegionsCache FileRegionsCache { get; set; }
+
 
         public void AnalysisStarted()
         {

--- a/src/Sarif/Writers/CachingLogger.cs
+++ b/src/Sarif/Writers/CachingLogger.cs
@@ -37,6 +37,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private readonly SemaphoreSlim _semaphore;
 
+        public FileRegionsCache FileRegionsCache { get; set; }
+
         public void AnalysisStarted()
         {
         }

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
         }
 
+        public FileRegionsCache FileRegionsCache { get; set; }
+
         public void AnalysisStarted()
         {
             WriteLineToConsole(SdkResources.MSG_Analyzing);

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private readonly Run _run;
         private readonly bool _closeWriterOnDispose;
-        public FileRegionsCache FileRegionsCache { get; set; }
         private readonly OptionallyEmittedData _dataToInsert;
         private readonly OptionallyEmittedData _dataToRemove;
         private readonly FilePersistenceOptions _filePersistenceOptions;
@@ -144,6 +143,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     RuleToIndexMap[_run.Tool.Driver.Rules[i]] = i;
                 }
             }
+        }
+
+        private FileRegionsCache _fileRegionsCache;
+        public FileRegionsCache FileRegionsCache 
+        {
+            get => _fileRegionsCache;
+            set => _insertOptionalDataVisitor.FileRegionsCache = _fileRegionsCache = value;
         }
 
         private void RecordRules(int? extensionIndex, ToolComponent toolComponent)

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -149,7 +149,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         public FileRegionsCache FileRegionsCache 
         {
             get => _fileRegionsCache;
-            set => _insertOptionalDataVisitor.FileRegionsCache = _fileRegionsCache = value;
+            set
+            {
+                _fileRegionsCache = value;
+                if (_insertOptionalDataVisitor != null)
+                {
+
+                    _insertOptionalDataVisitor.FileRegionsCache = _fileRegionsCache = value;
+                }
+            }
         }
 
         private void RecordRules(int? extensionIndex, ToolComponent toolComponent)

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         }
 
         private FileRegionsCache _fileRegionsCache;
-        public FileRegionsCache FileRegionsCache 
+        public FileRegionsCache FileRegionsCache
         {
             get => _fileRegionsCache;
             set

--- a/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
+++ b/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 OptionallyEmittedData.ContextRegionSnippets |
                 OptionallyEmittedData.ComprehensiveRegionProperties;
 
-            SarifLog reformattedLog = new InsertOptionalDataVisitor(dataToInsert).VisitSarifLog(actualLog);
+            SarifLog reformattedLog = new InsertOptionalDataVisitor(dataToInsert, new FileRegionsCache()).VisitSarifLog(actualLog);
 
             File.WriteAllText(actualFilePath, JsonConvert.SerializeObject(reformattedLog, settings));
         }

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -49,7 +49,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Plugins\Security\Security.csproj" />
     <ProjectReference Include="..\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\Test.Utilities.Sarif\Test.Utilities.Sarif.csproj" />

--- a/src/Test.UnitTests.Sarif/Visitors/InsertOptionalDataVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/InsertOptionalDataVisitorTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                 actualLog.Runs[0].OriginalUriBaseIds["TESTROOT"] = new ArtifactLocation { Uri = new Uri(uriString, UriKind.Absolute) };
 
-                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData);
+                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData, new FileRegionsCache());
                 visitor.Visit(actualLog.Runs[0]);
 
                 // Restore the remanufactured URI so that file diffing succeeds.
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                 actualLog.Runs[0].Artifacts[0].Location = new ArtifactLocation { Uri = new Uri(uriString, UriKind.Absolute) };
 
-                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData);
+                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData, new FileRegionsCache());
                 visitor.Visit(actualLog.Runs[0]);
 
                 // Restore the remanufactured URI so that file diffing matches
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             }
             else
             {
-                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData);
+                var visitor = new InsertOptionalDataVisitor(_currentOptionallyEmittedData, new FileRegionsCache());
                 visitor.Visit(actualLog.Runs[0]);
             }
 
@@ -349,6 +349,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             var visitor = new InsertOptionalDataVisitor(
                 OptionallyEmittedData.VersionControlDetails,
+                new FileRegionsCache(),
                 originalUriBaseIds: null,
                 fileSystem: mockFileSystem.Object,
                 processRunner: mockProcessRunner.Object,
@@ -433,7 +434,7 @@ Three";
                     }
                 };
 
-                var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.RegionSnippets, run, insertProperties: null);
+                var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.RegionSnippets, new FileRegionsCache(), run, insertProperties: null);
 
                 visitor.VisitResult(run.Results[0]);
 
@@ -492,8 +493,12 @@ Three";
                 }
             };
 
-            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.ContextRegionSnippetPartialFingerprints,
-                run, insertProperties: null);
+            var visitor =
+                new InsertOptionalDataVisitor(
+                    OptionallyEmittedData.ContextRegionSnippetPartialFingerprints,
+                    new FileRegionsCache(),
+                    run,
+                    insertProperties: null);
 
             visitor.VisitResult(run.Results[0]);
 
@@ -566,7 +571,11 @@ Three";
                 }
             };
 
-            var visitor = new InsertOptionalDataVisitor(dataToInsert, run, insertProperties: null);
+            var visitor =
+                new InsertOptionalDataVisitor(dataToInsert,
+                                              new FileRegionsCache(),
+                                              run,
+                                              insertProperties: null);
 
             visitor.VisitResult(run.Results[0]);
 
@@ -671,7 +680,7 @@ Three";
                     }
                 });
 
-            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
+            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages, new FileRegionsCache());
             visitor.Visit(run);
 
             run.Results[0].Message.Text.Should().Be(UniqueGlobalMessageValue);
@@ -737,7 +746,7 @@ Three";
                 });
             configurationNotifications.Add(toolNotifications[2]);
 
-            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
+            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages, new FileRegionsCache());
             visitor.Visit(run);
 
             toolNotifications[0].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
@@ -809,7 +818,7 @@ Three";
                     }
                 });
 
-            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
+            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages, new FileRegionsCache());
             visitor.Visit(run);
 
             run.Results[0].Fixes[0].Description.Text.Should().Be(UniqueGlobalMessageValue);
@@ -859,14 +868,14 @@ Three";
                 }
             };
 
-            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.TextFiles);
+            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.TextFiles, new FileRegionsCache());
             visitor.VisitRun(run);
 
             run.OriginalUriBaseIds.Should().BeNull();
             run.Artifacts.Count.Should().Be(1);
             run.Artifacts[0].Contents.Should().BeNull();
 
-            visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.TextFiles, originalUriBaseIds);
+            visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.TextFiles, new FileRegionsCache(), originalUriBaseIds);
             visitor.VisitRun(run);
 
             run.OriginalUriBaseIds.Should().Equal(originalUriBaseIds);

--- a/src/Test.Utilities.Sarif/TestMessageLogger.cs
+++ b/src/Test.Utilities.Sarif/TestMessageLogger.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public List<Notification> ConfigurationNotifications { get; set; }
 
+        public FileRegionsCache FileRegionsCache { get; set; }
 
         public void AnalysisStarted()
         {


### PR DESCRIPTION
In general, our static singletons work well for use in a client tool model, where executions lights up, completes, and exits. This pattern is creating complications for API-driven scenarios where consumers want to take more control of thread & state management.

Removing `FileRegionsCache.Instance` first as its existence clearly permits threading issues (even if we haven't encountered them in the wild yet). We will hunt down and remove all other occurrences of this pattern as follow-on changes.