### PR TITLE
Fix Hash issue in 4.1.0

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,6 +14,7 @@
 * BRK: Remove unused `quiet` parameter from `SarifLogger`. [#2639]https://github.com/microsoft/sarif-sdk/pull/2639
 * BRK: Remove `ComputeHashData` and `AnalysisTargetToHashDataMap` properties from `SarifLogger` (in preference of new `fileRegionsCache` parameter. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
 * BRK: Eliminate proactive hashing of artifacts in `SarifLogger` constructor when `OptionallyEmittedData.Hashes` is specified. [#2639](https://github.com/microsoft/sarif-sdk/pull/2639)
+* BUG: Fixed incorrect hashes being returned when `--insert hashes` is enabled. [#2667](https://github.com/microsoft/sarif-sdk/pull/2667)
 * BUG: Fixed `ERR999.UnhandledEngineException: System.InvalidOperationException: This operation is not supported for a relative URI` when running in Linux with files skipped due to zero byte size. [#2664](https://github.com/microsoft/sarif-sdk/pull/2664)
 * BUG: Properly report skipping empty files (rather than reporting file was skipped due to exceeding size limits). [#2660](https://github.com/microsoft/sarif-sdk/pull/2660)
 * BUG: Update user messages and code comments that refer to `--force` (replaced by `--log ForceOverwrite`). [#2656](https://github.com/microsoft/sarif-sdk/pull/2656)

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -365,14 +365,21 @@ namespace Microsoft.CodeAnalysis.Sarif
         public HashData GetHashData(Uri uri, string fileText = null)
         {
             string path = uri.GetFilePath();
+
             if (fileText != null)
             {
                 _fileTextCache[path] = fileText;
+                _hashDataCache[path] = HashUtilities.ComputeHashesForText(fileText);
+                return _hashDataCache[path];
             }
 
-            fileText = _fileTextCache[path];
+            if (_hashDataCache.ContainsKey(path))
+            {
+                return _hashDataCache[path];
+            }
 
-            return HashUtilities.ComputeHashesForText(fileText);
+            _hashDataCache[path] = HashUtilities.ComputeHashes(path);
+            return _hashDataCache[path];
         }
 
         public NewLineIndex GetNewLineIndex(Uri uri, string fileText = null)
@@ -422,8 +429,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private HashData BuildHashDataForFile(string path)
         {
-            string fileText = _fileTextCache[path];
-            return HashUtilities.ComputeHashesForText(fileText);
+            if (_hashDataCache.ContainsKey(path))
+            {
+                return _hashDataCache[path];
+            }
+
+            _hashDataCache[path] = HashUtilities.ComputeHashes(path);
+            return _hashDataCache[path];
         }
 
         /// <summary>


### PR DESCRIPTION
Fix Hash issue in 4.1.0, if point BinSkim to this version, the exact changes for hashes in https://github.com/microsoft/binskim/pull/853 will be reverted to the original hash, which is expected:
https://github.com/microsoft/binskim/pull/891
