### PR TITLE
HdfConverter: Map Impact=0 to Kind=Not Applicable

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,8 @@
 ## **v4.2.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/4.2.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/4.2.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/4.2.2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/4.2.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/4.2.2)
 * BUG: Resolve `NullReferenceException` retrieving `MultithreadedZipArchiveArtifactProvider.SizeInBytes` after content have been faulted in.
 
+* BUG: Improve HDF->SARIF conversion to properly map various properties (e.g., `kind`, `level`, `rank`) and generally prepare the converted SARIF for ingestion to [GitHub Advanced Security](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning).
+
 ## **v4.2.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/4.2.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/4.2.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/4.2.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/4.2.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/4.2.1)
 * BUG: Resolve `NotSupportedException` thrown (on .NET 4.8 and earlier) on accessing `DeflateStream.Length` from `MultithreadedZipArchiveArtifactProvider.SizeInBytes` property. 
 

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -138,14 +138,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var results = new List<Result>(execJsonControl.Results.Count);
             foreach (ControlResult controlResult in execJsonControl.Results)
             {
-                ResultKind kind = controlResult.Status switch
+                ResultKind kind;
+                if (execJsonControl.Impact <= 0.1)
                 {
-                    ControlResultStatus.Passed => ResultKind.Pass,
-                    ControlResultStatus.Failed => ResultKind.Fail,
-                    ControlResultStatus.Error => ResultKind.Review,
-                    ControlResultStatus.Skipped => ResultKind.NotApplicable,
-                    _ => ResultKind.Fail,
-                };
+                    kind = ResultKind.NotApplicable;
+                }
+                else
+                {
+                    kind = controlResult.Status switch
+                    {
+                        ControlResultStatus.Passed => ResultKind.Pass,
+                        ControlResultStatus.Failed => ResultKind.Fail,
+                        ControlResultStatus.Error => ResultKind.Review,
+                        ControlResultStatus.Skipped => ResultKind.Review,
+                        _ => ResultKind.Fail,
+                    };
+                }
                 FailureLevel level = (kind == ResultKind.Fail) ? SarifLevelFromHdfImpact(execJsonControl.Impact) : FailureLevel.None;
                 double rank = (kind == ResultKind.Fail) ? SarifRankFromHdfImpact(execJsonControl.Impact) : -1.0;
                 var result = new Result


### PR DESCRIPTION
Per @Amndeep7 and @aaronlippold of the MITRE SAF team, which is the team that manages the Heimdall Data Format (HDF), `impact` of `0` indicates not applicable. See: https://github.com/microsoft/sarif-sdk/issues/2695#issuecomment-1648728655