### PR TITLE
File regions cache for notifications

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -11,7 +11,7 @@
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BRK: Eliminate proactive hashing of artifacts in `SarifLogger` constructor when `OptionallyEmittedData.Hashes` is specified. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
-* BUG: Eliminate `NullReferenceException` in `HashUtilities.ComputeHashesForText` when processing a tool notification in a scan target with no results previously fired.
+* BUG: Eliminate `NullReferenceException` in `HashUtilities.ComputeHashesForText` when processing a tool notification in a scan target with no results previously fired. [#2657](https://github.com/microsoft/sarif-sdk/pull/2657)
 * BUG: Eliminate erroneous `Posted log file successfully` message when context `PostUri` is non-null but empty. [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * BUG: Resolves `IOException` raised by calling `FileSystem.ReadAllText` on file locked for write (but not read). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * BUG: Correct `toolComponent.language` regex in JSON schema. [#2653]https://github.com/microsoft/sarif-sdk/pull/2653

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -11,6 +11,7 @@
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `CompuateHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BRK: Eliminate proactive hashing of artifacts in `SarifLogger` constructor when `OptionallyEmittedData.Hashes` is specified. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* BUG: Eliminate `NullReferenceException` in `HashUtilities.ComputeHashesForText` when processing a tool notification in a scan target with no results previously fired.
 * BUG: Eliminate erroneous `Posted log file successfully` message when context `PostUri` is non-null but empty. [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * BUG: Resolves `IOException` raised by calling `FileSystem.ReadAllText` on file locked for write (but not read). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * BUG: Correct `toolComponent.language` regex in JSON schema. [#2653]https://github.com/microsoft/sarif-sdk/pull/2653

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -484,8 +484,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             IEnumeratedArtifact artifact = globalContext.CurrentTarget;
 
             globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
-            globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget.Uri,
-                                                                 globalContext.CurrentTarget.Contents);
+            globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget?.Uri,
+                                                                 globalContext.CurrentTarget?.Contents);
 
             if (results?.Count > 0)
             {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -478,6 +478,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             globalContext.CancellationToken.ThrowIfCancellationRequested();
             IEnumeratedArtifact artifact = globalContext.CurrentTarget;
 
+            globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
+            globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget.Uri,
+                                                                 globalContext.CurrentTarget.Contents);
+
             if (results?.Count > 0)
             {
                 foreach (KeyValuePair<ReportingDescriptor, IList<Tuple<Result, int?>>> kv in results)
@@ -495,7 +499,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                             currentResult = clonedResult;
                         }
-                        globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache;
                         globalContext.Logger.Log(kv.Key, currentResult, tuple.Item2);
                     }
                 }
@@ -524,7 +527,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                     globalContext.Logger.LogConfigurationNotification(currentNotification);
                 }
-
             }
 
             globalContext.Logger.TargetAnalyzed(globalContext);

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -483,12 +483,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             globalContext.CancellationToken.ThrowIfCancellationRequested();
             IEnumeratedArtifact artifact = globalContext.CurrentTarget;
 
-            globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
-            globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget?.Uri,
-                                                                 globalContext.CurrentTarget?.Contents);
-
             if (results?.Count > 0)
             {
+                globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
+                globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget?.Uri,
+                                                                     globalContext.CurrentTarget?.Contents);
+
                 foreach (KeyValuePair<ReportingDescriptor, IList<Tuple<Result, int?>>> kv in results)
                 {
                     globalContext.CancellationToken.ThrowIfCancellationRequested();
@@ -511,6 +511,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (cachingLogger.ToolNotifications != null)
             {
+                globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
+                globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget?.Uri,
+                                                                     globalContext.CurrentTarget?.Contents);
+
                 foreach (Tuple<Notification, ReportingDescriptor> tuple in cachingLogger.ToolNotifications)
                 {
                     globalContext.Logger.LogToolNotification(tuple.Item1, tuple.Item2);
@@ -519,6 +523,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (cachingLogger.ConfigurationNotifications != null)
             {
+                globalContext.Logger.FileRegionsCache = cachingLogger.FileRegionsCache ?? new FileRegionsCache();
+                globalContext.Logger.FileRegionsCache.SetTextForFile(globalContext.CurrentTarget?.Uri,
+                                                                     globalContext.CurrentTarget?.Contents);
+
                 foreach (Notification notification in cachingLogger.ConfigurationNotifications)
                 {
                     Notification currentNotification = notification;

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (Stream == null && this.contents == null)
             {
                 // TBD we actually have no validation URI is non-null yet.
-                contents = Uri!.IsFile
+                contents = Uri.IsAbsoluteUri && Uri!.IsFile
                     ? FileSystem.FileReadAllText(Uri.LocalPath)
                     : null;
 

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -447,5 +447,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             //Debug.Assert(condition);
         }
+
+        internal void SetTextForFile(Uri uri, string contents)
+        {
+            string path = uri.GetFilePath();
+            _fileTextCache[path] = contents;
+        }
     }
 }

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -450,6 +450,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         internal void SetTextForFile(Uri uri, string contents)
         {
+            if (uri == null) { return; }
             string path = uri.GetFilePath();
             _fileTextCache[path] = contents;
         }

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 var context = new SarifValidationContext { FileSystem = mockFileSystem.Object };
                 int returnCode = validateCommand.Run(validateOptions, ref context);
-                context.RuntimeExceptions.Should().BeNull();
+                context.RuntimeExceptions?[0].ToString().Should().BeNull();
                 (context.RuntimeErrors & ~RuntimeConditions.Nonfatal).Should().Be(0);
                 returnCode.Should().Be(0);
             }


### PR DESCRIPTION
BUG: Eliminate `NullReferenceException` in `HashUtilities.ComputeHashesForText` when processing a tool notification in a scan target with no results previously fired.

This bug identified in (and fully tested by) the sarif pattern matcher tool. There is clearly more testing/hardening we can do with the new pipeline model.

@HulonJenkins 