### PR TITLE
User facing string update: "expressed as a semicolon-delimited list enclosed in double quotes"

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -52,14 +52,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             'p',
             "plugin",
             Separator = ';',
-            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "points to plugin(s) that should drive analysis for all configured scan targets.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
 
         [Option(
             "invocation-properties",
             Separator = ';',
-            HelpText = "Properties of the Invocation object to log, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS). " +
+            HelpText = "Properties of the Invocation object to log, expressed as a semicolon-delimited list enclosed in double quotes. " +
                        "NOTE: StartTime and EndTime are always logged.")]
         public IEnumerable<string> InvocationPropertiesToLog { get; set; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "trace",
             Separator = ';',
             Default = null,
-            HelpText = "Execution traces, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "should be emitted to the console and log file (if appropriate). " +
                        "Valid values: ScanTime.")]
         public IEnumerable<string> Trace
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "level",
             Separator = ';',
             Default = null,
-            HelpText = "Failure levels, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Failure levels, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "is used to filter the scan results. Valid values: Error, Warning and Note.")]
         public IEnumerable<FailureLevel> Level
         {
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "kind",
             Separator = ';',
             Default = null,
-            HelpText = "Result kinds, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Result kinds, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "is used to filter the scan results. Valid values: Fail (for literal scan results), Pass, Review, Open, NotApplicable and Informational.")]
         public IEnumerable<ResultKind> Kind
         {

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "log",
             Separator = ';',
             HelpText =
-            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "Optionally present data, expressed as a semicolon-delimited list enclosed in double quotes, " +
             "for governing output files. Valid values include ForceOverwrite, Inline, PrettyPrint, Minify or Optimize.")]
         public IEnumerable<FilePersistenceOptions> OutputFileOptions
         {
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "insert",
             Separator = ';',
             HelpText =
-            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "Optionally present data, expressed as a semicolon-delimited list enclosed in double quotes, " +
             "that should be inserted into the log file. Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, " +
             "RegionSnippets, ContextRegionSnippets, ContextRegionSnippetPartialFingerprints, Guids, VersionControlDetails, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToInsert { get; set; }
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "remove",
             Separator = ';',
             HelpText =
-            "Optionally present data, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            "Optionally present data, expressed as a semicolon-delimited list enclosed in double quotes, " +
             "that should be not be persisted to or which should be removed from the log file. Valid values include Hashes, TextFiles, " +
             "BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, Guids, VersionControlDetails, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToRemove { get; set; }
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "uriBaseIds",
             Separator = ';',
             HelpText =
-            @"Key + value pairs, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), " +
+            @"Key + value pairs, expressed as a semicolon-delimited list enclosed in double quotes, " +
             @"that defines a uriBaseId and its corresponding local file path. E.g., SRC=c:\src;TEST=c:\test")]
         public IEnumerable<string> UriBaseIds { get; set; }
 
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "insert-property",
             Separator = ';',
             HelpText =
-            "JSON path + property values, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            "JSON path + property values, expressed as a semicolon-delimited list enclosed in double quotes, that " +
             "should be inserted into the output log. Currently, only paths that point to a version control provenance property bag " +
             "is supported, e.g., 'runs[0].invocations[1].versionControlProvenance.properties.myProperty=myValue'.")]
         public IEnumerable<string> InsertProperties { get; set; }

--- a/src/Sarif.Driver/Sdk/ExportConfigurationOptions.cs
+++ b/src/Sarif.Driver/Sdk/ExportConfigurationOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             "plugin",
             Separator = ';',
-            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "will be invoked to retrieve rule options.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
     }

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataOptions.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             "plugin",
             Separator = ';',
-            HelpText = "Plugin paths, expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS), that " +
+            HelpText = "Plugin paths, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "will be invoked to retrieve rule metadata.")]
         public IEnumerable<string> PluginFilePaths { get; set; }
     }

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more targets was skipped entirely as it was determined to be an invalid target for analysis. Include &apos;Note&apos; on an explicit &apos;--level &apos; command-line argument (e.g., &apos;--level Error;Warning;Note&apos;) for more information..
+        ///   Looks up a localized string similar to One or more targets was skipped entirely as it was determined to be an invalid target for analysis. Include &apos;Note&apos; on an explicit &apos;--level &apos; command-line argument (e.g., &apos;--level &quot;Error;Warning;Note&quot;&apos;) for more information..
         /// </summary>
         public static string MSG_OneOrMoreInvalidTargets {
             get {
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more rules was disabled for an analysis target, as it was determined not to be applicable to it (this is a common condition). Include &apos;NotApplicable&apos; on an explicit &apos;--kind&apos; command-line argument (e.g., &apos;--kind Fail;NotApplicable&apos;) for more information..
+        ///   Looks up a localized string similar to One or more rules was disabled for an analysis target, as it was determined not to be applicable to it (this is a common condition). Include &apos;NotApplicable&apos; on an explicit &apos;--kind&apos; command-line argument (e.g., &apos;--kind &quot;Fail;NotApplicable&quot;&apos;) for more information..
         /// </summary>
         public static string MSG_OneOrMoreNotApplicable {
             get {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -226,10 +226,10 @@
     <value>Unexpected fatal runtime condition(s) observed: </value>
   </data>
   <data name="MSG_OneOrMoreInvalidTargets" xml:space="preserve">
-    <value>One or more targets was skipped entirely as it was determined to be an invalid target for analysis. Include 'Note' on an explicit '--level ' command-line argument (e.g., '--level Error;Warning;Note') for more information.</value>
+    <value>One or more targets was skipped entirely as it was determined to be an invalid target for analysis. Include 'Note' on an explicit '--level ' command-line argument (e.g., '--level "Error;Warning;Note"') for more information.</value>
   </data>
   <data name="MSG_OneOrMoreNotApplicable" xml:space="preserve">
-    <value>One or more rules was disabled for an analysis target, as it was determined not to be applicable to it (this is a common condition). Include 'NotApplicable' on an explicit '--kind' command-line argument (e.g., '--kind Fail;NotApplicable') for more information.</value>
+    <value>One or more rules was disabled for an analysis target, as it was determined not to be applicable to it (this is a common condition). Include 'NotApplicable' on an explicit '--kind' command-line argument (e.g., '--kind "Fail;NotApplicable"') for more information.</value>
   </data>
   <data name="ERR997_InvalidInvocationPropertyName" xml:space="preserve">
     <value>'{0}' is not a property of the Invocation object.</value>


### PR DESCRIPTION
User facing string update,
change from:
"expressed as a semicolon-delimited list (escape semicolon with backslash in Unix-like OS)"
to:
"expressed as a semicolon-delimited list enclosed in double quotes"