### PR TITLE
Remove options from per-target context creation.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -11,9 +11,12 @@
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BRK: Eliminate proactive hashing of artifacts in `SarifLogger` constructor when `OptionallyEmittedData.Hashes` is specified. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* BUG: Eliminate erroneous `Posted log file successfully` message when context `PostUri` is non-null but empty. [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
+* BUG: Resolves `IOException` raised by calling `FileSystem.ReadAllText` on file locked for write (but not read). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * BUG: Generate `IAnalysisLogger.AnalyzingTarget` callbacks from `MulthreadedAnalyzeCommandBase`. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BUG: Persist `fileRegionsCache` parameter in `SarifLogger` to support retrieving hash data. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BUG: Allow override of `FailureLevels` and `ResultKinds` in context objects. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* NEW: Add `MemoryStreamSarifLogger` (for in-memory SARIF generation). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * NEW: Add `AnalyzeContext.VersionControlProvenance` property. [#2646](https://github.com/microsoft/sarif-sdk/pull/2646)
 * NEW: Add `DefaultTraces.ResultsSummary` property that drives naive results summary in console logger. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)
 * NEW: Prove `AnalyzeContextBase.Inline` helper. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
-            if (globalContext.PostUri == null) { return; }
+            if (string.IsNullOrEmpty(globalContext.PostUri)) { return; }
 
             try
             {

--- a/src/Sarif.Multitool.Library/ValidateCommand.cs
+++ b/src/Sarif.Multitool.Library/ValidateCommand.cs
@@ -43,21 +43,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
         }
 
-        protected override SarifValidationContext CreateContext(ValidateOptions options,
-                                                                IAnalysisLogger logger,
-                                                                RuntimeConditions runtimeErrors,
-                                                                IFileSystem fileSystem,
-                                                                PropertiesDictionary policy = null)
+        protected override SarifValidationContext CreateScanTargetContext(SarifValidationContext globalContext)
         {
-            SarifValidationContext context = base.CreateContext(options, logger, runtimeErrors, fileSystem, policy);
+            SarifValidationContext scanTargetContext = base.CreateScanTargetContext(globalContext);
 
-            if (options != null)
-            {
-                context.SchemaFilePath = options.SchemaFilePath;
-                context.UpdateInputsToCurrentSarif = options.UpdateInputsToCurrentSarif;
-            }
-
-            return context;
+            scanTargetContext.SchemaFilePath = globalContext.SchemaFilePath;
+            scanTargetContext.UpdateInputsToCurrentSarif = globalContext.UpdateInputsToCurrentSarif;
+            return scanTargetContext;
         }
 
         protected override void AnalyzeTarget(SarifValidationContext context,

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     exception: null,
                     persistExceptionStack: false,
                     messageFormat: null,
-                    fileName));
+                    Path.GetFullPath(fileName)));
         }
 
         public static void LogMissingCommandlineArgument(IAnalysisContext context, string missing, string required)

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -198,7 +198,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </returns>
         public string FileReadAllText(string path)
         {
-            return File.ReadAllText(path);
+            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var textReader = new StreamReader(fileStream);
+            return textReader.ReadToEnd();
         }
 
         /// <summary>

--- a/src/Sarif/Writers/MemoryStreamSarifLogger.cs
+++ b/src/Sarif/Writers/MemoryStreamSarifLogger.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Sarif.Writers
+{
+    internal class MemoryStreamSarifLogger : SarifLogger
+    {
+        protected StreamWriter writer;
+        protected bool disposed;
+
+        public MemoryStreamSarifLogger(FilePersistenceOptions logFilePersistenceOptions = FilePersistenceOptions.PrettyPrint,
+                                       OptionallyEmittedData dataToInsert = OptionallyEmittedData.None,
+                                       OptionallyEmittedData dataToRemove = OptionallyEmittedData.None,
+                                       Run run = null,
+                                       IEnumerable<string> analysisTargets = null,
+                                       IEnumerable<string> invocationTokensToRedact = null,
+                                       IEnumerable<string> invocationPropertiesToLog = null,
+                                       string defaultFileEncoding = null,
+                                       FailureLevelSet levels = null,
+                                       ResultKindSet kinds = null,
+                                       IEnumerable<string> insertProperties = null) : this(new StreamWriter(new MemoryStream()),
+                                                                                           logFilePersistenceOptions,
+                                                                                           dataToInsert,
+                                                                                           dataToRemove,
+                                                                                           run,
+                                                                                           analysisTargets,
+                                                                                           invocationTokensToRedact,
+                                                                                           invocationPropertiesToLog,
+                                                                                           defaultFileEncoding,
+                                                                                           levels,
+                                                                                           kinds,
+                                                                                           insertProperties)
+        {
+        }
+
+        internal MemoryStreamSarifLogger(StreamWriter writer,
+                                         FilePersistenceOptions logFilePersistenceOptions = FilePersistenceOptions.PrettyPrint,
+                                         OptionallyEmittedData dataToInsert = OptionallyEmittedData.None,
+                                         OptionallyEmittedData dataToRemove = OptionallyEmittedData.None,
+                                         Run run = null,
+                                         IEnumerable<string> analysisTargets = null,
+                                         IEnumerable<string> invocationTokensToRedact = null,
+                                         IEnumerable<string> invocationPropertiesToLog = null,
+                                         string defaultFileEncoding = null,
+                                         FailureLevelSet levels = null,
+                                         ResultKindSet kinds = null,
+                                         IEnumerable<string> insertProperties = null) : base(writer,
+                                                                                             logFilePersistenceOptions,
+                                                                                             dataToInsert,
+                                                                                             dataToRemove,
+                                                                                             run,
+                                                                                             analysisTargets,
+                                                                                             invocationTokensToRedact,
+                                                                                             invocationPropertiesToLog,
+                                                                                             defaultFileEncoding,
+                                                                                             closeWriterOnDispose: false,
+                                                                                             levels,
+                                                                                             kinds,
+                                                                                             insertProperties)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+
+            this.writer = writer;
+            this.writer.AutoFlush = true;
+        }
+
+        public SarifLog ToSarifLog()
+        {
+            if (!this.disposed)
+            {
+                this.Dispose();
+            }
+
+            this.writer.BaseStream.Position = 0;
+
+            SarifLog log = SarifLog.Load(this.writer.BaseStream);
+            return log;
+        }
+
+        public override void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            base.Dispose();
+            this.writer.Flush();
+
+            this.disposed = true;
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
@@ -35,7 +35,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(FilePersistenceOptions.None);
 
             TestAnalysisContext context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(false);
             context.PrettyPrint.Should().Be(true);
@@ -51,7 +51,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(FilePersistenceOptions.Minify);
 
             context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(false);
             context.PrettyPrint.Should().Be(false);
@@ -69,7 +69,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             loggingOptions.Should().Be(FilePersistenceOptions.PrettyPrint);
 
             context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(false);
             context.PrettyPrint.Should().Be(true);
@@ -88,7 +88,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
                 FilePersistenceOptions.PrettyPrint);
 
             context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(true);
             context.PrettyPrint.Should().Be(true);
@@ -107,7 +107,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
                 FilePersistenceOptions.PrettyPrint);
 
             context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(false);
             context.PrettyPrint.Should().Be(true);
@@ -126,7 +126,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
                 FilePersistenceOptions.Minify);
 
             context = null;
-            command.InitializeContextFromOptions(analyzeOptions, ref context);
+            command.InitializeGlobalContextFromOptions(analyzeOptions, ref context);
 
             context.ForceOverwrite.Should().Be(false);
             context.PrettyPrint.Should().Be(false);

--- a/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
+++ b/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
@@ -16,12 +16,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             TestRule.s_testRuleBehaviors = 0;
         }
 
-        public override TestAnalysisContext InitializeContextFromOptions(TestAnalyzeOptions options, ref TestAnalysisContext context)
+        public override TestAnalysisContext InitializeGlobalContextFromOptions(TestAnalyzeOptions options, ref TestAnalysisContext context)
         {
             context ??= new TestAnalysisContext();
             context.Policy ??= new PropertiesDictionary();
 
-            context = base.InitializeContextFromOptions(options, ref context);
+            context = base.InitializeGlobalContextFromOptions(options, ref context);
 
             if (options.TestRuleBehaviors != null)
             {
@@ -37,18 +37,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             return context;
         }
 
-        protected override TestAnalysisContext CreateContext(TestAnalyzeOptions options, IAnalysisLogger logger, RuntimeConditions runtimeErrors, IFileSystem fileSystem = null, PropertiesDictionary policy = null)
+        protected override TestAnalysisContext CreateScanTargetContext(TestAnalysisContext globalContext)
         {
-            TestAnalysisContext context = base.CreateContext(options, logger, runtimeErrors, fileSystem, policy);
-            TestRuleBehaviors behaviors = context.Policy.GetProperty(TestRule.Behaviors);
-            context.IsValidAnalysisTarget = !behaviors.HasFlag(TestRuleBehaviors.RegardAnalysisTargetAsInvalid);
+            globalContext = base.CreateScanTargetContext(globalContext);
+            TestRuleBehaviors behaviors = globalContext.Policy.GetProperty(TestRule.Behaviors);
+            globalContext.IsValidAnalysisTarget = !behaviors.HasFlag(TestRuleBehaviors.RegardAnalysisTargetAsInvalid);
 
-            context.RuntimeExceptions =
+            globalContext.RuntimeExceptions =
                 behaviors.HasFlag(TestRuleBehaviors.RegardAnalysisTargetAsCorrupted)
                ? new List<Exception>(new[] { new InvalidOperationException() })
                : null;
 
-            return context;
+            return globalContext;
         }
 
         protected override void ValidateOptions(TestAnalyzeOptions options, TestAnalysisContext context)

--- a/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
+++ b/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 using FluentAssertions;
 


### PR DESCRIPTION
* BUG: Eliminate erroneous `Posted log file successfully` message when context `PostUri` is non-null but empty. [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
* BUG: Resolves `IOException` raised by calling `FileSystem.ReadAllText` on file locked for write (but not read). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
* NEW: `MultithreadedAnalyzeCommandBase.Tool` is now public to support in-memory analysis (and logging) of targets. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)

