### PR TITLE
Remove not used `DefaultTraces Traces`

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -68,7 +68,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             HelpText = "Emit a 'rich' return code consisting of a bitfield of conditions (as opposed to 0 or 1 indicating success or failure.")]
         public bool? RichReturnCode { get; set; }
 
-        private IEnumerable<string> trace;
         [Option(
             "trace",
             Separator = ';',
@@ -76,25 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             HelpText = "Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that " +
                        "should be emitted to the console and log file (if appropriate). " +
                        "Valid values: ScanTime.")]
-        public IEnumerable<string> Trace
-        {
-            get => this.trace;
-            set => this.trace = value?.Count() > 0 ? value : null;
-        }
-
-        private DefaultTraces? defaultTraces;
-        public DefaultTraces Traces
-        {
-            get
-            {
-                defaultTraces ??=
-                    this.Trace.Any()
-                        ? (DefaultTraces)Enum.Parse(typeof(DefaultTraces), string.Join(",", this.Trace))
-                        : DefaultTraces.None;
-
-                return this.defaultTraces.Value;
-            }
-        }
+        public IEnumerable<string> Trace { get; set; } = Array.Empty<string>();
 
         private IEnumerable<FailureLevel> level;
         [Option(


### PR DESCRIPTION
The `DefaultTraces Traces` is not used and can be removed, then in BinSkim we just need to change the 
`public new IEnumerable<string> Traces`
to
`public new IEnumerable<string> Trace`
then both the BinSkim one PdbLoad and the SDK ones works together:

![image](https://github.com/microsoft/sarif-sdk/assets/81775155/5a4e3175-137d-4f4a-818b-de2972d1823a)

all existing tests pass after delete this field, because it is not used.
