### PR TITLE
Strengthen ability to drive analysis via XML config files.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
+[#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
+* BRK: Rename `Errors.LogExceptionCreatingLogFile` to `Errors.LogExceptionCreatingOutputFile` to reflect its general purpose. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
 * BRK: Add `IAnalysisContext.FileRegionsCache` property. Used for data sharing across analysis phases. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: Remove `FileRegionsCache.Instance` singleton object. Analysis should always prefer context file region context instead. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * BRK: `fileRegionsCache` parameter is now required for the `InsertOptionalDataVisitor`. [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
@@ -10,6 +12,8 @@
 * BUG: Generate `IAnalysisLogger.AnalyzingTarget` callbacks from `MulthreadedAnalyzeCommandBase`. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BUG: Persist `fileRegionsCache` parameter in `SarifLogger` to support retrieving hash data. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BUG: Allow override of `FailureLevels` and `ResultKinds` in context objects. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* NEW: Add `DefaultTraces.ResultsSummary` property that drives naive results summary in console logger. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
+* NEW: Prove `AnalyzeContextBase.Inline` helper. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
 * NEW: `SarifLogger.FileRegionsCache` property added (to support sharing this instance with context and other classes). [#2642](https://github.com/microsoft/sarif-sdk/pull/2642)
 * NEW: `MultithreadedAnalyzeCommandBase.Tool` is now public to support in-memory analysis (and logging) of targets. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * NEW: Add `DefaultTraces.TargetsScanned` which is used by `ConsoleLogger` to emit target start and stop analysis messages. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)

--- a/src/Sarif.Driver/ResultsSummaryLogger.cs
+++ b/src/Sarif.Driver/ResultsSummaryLogger.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Driver
+{
+    internal class ResultsSummaryLogger : IAnalysisLogger, IDisposable
+    {
+        public FileRegionsCache FileRegionsCache { get; set; }
+
+        public void AnalysisStarted()
+        {
+        }
+
+        public void AnalysisStopped(RuntimeConditions runtimeConditions)
+        {
+        }
+
+        public void AnalyzingTarget(IAnalysisContext context)
+        {
+        }
+
+        private Dictionary<string, Tuple<int, int, int>> rulesSummary;
+
+        public void Log(ReportingDescriptor rule, Result result, int? extensionIndex = null)
+        {
+            string key = $"{rule.Id}.{rule.Name}";
+            rulesSummary ??= new Dictionary<string, Tuple<int, int, int>>();
+            rulesSummary.TryGetValue(key, out Tuple<int, int, int> tuple);
+            tuple ??= new Tuple<int, int, int>(0, 0, 0);
+
+            switch (result.Level)
+            {
+                case FailureLevel.Error:
+                {
+                    tuple = new Tuple<int, int, int>(tuple.Item1 + 1, tuple.Item2, tuple.Item3);
+                    break;
+                }
+                case FailureLevel.Warning:
+                {
+                    tuple = new Tuple<int, int, int>(tuple.Item1 + 1, tuple.Item2, tuple.Item3);
+                    break;
+                }
+                case FailureLevel.Note:
+                {
+                    tuple = new Tuple<int, int, int>(tuple.Item1 + 1, tuple.Item2, tuple.Item3);
+                    break;
+                }
+            }
+
+            rulesSummary[key] = tuple;
+        }
+
+        public void LogConfigurationNotification(Notification notification)
+        {
+        }
+
+        public void LogToolNotification(Notification notification, ReportingDescriptor associatedRule = null)
+        {
+        }
+
+        public void TargetAnalyzed(IAnalysisContext context)
+        {
+        }
+
+        public void Dispose()
+        {
+            if (this.rulesSummary == null) { return; }
+
+            Console.WriteLine();
+
+            var aggregatedCounts = new Dictionary<string, long>();
+            foreach (string ruleIdAndName in this.rulesSummary.Keys)
+            {
+                Tuple<int, int, int> tuple = this.rulesSummary[ruleIdAndName];
+                long count = tuple.Item1 + tuple.Item2 + tuple.Item3;
+                string line = $"{ruleIdAndName} : {count}";
+                aggregatedCounts[line] = count;
+            }
+
+            IOrderedEnumerable<KeyValuePair<string, long>> sortedResults = from entry in aggregatedCounts orderby entry.Value descending select entry;
+            foreach (KeyValuePair<string, long> line in sortedResults)
+            {
+                Console.WriteLine(line.Key);
+            }
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             'r',
             "recurse",
             HelpText = "Recurse into subdirectories when evaluating file specifier arguments.")]
-        public bool Recurse { get; set; }
+        public bool? Recurse { get; set; }
 
         [Option(
             'c',
@@ -41,20 +41,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "quiet",
             HelpText = "Suppress all console output (except for catastrophic tool runtime or configuration errors).")]
         public bool? Quiet { get; set; }
-
-        [Option(
-            's',
-            "statistics",
-            HelpText = "Generate timing and other statistics for analysis session.")]
-        [Obsolete()]
-        public bool Statistics { get; set; }
-
-        [Option(
-            'h',
-            "hashes",
-            HelpText = "Output MD5, SHA1, and SHA-256 hash of analysis targets when emitting SARIF reports.")]
-        [Obsolete("Use --insert instead, passing 'Hashes' along with any other references to data to be inserted.")]
-        public bool ComputeFileHashes { get; set; }
 
         [Option(
             'e',
@@ -132,7 +118,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             get => this.kind;
             set => this.kind = value?.Count() > 0 ? value : null;
         }
-
 
         public ResultKindSet ResultKinds => Kind != null ? new ResultKindSet(Kind) : BaseLogger.Fail;
 

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public bool ForceOverwrite => OutputFileOptions.ToFlags().HasFlag(FilePersistenceOptions.ForceOverwrite);
 
-
         private HashSet<FilePersistenceOptions> _filePersistenceOptions;
 
         [Option(
@@ -46,10 +45,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 filePersistenceOptions.Remove(FilePersistenceOptions.Minify);
             }
 
-            if (!filePersistenceOptions.Contains(FilePersistenceOptions.Minify))
+            if (filePersistenceOptions.Count > 0 &&
+                !filePersistenceOptions.Contains(FilePersistenceOptions.Minify))
             {
                 filePersistenceOptions.Add(FilePersistenceOptions.PrettyPrint);
             }
+
             return filePersistenceOptions;
         }
 

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public virtual RuntimeConditions RuntimeErrors { get; set; }
         public virtual bool AnalysisComplete { get; set; }
 
+        public bool Inline => OutputFileOptions.HasFlag(FilePersistenceOptions.Inline);
         public bool Minify => OutputFileOptions.HasFlag(FilePersistenceOptions.Minify);
         public bool Optimize => OutputFileOptions.HasFlag(FilePersistenceOptions.Optimize);
         public bool PrettyPrint => OutputFileOptions.HasFlag(FilePersistenceOptions.PrettyPrint);

--- a/src/Sarif/DefaultTraces.cs
+++ b/src/Sarif/DefaultTraces.cs
@@ -25,5 +25,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Enables a trace message that reports progress against each scan target.
         /// </summary>
         TargetsScanned = 0x8,
+        /// <summary>
+        /// Enables a trace message that summarizes all results and notification by id and severity.
+        /// </summary>
+        ResultsSummary = 0x10,
     }
 }

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -22,9 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         private const string ERR997_ExceptionLoadingPlugIn = "ERR997.ExceptionLoadingPlugIn";
         private const string ERR997_NoValidAnalysisTargets = "ERR997.NoValidAnalysisTargets";
         private const string ERR997_ExceptionAccessingFile = "ERR997.ExceptionAccessingFile";
-        private const string ERR997_ExceptionCreatingLogFile = "ERR997.ExceptionCreatingLogFile";
         internal const string ERR997_IncompatibleRulesDetected = "ERR997.IncompatibleRulesDetected";
         internal const string ERR997_AllRulesExplicitlyDisabled = "ERR997.AllRulesExplicitlyDisabled";
+        private const string ERR997_ExceptionCreatingOutputFile = "ERR997.ExceptionCreatingOutputFile";
         private const string ERR997_InvalidInvocationPropertyName = "ERR997.InvalidInvocationPropertyName";
         private const string ERR997_MissingReportingConfiguration = "ERR997.MissingReportingConfiguration";
         private const string ERR997_ExceptionLoadingAnalysisTarget = "ERR997.ExceptionLoadingAnalysisTarget";
@@ -183,20 +183,20 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         }
 
-        public static void LogExceptionCreatingLogFile(IAnalysisContext context, string fileName, Exception exception)
+        public static void LogExceptionCreatingOutputFile(IAnalysisContext context, string fileName, Exception exception)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            context.RuntimeErrors |= RuntimeConditions.ExceptionCreatingLogFile;
+            context.RuntimeErrors |= RuntimeConditions.ExceptionCreatingOutputFile;
 
             // Could not create output file: '{0}'
             context.Logger.LogConfigurationNotification(
                 CreateNotification(
                     uri: null,
-                    ERR997_ExceptionCreatingLogFile,
+                    ERR997_ExceptionCreatingOutputFile,
                     ruleId: null,
                     FailureLevel.Error,
                     exception: exception,

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -129,6 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static HashData ComputeHashesForText(string text)
         {
+            if (text == null) { throw new ArgumentNullException(nameof(text)); }
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
             return ComputeHashes(stream);
         }

--- a/src/Sarif/RuntimeConditions.cs
+++ b/src/Sarif/RuntimeConditions.cs
@@ -15,16 +15,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     {
         None = 0,
 
-        // Not used today but perhaps soon...
-        //CouldNotLoadCustomLoggerAssembly,
-        //CouldNotLoadCustomLoggerType,
-        //UnrecognizedDefaultLoggerExtension,
-        //MalformedCustomLoggersArgument,
-        //LoggerFailedInitialization,
-        //LoggerRaisedExceptionOnInitialization,
-        //LoggerRaisedExceptionOnWrite,
-        //LoggerRaisedExceptionOnClose,
-
         // Fatal conditions
         // InvalidCommandLineOption is a useful bit to
         // use as value 0x1. This allows for a consistent
@@ -35,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         ExceptionInSkimmerInitialize = 0x2,
         ExceptionRaisedInSkimmerCanAnalyze = 0x4,
         ExceptionInSkimmerAnalyze = 0x8,
-        ExceptionCreatingLogFile = 0x10,
+        ExceptionCreatingOutputFile = 0x10,
         ExceptionLoadingPdb = 0x20,
         ExceptionInEngine = 0x40,
         ExceptionLoadingTargetFile = 0x80,

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class SdkResources {
@@ -144,9 +144,9 @@ namespace Microsoft.CodeAnalysis.Sarif {
         /// <summary>
         ///   Looks up a localized string similar to Could not create output file &apos;{0}&apos;..
         /// </summary>
-        public static string ERR997_ExceptionCreatingLogFile {
+        public static string ERR997_ExceptionCreatingOutputFile {
             get {
-                return ResourceManager.GetString("ERR997_ExceptionCreatingLogFile", resourceCulture);
+                return ResourceManager.GetString("ERR997_ExceptionCreatingOutputFile", resourceCulture);
             }
         }
         

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -159,7 +159,7 @@
   <data name="ERR997_ExceptionAccessingFile" xml:space="preserve">
     <value>Could not access a file specified on the command line: '{0}'.</value>
   </data>
-  <data name="ERR997_ExceptionCreatingLogFile" xml:space="preserve">
+  <data name="ERR997_ExceptionCreatingOutputFile" xml:space="preserve">
     <value>Could not create output file '{0}'.</value>
   </data>
   <data name="ERR998_ExceptionInAnalyze" xml:space="preserve">

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -502,6 +502,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 return;
             }
 
+            // We only populate the artifacts table is there is some data
+            // in addition to the location URI. Otherwise, each results
+            // stores the URI and an artifact index that points to an
+            // entry that merely recapitulates the URI with no other data.
+            bool createArtifactEntries =
+                _dataToInsert.HasFlag(OptionallyEmittedData.Hashes) ||
+                _dataToInsert.HasFlag(OptionallyEmittedData.TextFiles) ||
+                _dataToInsert.HasFlag(OptionallyEmittedData.BinaryFiles) ||
+                !string.IsNullOrEmpty(fileLocation.UriBaseId) ||
+                this.Optimize;
+
             Encoding encoding = null;
 
             if (_run.DefaultEncoding != null)
@@ -521,7 +532,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             // Ensure Artifact is in Run.Artifacts and ArtifactLocation.Index is set to point to it
             int index = _run.GetFileIndex(fileLocation,
-                                          addToFilesTableIfNotPresent: true,
+                                          addToFilesTableIfNotPresent: createArtifactEntries,
                                           _dataToInsert,
                                           encoding,
                                           hashData);

--- a/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
@@ -135,9 +135,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             var validateCommand = new ValidateCommand();
             var context = new SarifValidationContext { FileSystem = mockFileSystem.Object };
             int returnCode = validateCommand.Run(validateOptions, ref context);
-            (context.RuntimeErrors & ~RuntimeConditions.Nonfatal).Should().Be(0);
-
-            returnCode.Should().Be(0);
+            context.ValidateCommandExecution(returnCode);
 
             string actualLogFileContents = File.ReadAllText(this.IsInline ? baselineFilePath : outputLogFilePath);
             SarifLog actualLog = JsonConvert.DeserializeObject<SarifLog>(actualLogFileContents);

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     };
 
                     ExceptionTestHelper(
-                        RuntimeConditions.ExceptionCreatingLogFile,
+                        RuntimeConditions.ExceptionCreatingOutputFile,
                         expectedExitReason: ExitReason.ExceptionCreatingLogFile,
                         analyzeOptions: options);
                 }
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 };
 
                 ExceptionTestHelper(
-                    RuntimeConditions.ExceptionCreatingLogFile,
+                    RuntimeConditions.ExceptionCreatingOutputFile,
                     expectedExitReason: ExitReason.ExceptionCreatingLogFile,
                     analyzeOptions: options);
             }
@@ -1748,6 +1748,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var options = new TestAnalyzeOptions
             {
                 TestRuleBehaviors = testCase.TestRuleBehaviors,
+                DataToInsert = new[] { OptionallyEmittedData.Hashes },
                 OutputFilePath = testCase.PersistLogFileToDisk ? Guid.NewGuid().ToString() : null,
                 TargetFileSpecifiers = new string[] { Guid.NewGuid().ToString() },
             };

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
@@ -6,6 +6,7 @@ using System;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Driver;
 
 using Xunit;
 
@@ -24,26 +25,39 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
                 Quiet = true
             };
 
+            var command = new TestMultithreadedAnalyzeCommand();
             loggingOptions = analyzeOptions.OutputFileOptions.ToFlags();
-            loggingOptions.Should().Be(FilePersistenceOptions.PrettyPrint);
-            analyzeOptions.ForceOverwrite.Should().Be(false);
-            analyzeOptions.PrettyPrint.Should().Be(true);
-            analyzeOptions.Optimize.Should().Be(false);
-            analyzeOptions.Minify.Should().Be(false);
-            analyzeOptions.Inline.Should().Be(false);
+
+            // We need logging options to evaluate as empty when not set,
+            // so that we always know when a user has or has not explicitly
+            // set this option. This allows is to be overridden in disk
+            // configuration.
+            loggingOptions.Should().Be(FilePersistenceOptions.None);
+
+            TestAnalysisContext context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(false);
+            context.PrettyPrint.Should().Be(true);
+            context.Optimize.Should().Be(false);
+            context.Minify.Should().Be(false);
+            context.Inline.Should().Be(false);
 
             analyzeOptions = new TestAnalyzeOptions()
             {
                 OutputFileOptions = new[] { FilePersistenceOptions.Minify }
             };
-
             loggingOptions = analyzeOptions.OutputFileOptions.ToFlags();
             loggingOptions.Should().Be(FilePersistenceOptions.Minify);
-            analyzeOptions.ForceOverwrite.Should().Be(false);
-            analyzeOptions.PrettyPrint.Should().Be(false);
-            analyzeOptions.Optimize.Should().Be(false);
-            analyzeOptions.Inline.Should().Be(false);
-            analyzeOptions.Minify.Should().Be(true);
+
+            context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(false);
+            context.PrettyPrint.Should().Be(false);
+            context.Optimize.Should().Be(false);
+            context.Inline.Should().Be(false);
+            context.Minify.Should().Be(true);
 
             // If both Minify and PrettyPrint are set, we prefer PrettyPrint, with no exception raised.
             analyzeOptions = new TestAnalyzeOptions()
@@ -53,11 +67,15 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
 
             loggingOptions = analyzeOptions.OutputFileOptions.ToFlags();
             loggingOptions.Should().Be(FilePersistenceOptions.PrettyPrint);
-            analyzeOptions.ForceOverwrite.Should().Be(false);
-            analyzeOptions.PrettyPrint.Should().Be(true);
-            analyzeOptions.Optimize.Should().Be(false);
-            analyzeOptions.Minify.Should().Be(false);
-            analyzeOptions.Inline.Should().Be(false);
+
+            context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(false);
+            context.PrettyPrint.Should().Be(true);
+            context.Optimize.Should().Be(false);
+            context.Minify.Should().Be(false);
+            context.Inline.Should().Be(false);
 
             analyzeOptions = new TestAnalyzeOptions()
             {
@@ -68,11 +86,15 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(
                 FilePersistenceOptions.ForceOverwrite |
                 FilePersistenceOptions.PrettyPrint);
-            analyzeOptions.ForceOverwrite.Should().Be(true);
-            analyzeOptions.PrettyPrint.Should().Be(true);
-            analyzeOptions.Optimize.Should().Be(false);
-            analyzeOptions.Minify.Should().Be(false);
-            analyzeOptions.Inline.Should().Be(false);
+
+            context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(true);
+            context.PrettyPrint.Should().Be(true);
+            context.Optimize.Should().Be(false);
+            context.Minify.Should().Be(false);
+            context.Inline.Should().Be(false);
 
             analyzeOptions = new TestAnalyzeOptions()
             {
@@ -83,11 +105,15 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(
                 FilePersistenceOptions.Optimize |
                 FilePersistenceOptions.PrettyPrint);
-            analyzeOptions.ForceOverwrite.Should().Be(false);
-            analyzeOptions.PrettyPrint.Should().Be(true);
-            analyzeOptions.Optimize.Should().Be(true);
-            analyzeOptions.Minify.Should().Be(false);
-            analyzeOptions.Inline.Should().Be(false);
+
+            context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(false);
+            context.PrettyPrint.Should().Be(true);
+            context.Optimize.Should().Be(true);
+            context.Minify.Should().Be(false);
+            context.Inline.Should().Be(false);
 
             analyzeOptions = new TestAnalyzeOptions()
             {
@@ -98,11 +124,15 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(
                 FilePersistenceOptions.Inline |
                 FilePersistenceOptions.Minify);
-            analyzeOptions.ForceOverwrite.Should().Be(false);
-            analyzeOptions.PrettyPrint.Should().Be(false);
-            analyzeOptions.Optimize.Should().Be(false);
-            analyzeOptions.Minify.Should().Be(true);
-            analyzeOptions.Inline.Should().Be(true);
+
+            context = null;
+            command.InitializeContextFromOptions(analyzeOptions, ref context);
+
+            context.ForceOverwrite.Should().Be(false);
+            context.PrettyPrint.Should().Be(false);
+            context.Optimize.Should().Be(false);
+            context.Minify.Should().Be(true);
+            context.Inline.Should().Be(true);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -507,11 +507,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var sb = new StringBuilder();
 
+            var fileRegionsCache = new FileRegionsCache();
+            for (int i = 0; i < 6; i++)
+            {
+                fileRegionsCache.GetHashData(new Uri(@$"file:///c:/file{i}.cpp"), Guid.NewGuid().ToString());
+            }
+
             using (var textWriter = new StringWriter(sb))
             {
                 using (var sarifLogger = new SarifLogger(textWriter,
                                                          analysisTargets: null,
-                                                         dataToInsert: OptionallyEmittedData.None,
+                                                         dataToInsert: OptionallyEmittedData.Hashes,
+                                                         fileRegionsCache: fileRegionsCache,
                                                          invocationTokensToRedact: null,
                                                          invocationPropertiesToLog: null,
                                                          levels: BaseLogger.ErrorWarning,
@@ -1083,13 +1090,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         public void SarifLogger_ShouldWriteToArtifactsIfNotificationHasLocation()
         {
             const string filePath = @"C:\example\example.sarif";
+            var fileRegionsCache = new FileRegionsCache();
+            fileRegionsCache.GetHashData(new Uri(filePath), Guid.NewGuid().ToString());
 
             var sb = new StringBuilder();
 
             using (var writer = new StringWriter(sb))
             using (var sarifLogger = new SarifLogger(writer,
-                                                     levels: BaseLogger.ErrorWarning,
-                                                     kinds: BaseLogger.Fail))
+                                                     fileRegionsCache: fileRegionsCache,
+                                                     dataToInsert: OptionallyEmittedData.Hashes))
             {
                 var emptyNotification = new Notification();
 

--- a/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
+++ b/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 {
     public static class TestUtilitiesExtensions
     {
-        public static void ValidateCommandExecution(this TestAnalysisContext context, int result)
+        public static void ValidateCommandExecution(this IAnalysisContext context, int result)
         {
             // This method provides validation of execution success for happy path runs, 
             // i.e., where we don't expect to see anything unusual. The validation is


### PR DESCRIPTION
* BRK: All `AnalyzeOptionsBase` bool arguments are now `bool?` (to allow override in configuration XML. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* BRK: `SarifLogger` no longer populates artifact data if locations only contain URI data. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* BRK: Rename `RuntimeConditions.ExceptionCreatingLogFile` to ``RuntimeConditions.ExceptionCreatingOutputFile`. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* BRK: Rename `Errors.LogExceptionCreatingLogFile` to `Errors.LogExceptionCreatingOutputFile` to reflect its general purpose. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* NEW: Add `DefaultTraces.ResultsSummary` property that drives naive results summary in console logger via `ResultsSummaryLogger`. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* NEW: Prove `AnalyzeContextBase.Inline` helper. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
* BUG: Raise `ArgumentNullException` on passing null `text` argument to `HashUtilities.ComputeHashesForText`. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)