### PR TITLE
Reauthor runtime errors.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.2.0** UNRELEASED
+* BRK: `RuntimeConditions` now of type `long` to permit more flag values. Many literal values have changed for individual members. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
+* BRK: `RuntimeConditions.OneOrMoreFilesSkippedDueToSize` renamed to `OneOrMoreFilesSkippedDueToExceedingSizeLimits`. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
+* BRK: `Notes.LogFileSkippedDueToSize` renamed to `LogFileExceedingSizeLimitSkipped`. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
 * BRK: Command-line argument `automationGuid` renamed to `automation-guid`. [#2647](https://github.com/microsoft/sarif-sdk/pull/2647)
 * BRK: Command-line argument `automationId` renamed to `automation-id`. [#2647](https://github.com/microsoft/sarif-sdk/pull/2647)
 * BRK: Update `AnalyzeOptionsBase` `Quiet`, `Recurse`, `LogEnvironment`, and `RichReturnCode` properties to bool? type. [#2644](https://github.com/microsoft/sarif-sdk/pull/2644)
@@ -11,6 +14,7 @@
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `ComputeHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BRK: Eliminate proactive hashing of artifacts in `SarifLogger` constructor when `OptionallyEmittedData.Hashes` is specified. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* BUG: Properly report skipping empty files (rather than reporting file was skipped due to exceeding size limits). [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
 * BUG: Update user messages and code comments that refer to `--force` (replaced by `--log ForceOverwrite`). [#2656](https://github.com/microsoft/sarif-sdk/pull/2656)
 * BUG: Handle return code 422 `UnprocessableEntity` when validating that log file POST endpoint is available. [#2656](https://github.com/microsoft/sarif-sdk/pull/2656)
 * BUG: Eliminate erroneous `Posted log file successfully` message when context `PostUri` is non-null but empty. [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
@@ -19,6 +23,8 @@
 * BUG: Generate `IAnalysisLogger.AnalyzingTarget` callbacks from `MulthreadedAnalyzeCommandBase`. [#2637](https://github.com/microsoft/sarif-sdk/pull/2637)
 * BUG: Persist `fileRegionsCache` parameter in `SarifLogger` to support retrieving hash data. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BUG: Allow override of `FailureLevels` and `ResultKinds` in context objects. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* NEW: Provide convenience enumerator at the `SarifLog` level that iterates over all results in all runs in the log. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
+* NEW: Provide `Notes.LogEmptyFileSkipped` helper for reporting zero-byte files skipped at scan time. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
 * NEW: Add `MemoryStreamSarifLogger` (for in-memory SARIF generation). [#2655](https://github.com/microsoft/sarif-sdk/pull/2655)
 * NEW: Add `AnalyzeContext.VersionControlProvenance` property. [#2646](https://github.com/microsoft/sarif-sdk/pull/2646)
 * NEW: Add `DefaultTraces.ResultsSummary` property that drives naive results summary in console logger. [#2643](https://github.com/microsoft/sarif-sdk/pull/2643)

--- a/src/Sarif.Driver/Sdk/ExitApplicationException.cs
+++ b/src/Sarif.Driver/Sdk/ExitApplicationException.cs
@@ -12,5 +12,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public ExitApplicationException(string message, Exception innerException) : base(message, innerException) { }
 
         public T ExitReason { get; set; }
+
+        public override string ToString()
+        {
+            return $"{ExitReason}: {base.ToString()}";
+        }
     }
 }

--- a/src/Sarif/ArtifactProvider.cs
+++ b/src/Sarif/ArtifactProvider.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 
-namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
+namespace Microsoft.CodeAnalysis.Sarif
 {
     public class ArtifactProvider : IArtifactProvider
     {

--- a/src/Sarif/RuntimeConditions.cs
+++ b/src/Sarif/RuntimeConditions.cs
@@ -11,51 +11,98 @@ namespace Microsoft.CodeAnalysis.Sarif
     // code paths. These conditions are a combination of fatal
     // and non-fatal circumstances
     [Flags]
-    public enum RuntimeConditions : uint
+    public enum RuntimeConditions : long
     {
         None = 0,
 
-        // Fatal conditions
+        // Fatal conditions that relate to configuration and
+        // cause scan to error out before analysis occurs.
         // InvalidCommandLineOption is a useful bit to
         // use as value 0x1. This allows for a consistent
         // return value in cases where a command-line argument
         // for --rich-return-code can't be detected because it
         // fails to parse.
-        InvalidCommandLineOption = 0x1,
-        ExceptionInSkimmerInitialize = 0x2,
-        ExceptionRaisedInSkimmerCanAnalyze = 0x4,
-        ExceptionInSkimmerAnalyze = 0x8,
-        ExceptionCreatingOutputFile = 0x10,
-        ExceptionLoadingPdb = 0x20,
-        ExceptionInEngine = 0x40,
-        ExceptionLoadingTargetFile = 0x80,
-        ExceptionProcessingCommandline = 0x100,
-        ExceptionLoadingAnalysisPlugin = 0x200,
-        NoRulesLoaded = 0x400,
-        NoValidAnalysisTargets = 0x800,
-        RuleMissingRequiredConfiguration = 0x1000,
-        TargetParseError = 0x2000,
-        MissingFile = 0x4000,
-        ExceptionAccessingFile = 0x8000,
-        ExceptionInstantiatingSkimmers = 0x10000,
-        FileAlreadyExists = 0x20000,
-        ExceptionProcessingBaseline = 0x40000,
-        ExceptionPostingLogFile = 0x80000,
-        OneOrMoreRulesAreIncompatible = 0x100000,
-        AnalysisCanceled = 0x200000,
-        AnalysisTimedOut = 0x400000,
+        InvalidCommandLineOption = 1L << 0,
+        RuleMissingRequiredConfiguration = 1L << 1,
+        OneOrMoreRulesAreIncompatible = 1L << 2,
+        NoValidAnalysisTargets = 1L << 3,
+        FileAlreadyExists = 1L << 4,
+        NoRulesLoaded = 1L << 5,
+        MissingFile = 1L << 6,
+
+        FatalReserved0 = 1L << 7,
+        FatalReserved1 = 1L << 8,
+        FatalReserved2 = 1L << 9,
+        FatalReserved3 = 1L << 10,
+        FatalReserved4 = 1L << 11,
+
+        // Fatal conditions that occur during analysis.
+        ExceptionRaisedInSkimmerCanAnalyze = 1L << 12,
+        ExceptionInstantiatingSkimmers = 1L << 13,
+        ExceptionLoadingAnalysisPlugin = 1L << 14,
+        ExceptionProcessingCommandline = 1L << 15,
+        ExceptionInSkimmerInitialize = 1L << 16,
+        ExceptionProcessingBaseline = 1L << 17,
+        ExceptionCreatingOutputFile = 1L << 18,
+        ExceptionLoadingTargetFile = 1L << 19,
+        ExceptionInSkimmerAnalyze = 1L << 20,
+        ExceptionPostingLogFile = 1L << 21,
+        ExceptionAccessingFile = 1L << 22,
+        ExceptionLoadingPdb = 1L << 23,
+        ExceptionInEngine = 1L << 24,
+        TargetParseError = 1L << 25,
+        AnalysisCanceled = 1L << 26,
+        AnalysisTimedOut = 1L << 27,
+
+        FatalReserved5 = 1L << 28,
+        FatalReserved6 = 1L << 29,
+        FatalReserved7 = 1L << 30,
+        FatalReserved8 = 1L << 31,
+
+        Fatal = uint.MaxValue,
+        UnassignedFatal = FatalReserved0 | FatalReserved1 | FatalReserved3 | FatalReserved4 | FatalReserved5 |
+                          FatalReserved6 | FatalReserved7 | FatalReserved7 | FatalReserved8,
 
         // Non-fatal conditions
-        UnassignedNonfatal = 0x00C00000,
-        OneOrMoreFilesSkippedDueToSize = 0x01000000,
-        RuleWasExplicitlyDisabled = 0x02000000,
-        RuleCannotRunOnPlatform = 0x04000000,
-        RuleNotApplicableToTarget = 0x08000000,
-        TargetNotValidToAnalyze = 0x10000000,
-        OneOrMoreWarningsFired = 0x20000000,
-        OneOrMoreErrorsFired = 0x40000000,
-        ObsoleteOption = 0x80000000,
+        OneOrMoreFilesSkippedDueToExceedingSizeLimits = 1L << 32,
+        OneOrMoreEmptyFilesSkipped = 1L << 33,
+        RuleWasExplicitlyDisabled = 1L << 34,
+        RuleNotApplicableToTarget = 1L << 35,
+        RuleCannotRunOnPlatform = 1L << 36,
+        TargetNotValidToAnalyze = 1L << 37,
+        OneOrMoreWarningsFired = 1L << 38,
+        OneOrMoreErrorsFired = 1L << 39,
+        ObsoleteOption = 1L << 40,
 
-        Nonfatal = 0x7FC00000,
+        NonfatalReserved0 = 1L << 41,
+        NonfatalReserved1 = 1L << 42,
+        NonfatalReserved2 = 1L << 43,
+        NonfatalReserved3 = 1L << 44,
+        NonfatalReserved4 = 1L << 45,
+        NonfatalReserved5 = 1L << 46,
+        NonfatalReserved6 = 1L << 47,
+        NonfatalReserved7 = 1L << 48,
+        NonfatalReserved8 = 1L << 49,
+        NonfatalReserved9 = 1L << 50,
+        NonfatalReserved10 = 1L << 51,
+        NonfatalReserved11 = 1L << 52,
+        NonfatalReserved12 = 1L << 53,
+        NonfatalReserved13 = 1L << 54,
+        NonfatalReserved14 = 1L << 55,
+        NonfatalReserved15 = 1L << 56,
+        NonfatalReserved16 = 1L << 57,
+        NonfatalReserved17 = 1L << 58,
+        NonfatalReserved18 = 1L << 59,
+        NonfatalReserved19 = 1L << 60,
+        NonfatalReserved20 = 1L << 61,
+        NonfatalReserved21 = 1L << 62,
+
+        Nonfatal = long.MaxValue ^ uint.MaxValue,
+        UnassignedNonfatal =
+            NonfatalReserved0 | NonfatalReserved1 | NonfatalReserved2 | NonfatalReserved3 | NonfatalReserved4 |
+            NonfatalReserved5 | NonfatalReserved6 | NonfatalReserved7 | NonfatalReserved8 | NonfatalReserved9 |
+            NonfatalReserved10 | NonfatalReserved11 | NonfatalReserved12 | NonfatalReserved13 | NonfatalReserved14 |
+            NonfatalReserved15 | NonfatalReserved16 | NonfatalReserved17 | NonfatalReserved18 | NonfatalReserved19 |
+            NonfatalReserved20 | NonfatalReserved21,
     }
 }

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -432,11 +432,20 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; was skipped because it is empty (zero bytes in size)..
+        /// </summary>
+        public static string MSG002_EmptyFileSkipped {
+            get {
+                return ResourceManager.GetString("MSG002.EmptyFileSkipped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was not analyzed as its size ({1} kilobytes) exceeds the currently configured threshold ({2} kilobytes)..
         /// </summary>
-        public static string MSG002_FileSkippedDueToSize {
+        public static string MSG002_FileExceedingSizeLimitSkipped {
             get {
-                return ResourceManager.GetString("MSG002.FileSkippedDueToSize", resourceCulture);
+                return ResourceManager.GetString("MSG002.FileExceedingSizeLimitSkipped", resourceCulture);
             }
         }
         
@@ -585,11 +594,11 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} file(s) were skipped for analysis due to exceeding size limits (currently configured as {1} KB). The &apos;max-file-size-in-kb&apos; command-line argument can be used to increase this threshold..
+        ///   Looks up a localized string similar to {0} file(s) were skipped for analysis due to exceeding size limit (currently configured as {1} KB). The &apos;max-file-size-in-kb&apos; command-line argument can be used to increase this threshold..
         /// </summary>
-        public static string WRN997_OneOrMoreFilesSkippedDueToSize {
+        public static string WRN997_OneOrMoreFilesSkippedDueToExceedingSizeLimit {
             get {
-                return ResourceManager.GetString("WRN997_OneOrMoreFilesSkippedDueToSize", resourceCulture);
+                return ResourceManager.GetString("WRN997_OneOrMoreFilesSkippedDueToExceedingSizeLimit", resourceCulture);
             }
         }
         

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -281,10 +281,10 @@ You can also refer to properties in the result's property bag with 'properties.&
   <data name="ERR997_NoPluginsConfigured" xml:space="preserve">
     <value>No plugins were configured or successfully located and so no rules were loaded.</value>
   </data>
-  <data name="WRN997_OneOrMoreFilesSkippedDueToSize" xml:space="preserve">
-    <value>{0} file(s) were skipped for analysis due to exceeding size limits (currently configured as {1} KB). The 'max-file-size-in-kb' command-line argument can be used to increase this threshold.</value>
+  <data name="WRN997_OneOrMoreFilesSkippedDueToExceedingSizeLimit" xml:space="preserve">
+    <value>{0} file(s) were skipped for analysis due to exceeding size limit (currently configured as {1} KB). The 'max-file-size-in-kb' command-line argument can be used to increase this threshold.</value>
   </data>
-  <data name="MSG002.FileSkippedDueToSize" xml:space="preserve">
+  <data name="MSG002.FileExceedingSizeLimitSkipped" xml:space="preserve">
     <value>'{0}' was not analyzed as its size ({1} kilobytes) exceeds the currently configured threshold ({2} kilobytes).</value>
   </data>
   <data name="ERR997_IncompatibleRulesDetected" xml:space="preserve">
@@ -301,5 +301,8 @@ You can also refer to properties in the result's property bag with 'properties.&
   </data>
   <data name="MSG001_TargetAnalyzed" xml:space="preserve">
     <value>Completed '{0}'.</value>
+  </data>
+  <data name="MSG002.EmptyFileSkipped" xml:space="preserve">
+    <value>'{0}' was skipped because it is empty (zero bytes in size).</value>
   </data>
 </root>

--- a/src/Sarif/Warnings.cs
+++ b/src/Sarif/Warnings.cs
@@ -11,31 +11,31 @@ namespace Microsoft.CodeAnalysis.Sarif
     {
         // Conditions that may indicate an issue with command-line configuration.
         public const string Wrn997_InvalidTarget = "WRN997.InvalidTarget";
-        public const string Wrn997_OneOrMoreFilesSkippedDueToSize = "WRN997.OneOrMoreFilesSkippedDueToSize";
-
         public const string Wrn997_ObsoleteOption = "WRN997.ObsoleteOption";
         public const string Wrn997_ObsoleteOptionWithReplacement = "WRN997.ObsoleteOptionWithReplacement";
+        public const string Wrn997_OneOrMoreFilesSkippedDueToExceedingSizeLimits = "WRN997.OneOrMoreFilesSkippedDueToExceedingSizeLimit";
 
         // (Non-catastrophic) conditions that result in rules disabling themselves.
         public const string Wrn998_UnsupportedPlatform = "WRN998.UnsupportedPlatform";
 
-        // Warnings around dangerous
+        // Warnings around conditions of potential concern. An explicitly disabled rule,
+        // for example, might prevent an analysis run from meeting compliance goals.
         public const string Wrn999_RuleExplicitlyDisabled = "WRN999.RuleExplicitlyDisabled";
 
-        public static void LogOneOrMoreFilesSkippedDueToSize(IAnalysisContext context, uint skippedFilesCount)
+        public static void LogOneOrMoreFilesSkippedDueToExceedingSizeLimit(IAnalysisContext context, long skippedFilesCount)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            // {0} file(s)s were skipped for analysis due to exceeding size limits
+            // {0} file(s)s were skipped for analysis due to exceeding size limit
             // (currently configured as {1} kilobytes). The 'max-file-size-in-kb'
             // command-line argument can be used to increase this threshold.
             context.Logger.LogConfigurationNotification(
                 Errors.CreateNotification(
                     context.CurrentTarget?.Uri,
-                    Wrn997_OneOrMoreFilesSkippedDueToSize,
+                    Wrn997_OneOrMoreFilesSkippedDueToExceedingSizeLimits,
                     ruleId: null,
                     FailureLevel.Warning,
                     exception: null,
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     skippedFilesCount.ToString(),
                     context.MaxFileSizeInKilobytes.ToString()));
 
-            context.RuntimeErrors |= RuntimeConditions.OneOrMoreFilesSkippedDueToSize;
+            context.RuntimeErrors |= RuntimeConditions.OneOrMoreFilesSkippedDueToExceedingSizeLimits;
         }
 
         public static void LogExceptionInvalidTarget(IAnalysisContext context)

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -528,7 +528,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 var validateCommand = new ValidateCommand(mockFileSystem.Object);
 
-                var context = new SarifValidationContext { FileSystem = mockFileSystem.Object };
+                var context = new SarifValidationContext
+                {
+                    FileSystem = mockFileSystem.Object
+                };
+
                 int returnCode = validateCommand.Run(validateOptions, ref context);
                 context.RuntimeExceptions.Should().BeNull();
                 (context.RuntimeErrors & ~RuntimeConditions.Nonfatal).Should().Be(0);

--- a/src/Test.FunctionalTests.Sarif/SarifValidatorTests.cs
+++ b/src/Test.FunctionalTests.Sarif/SarifValidatorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Path.Combine("v2", "ConverterTestData"),
             Path.Combine("v2", "SpecExamples"),
             Path.Combine("v2", "ObsoleteFormats"),
-            Path.Combine("..", "..", "Test.UnitTests.Sarif", "netcoreapp3.1", "TestData")
+            Path.Combine("..", "..", "Test.UnitTests.Sarif", "net6.0", "TestData")
         };
 
         private static IEnumerable<string> s_testCases;

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -12,7 +12,6 @@ using System.Text;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;
-using Microsoft.CodeAnalysis.Sarif.PatternMatcher;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 
 using Moq;

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             {
                 File.Create(Path.GetInvalidFileNameChars()[0].ToString(), 0);
             }
-            catch (ArgumentException exception)
+            catch (IOException exception)
             {
                 IList<Stack> stacks = Stack.CreateStacks(exception).ToList();
 
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             {
                 File.Create(Path.GetInvalidFileNameChars()[0].ToString(), 0);
             }
-            catch (ArgumentException exception)
+            catch (IOException exception)
             {
                 Exception containerException = new InvalidOperationException("test exception", exception);
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             {
                 File.Create(Path.GetInvalidFileNameChars()[0].ToString(), 0);
             }
-            catch (ArgumentException exception)
+            catch (IOException exception)
             {
                 var innerException1 = new InvalidOperationException("Test exception 1.");
                 var innerException2 = new InvalidOperationException("Test exception 2.", exception);

--- a/src/Test.UnitTests.Sarif/NotesTests.cs
+++ b/src/Test.UnitTests.Sarif/NotesTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+using Microsoft.CodeAnalysis.Sarif.Writers;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class NotesTests
+    {
+        [Fact]
+        public void NotesTests_LogEmptyFileSkipped()
+        {
+            using var logger =
+                new MemoryStreamSarifLogger(levels: BaseLogger.ErrorWarningNote,
+                                            kinds: BaseLogger.Fail);
+
+            var oneCharacterFile = new EnumeratedArtifact(FileSystem.Instance)
+            {
+                Uri = new Uri(@"c:\\nonemptyfile.txt"),
+            };
+
+            var emptyFile = new EnumeratedArtifact(FileSystem.Instance)
+            {
+                Uri = new Uri(@"c:\\emptyfile.txt"),
+                SizeInBytes = 0,
+            };
+
+            var context = new TestAnalysisContext()
+            {
+                Logger = logger,
+                TargetsProvider = new ArtifactProvider(FileSystem.Instance)
+                {
+                    Artifacts = new EnumeratedArtifact[] { oneCharacterFile },
+                    Skipped = new[] { emptyFile },
+                },
+                FailureLevels = BaseLogger.ErrorWarningNote,
+                ResultKinds = BaseLogger.Fail,
+            };
+
+            var command = new TestMultithreadedAnalyzeCommand();
+            int result = command.Run(options: null, ref context);
+            context.ValidateCommandExecution(result);
+
+            var log = logger.ToSarifLog();
+            log.Runs.Should().HaveCount(1);
+
+            Run run = log.Runs[0];
+            run.Results.Should().HaveCount(0);
+
+            run.Invocations.Should().HaveCount(1);
+            Invocation invocation = run.Invocations[0];
+            invocation.ToolExecutionNotifications.Should().BeNull();
+
+            // Finally, what we're here for, verify that we received a
+            // notification warning us about the skipped zero-byte file.
+            invocation.ToolConfigurationNotifications.Should().HaveCount(1);
+            Notification notification = invocation.ToolConfigurationNotifications[0];
+            notification.Descriptor.Id.Should().Be(Notes.Msg002_EmptyFileSkipped);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/RuntimeConditionsTests.cs
+++ b/src/Test.UnitTests.Sarif/RuntimeConditionsTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Xunit;
+
+namespace Test.UnitTests.Sarif
+{
+    public class RuntimeConditionsTests
+    {
+        [Fact]
+        public void RuntimeConditions_EnsureFatalConditionsAreReserved()
+        {
+            using var assertionScope = new AssertionScope();
+
+            RuntimeConditions condition;
+
+            // We reserve the first 32 bits of this enum as fatal conditions.
+            for (int i = 0; i < 32; i++)
+            {
+                condition = (RuntimeConditions)(1L << i);
+
+                (condition & RuntimeConditions.Fatal).Should().Be(condition);
+                condition.Fatal().Should().Be(condition);
+
+                (condition & RuntimeConditions.Nonfatal).Should().Be(0);
+                condition.Nonfatal().Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public void RuntimeConditions_EnsureNonfatalConditionsAreReserved()
+        {
+            using var assertionScope = new AssertionScope();
+
+            RuntimeConditions condition;
+
+            // We use the most significant 32 bits of the enum for non-fatal conditions.
+            // We use a long for this enum to make it as .NET friendly as possible.
+            // As a result, the sign bit is not valid for use.
+            for (int i = 32; i < 63; i++)
+            {
+                condition = (RuntimeConditions)(1L << i);
+
+                (condition & RuntimeConditions.Nonfatal).Should().Be(condition);
+                condition.Nonfatal().Should().Be(condition);
+
+                (condition & RuntimeConditions.Fatal).Should().Be(0);
+                condition.Fatal().Should().Be(0);
+            }
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -8,7 +8,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Test.UnitTests.Sarif</RootNamespace>
@@ -298,6 +298,7 @@
     <ProjectReference Include="..\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\Sarif.Converters\Sarif.Converters.csproj" />
+    <ProjectReference Include="..\Test.UnitTests.Sarif.Driver\Test.UnitTests.Sarif.Driver.csproj" />
     <ProjectReference Include="..\Test.Utilities.Sarif\Test.Utilities.Sarif.csproj" />
   </ItemGroup>
 

--- a/src/Test.UnitTests.Sarif/WarningsTests.cs
+++ b/src/Test.UnitTests.Sarif/WarningsTests.cs
@@ -53,14 +53,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             var binaryAnalysisContext = new TestAnalysisContext();
             binaryAnalysisContext.Logger = testLogger;
 
-            Warnings.LogOneOrMoreFilesSkippedDueToSize(binaryAnalysisContext, 1);
+            Warnings.LogOneOrMoreFilesSkippedDueToExceedingSizeLimit(binaryAnalysisContext, 1);
 
             testLogger.Messages.Should().BeNull();
             testLogger.ToolNotifications.Should().BeNull();
             testLogger.ConfigurationNotifications.Count.Should().Be(1);
-            testLogger.ConfigurationNotifications[0].Descriptor.Id.Should().BeEquivalentTo(Warnings.Wrn997_OneOrMoreFilesSkippedDueToSize);
+            testLogger.ConfigurationNotifications[0].Descriptor.Id.Should().BeEquivalentTo(Warnings.Wrn997_OneOrMoreFilesSkippedDueToExceedingSizeLimits);
 
-            binaryAnalysisContext.RuntimeErrors.Should().Be(RuntimeConditions.OneOrMoreFilesSkippedDueToSize);
+            binaryAnalysisContext.RuntimeErrors.Should().Be(RuntimeConditions.OneOrMoreFilesSkippedDueToExceedingSizeLimits);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -845,13 +845,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifLogger_AcceptsOverrideOfDefaultEncoding()
         {
-            const string Utf8 = "UTF-8";
-            const string Utf7 = "UTF-7";
+            const string utf8 = "UTF-8";
+            const string ascii = "ASCII";
 
             // Start off with a run that specifies the default file encoding.
             var run = new Run
             {
-                DefaultEncoding = Utf8
+                DefaultEncoding = utf8
             };
 
             var sb = new StringBuilder();
@@ -861,7 +861,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 // Create a logger that uses that run but specifies a different encoding.
                 using (_ = new SarifLogger(textWriter,
                                            run: run,
-                                           defaultFileEncoding: Utf7,
+                                           defaultFileEncoding: ascii,
                                            levels: BaseLogger.ErrorWarning,
                                            kinds: BaseLogger.Fail))
                 {
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
 
             // The logger accepted the override for default file encoding.
-            sarifLog.Runs[0].DefaultEncoding.Should().Be(Utf7);
+            sarifLog.Runs[0].DefaultEncoding.Should().Be(ascii);
         }
 
         private void LogSimpleResult(SarifLogger sarifLogger)

--- a/src/Test.Utilities.Sarif/HttpMockHelper.cs
+++ b/src/Test.Utilities.Sarif/HttpMockHelper.cs
@@ -20,6 +20,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new StringContent(AnyContentText);
         }
 
+        public static HttpResponseMessage CreateOKResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
         public static readonly HttpResponseMessage OKResponse =
             new HttpResponseMessage(HttpStatusCode.OK);
 

--- a/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
+++ b/src/Test.Utilities.Sarif/TestUtilitiesExtensions.cs
@@ -24,11 +24,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             // For application exist exceptions, e.g., an unhandled exception in a rule,
             // the inner exception has the most useful details.
-            context.RuntimeExceptions?[0].InnerException.Should().BeNull();
-            context.RuntimeExceptions?[0].Should().BeNull();
-
+            context.RuntimeExceptions?[0].InnerException?.ToString().Should().BeNull();
+            context.RuntimeExceptions?[0].ToString().Should().BeNull();
             context.RuntimeErrors.Fatal().Should().Be(0);
-
             result.Should().Be(CommandBase.SUCCESS);
         }
 


### PR DESCRIPTION
* BRK: `RuntimeConditions` now of type `long` to permit more flag values. Many literal values have changed for individual members. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
* BRK: `RuntimeConditions.OneOrMoreFilesSkippedDueToSize` renamed to `OneOrMoreFilesSkippedDueToExceedingSizeLimits`. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
* BUG: Properly report skipping empty files (rather than reporting file was skipped due to exceeding size limits). [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
* NEW: Provide convenience enumerator at the `SarifLog` level that iterates over all results in all runs in the log. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
* NEW: Provide `Notes.LogEmptyFileSkipped` helper for reporting zero-byte files skipped at scan time. [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
