### PR TITLE
File Size enumeration exception

### DIFF
--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -62,9 +62,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 if (sizeInBytes != null) { return sizeInBytes.Value; };
 
-                this.sizeInBytes = Uri!.IsFile
-                    ? (ulong)FileSystem.FileInfoLength(Uri.LocalPath)
-                    : (ulong?)null;
+                if (!File.GetAttributes(Uri.GetFilePath()).HasFlag(FileAttributes.Directory))
+                {
+                    this.sizeInBytes = (ulong)FileSystem.FileInfoLength(Uri.GetFilePath());
+                }
+                else
+                { 
+                    this.sizeInBytes = (ulong?)null; 
+                }
 
                 return this.sizeInBytes;
             }

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -70,7 +70,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="CoyoteRewriting" AfterTargets="AfterBuild">
+  <Target Name="CoyoteRewriting" AfterTargets="AfterBuild" Condition=" '$(OS)' == 'Windows_NT' ">
     <Exec Command="$(ExecCommand)" />
   </Target>
 </Project>


### PR DESCRIPTION
This PR makes the following fixes:

1. `EnumeratedArtifact` class throws an exception while analyzing certain Linux files. An example file path which reproduces the error is `D:/test/file`. The issue arises in the `get_SizeInBytes` method:
```
this.sizeInBytes = Uri!.IsFile
                    ? (ulong)FileSystem.FileInfoLength(Uri.LocalPath)
                    : (ulong?)null;
```
The example file path above is treated as a relative URI, which causes exceptions in `Uri.IsFile` and `Uri.LocalPath`. The change in this PR checks if the path associated with `Uri.GetFilePath()` has the attributes of a file or directory (which is expected work across Windows and Linux). I tested this change by doing an analysis in Linux, and no exceptions are thrown.

2. The post-build task of Coyote binary instrumentation does not work in Linux, since it is a powershell script. This causes a build failure in Linux. This PR adds a condition in the post-build task to perform the rewriting only in Windows.