### PR TITLE
Add "(escape semicolon with backslash in Unix-like OS)"

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -52,13 +52,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             'p',
             "plugin",
             Separator = ';',
-            HelpText = "Path to plugin(s) that should drive analysis for all configured scan targets.")]
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+                       "points to plugin(s) that should drive analysis for all configured scan targets.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
 
         [Option(
             "invocation-properties",
             Separator = ';',
-            HelpText = "Properties of the Invocation object to log. NOTE: StartTime and EndTime are always logged.")]
+            HelpText = "Properties of the Invocation object to log, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS). " +
+                       "NOTE: StartTime and EndTime are always logged.")]
         public IEnumerable<string> InvocationPropertiesToLog { get; set; }
 
         [Option(
@@ -71,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "trace",
             Separator = ';',
             Default = null,
-            HelpText = "Execution traces, expressed as a semicolon-delimited list, that " +
+            HelpText = "Execution traces, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
                        "should be emitted to the console and log file (if appropriate). " +
                        "Valid values: ScanTime.")]
         public IEnumerable<string> Trace
@@ -99,7 +101,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "level",
             Separator = ';',
             Default = null,
-            HelpText = "A semicolon delimited list to filter output of scan results to one or more failure levels. Valid values: Error, Warning and Note.")]
+            HelpText = "Failure levels, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+                       "is used to filter the scan results. Valid values: Error, Warning and Note.")]
         public IEnumerable<FailureLevel> Level
         {
             get => this.level;
@@ -113,7 +116,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "kind",
             Separator = ';',
             Default = null,
-            HelpText = "A semicolon delimited list to filter output to one or more result kinds. Valid values: Fail (for literal scan results), Pass, Review, Open, NotApplicable and Informational.")]
+            HelpText = "Result kinds, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+                       "is used to filter the scan results. Valid values: Fail (for literal scan results), Pass, Review, Open, NotApplicable and Informational.")]
         public IEnumerable<ResultKind> Kind
         {
             get => this.kind;

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "log",
             Separator = ';',
             HelpText =
-            "One or more semicolon-delimited settings for governing output files. Valid values include ForceOverwrite, Inline, PrettyPrint, Minify or Optimize.")]
+            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "for governing output files. Valid values include ForceOverwrite, Inline, PrettyPrint, Minify or Optimize.")]
         public IEnumerable<FilePersistenceOptions> OutputFileOptions
         {
             get => NormalizeFilePersistenceOptions(_filePersistenceOptions);
@@ -56,18 +57,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "insert",
             Separator = ';',
             HelpText =
-            "Optionally present data, expressed as a semicolon-delimited list, that should be inserted into the log file. " +
-            "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, " +
-            "ContextRegionSnippetPartialFingerprints, Guids, VersionControlDetails, and NondeterministicProperties.")]
+            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "that should be inserted into the log file. Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, " +
+            "RegionSnippets, ContextRegionSnippets, ContextRegionSnippetPartialFingerprints, Guids, VersionControlDetails, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToInsert { get; set; }
 
         [Option(
             "remove",
             Separator = ';',
             HelpText =
-            "Optionally present data, expressed as a semicolon-delimited list, that should be not be persisted to or which " +
-            "should be removed from the log file. Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, " +
-            "RegionSnippets, ContextRegionSnippets, Guids, VersionControlDetails, and NondeterministicProperties.")]
+            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "that should be not be persisted to or which should be removed from the log file. Valid values include Hashes, TextFiles, " +
+            "BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, Guids, VersionControlDetails, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToRemove { get; set; }
 
         [Option(
@@ -75,7 +76,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "uriBaseIds",
             Separator = ';',
             HelpText =
-            @"A key + value pair that defines a uriBaseId and its corresponding local file path. E.g., SRC=c:\src;TEST=c:\test")]
+            @"Key + value pairs, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            @"that defines a uriBaseId and its corresponding local file path. E.g., SRC=c:\src;TEST=c:\test")]
         public IEnumerable<string> UriBaseIds { get; set; }
 
         [Option(
@@ -95,9 +97,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "insert-property",
             Separator = ';',
             HelpText =
-            "A semicolon-delimited list of JSON path + property values that should be inserted into the output log. Currently, " +
-            "only paths that point to a version control provenance property bag is supported, e.g., 'runs[0].invocations[1]." +
-            "versionControlProvenance.properties.myProperty=myValue'.")]
+            "JSON path + property values, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            "should be inserted into the output log. Currently, only paths that point to a version control provenance property bag " +
+            "is supported, e.g., 'runs[0].invocations[1].versionControlProvenance.properties.myProperty=myValue'.")]
         public IEnumerable<string> InsertProperties { get; set; }
 
         [Option(

--- a/src/Sarif.Driver/Sdk/ExportConfigurationOptions.cs
+++ b/src/Sarif.Driver/Sdk/ExportConfigurationOptions.cs
@@ -23,7 +23,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             "plugin",
             Separator = ';',
-            HelpText = "Path to plugin that will be invoked to retrieve rule options.")]
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+                       "will be invoked to retrieve rule options.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataOptions.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataOptions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             "plugin",
             Separator = ';',
-            HelpText = "Path to plugin that will be invoked to retrieve rule metadata.")]
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+                       "will be invoked to retrieve rule metadata.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
     }
 }


### PR DESCRIPTION
For Linux, need escape semicolon with backslash, else it will be considered another command.