### PR TITLE
HdfConverter: SARIF location improvements

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## Unreleased
-
+## **v4.3.1** UNRELEASED
+* BUG: Improve `HdfConverter` ensure uri data is populated and to provide location and region data property from `SourceLocation`. [#2704](https://github.com/microsoft/sarif-sdk/pull/2704)
 * BUG: Correct `run.language` regex in JSON schema. [#2708]https://github.com/microsoft/sarif-sdk/pull/2708
 
 ## **v4.3.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.0)

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                             {
                                 ArtifactLocation = new ArtifactLocation
                                 {
-                                   Uri =  new Uri(execJsonControl.SourceLocation.Ref ?? "", UriKind.Relative),
+                                   Uri =  new Uri(execJsonControl.SourceLocation.Ref ?? "file:///", UriKind.RelativeOrAbsolute),
                                    UriBaseId = "ROOTPATH",
                                 },
                                 Region = new Region

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -173,14 +173,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                             {
                                 ArtifactLocation = new ArtifactLocation
                                 {
-                                   Uri =  new Uri(".", UriKind.Relative),
+                                   Uri =  new Uri(execJsonControl.SourceLocation.Ref ?? "", UriKind.Relative),
                                    UriBaseId = "ROOTPATH",
                                 },
                                 Region = new Region
                                 {
-                                    StartLine = 1,
+                                    StartLine = execJsonControl.SourceLocation.Line ?? 1,
                                     StartColumn = 1,
-                                    EndLine = 1,
+                                    EndLine = execJsonControl.SourceLocation.Line ?? 1,
                                     EndColumn = 1,
                                 }
                             }

--- a/src/Sarif.Converters/HdfModel/SourceLocation.cs
+++ b/src/Sarif.Converters/HdfModel/SourceLocation.cs
@@ -10,13 +10,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters.HdfModel
         /// <summary>
         /// The line at which this statement is located in the file
         /// </summary>
-        [JsonProperty("line", Required = Required.Default)]
-        public double Line { get; set; }
+        [JsonProperty("line", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public int? Line { get; set; }
 
         /// <summary>
         /// Path to the file that this statement originates from
         /// </summary>
-        [JsonProperty("ref", Required = Required.Default)]
+        [JsonProperty("ref", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
         public string Ref { get; set; }
     }
 }

--- a/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
@@ -13,7 +13,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -37,7 +37,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -61,7 +61,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -85,7 +85,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -109,7 +109,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -133,7 +133,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -157,7 +157,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -181,7 +181,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -205,7 +205,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -229,7 +229,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -253,7 +253,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -277,7 +277,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -301,7 +301,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -325,7 +325,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -349,7 +349,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -373,7 +373,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -397,7 +397,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -421,7 +421,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -445,7 +445,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -469,7 +469,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -493,7 +493,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -517,7 +517,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -541,7 +541,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -565,7 +565,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -589,7 +589,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -613,7 +613,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -637,7 +637,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -661,7 +661,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -685,7 +685,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -709,7 +709,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -733,7 +733,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -757,7 +757,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -781,7 +781,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -805,7 +805,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -829,7 +829,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -853,7 +853,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -877,7 +877,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -901,7 +901,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -925,7 +925,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -949,7 +949,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -973,7 +973,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -997,7 +997,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1021,7 +1021,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1045,7 +1045,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1069,7 +1069,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1093,7 +1093,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1117,7 +1117,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1141,7 +1141,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1165,7 +1165,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1189,7 +1189,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1213,7 +1213,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1237,7 +1237,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1261,7 +1261,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1285,7 +1285,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1309,7 +1309,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1333,7 +1333,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1357,7 +1357,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1381,7 +1381,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1405,7 +1405,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1429,7 +1429,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1453,7 +1453,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1477,7 +1477,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1501,7 +1501,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1525,7 +1525,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1549,7 +1549,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1573,7 +1573,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1597,7 +1597,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1621,7 +1621,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1645,7 +1645,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1669,7 +1669,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1693,7 +1693,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1718,7 +1718,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1743,7 +1743,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1768,7 +1768,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1793,7 +1793,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1818,7 +1818,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1843,7 +1843,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1868,7 +1868,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1893,7 +1893,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1918,7 +1918,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1943,7 +1943,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1968,7 +1968,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -1993,7 +1993,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2018,7 +2018,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2043,7 +2043,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2068,7 +2068,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2093,7 +2093,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2118,7 +2118,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2143,7 +2143,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2168,7 +2168,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2192,7 +2192,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2216,7 +2216,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2240,7 +2240,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2264,7 +2264,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2288,7 +2288,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2312,7 +2312,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2336,7 +2336,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2360,7 +2360,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2384,7 +2384,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2408,7 +2408,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2432,7 +2432,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2456,7 +2456,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2480,7 +2480,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2504,7 +2504,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2528,7 +2528,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2552,7 +2552,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2576,7 +2576,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2600,7 +2600,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2624,7 +2624,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2648,7 +2648,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2673,7 +2673,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2698,7 +2698,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2723,7 +2723,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2748,7 +2748,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2773,7 +2773,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2798,7 +2798,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2823,7 +2823,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2848,7 +2848,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2873,7 +2873,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2898,7 +2898,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2923,7 +2923,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2948,7 +2948,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2973,7 +2973,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -2998,7 +2998,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3023,7 +3023,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3048,7 +3048,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3073,7 +3073,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3098,7 +3098,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3123,7 +3123,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3148,7 +3148,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3172,7 +3172,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3196,7 +3196,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3220,7 +3220,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3244,7 +3244,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3268,7 +3268,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3292,7 +3292,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3316,7 +3316,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3340,7 +3340,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3364,7 +3364,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3388,7 +3388,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3412,7 +3412,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3436,7 +3436,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3460,7 +3460,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3484,7 +3484,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3508,7 +3508,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3532,7 +3532,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3556,7 +3556,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3580,7 +3580,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3604,7 +3604,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3628,7 +3628,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3652,7 +3652,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3676,7 +3676,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3700,7 +3700,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3724,7 +3724,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3748,7 +3748,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3772,7 +3772,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3796,7 +3796,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3820,7 +3820,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3844,7 +3844,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3868,7 +3868,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3892,7 +3892,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3917,7 +3917,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3942,7 +3942,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3967,7 +3967,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -3992,7 +3992,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -4016,7 +4016,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "",
+                  "uri": "file:///",
                   "uriBaseId": "ROOTPATH",
                   "index": 0
                 },
@@ -4053,7 +4053,7 @@
                     "id": "RA-5",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4065,7 +4065,7 @@
                     "id": "SA-11",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4089,7 +4089,7 @@
                     "id": "RA-5",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4101,7 +4101,7 @@
                     "id": "SA-11",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4125,7 +4125,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4137,7 +4137,7 @@
                     "id": "SC-8",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4161,7 +4161,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4173,7 +4173,7 @@
                     "id": "SC-8",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4200,7 +4200,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4212,7 +4212,7 @@
                     "id": "SC-8",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4236,7 +4236,7 @@
                     "id": "RA-5",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4248,7 +4248,7 @@
                     "id": "SA-11",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4275,7 +4275,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4287,7 +4287,7 @@
                     "id": "SI-10",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4311,7 +4311,7 @@
                     "id": "RA-5",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4323,7 +4323,7 @@
                     "id": "SA-11",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4347,7 +4347,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4359,7 +4359,7 @@
                     "id": "SC-8",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4386,7 +4386,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4398,7 +4398,7 @@
                     "id": "SI-10",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4425,7 +4425,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4437,7 +4437,7 @@
                     "id": "SI-10",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4464,7 +4464,7 @@
                     "id": "RA-5",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4476,7 +4476,7 @@
                     "id": "SA-11",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4500,7 +4500,7 @@
                     "id": "Rev_4",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4512,7 +4512,7 @@
                     "id": "SI-10",
                     "toolComponent": {
                       "name": "NIST",
-                      "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+                      "guid": "aafbab93-5201-419e-8443-d4925c542398"
                     }
                   },
                   "kinds": [
@@ -4525,7 +4525,7 @@
           "supportedTaxonomies": [
             {
               "name": "NIST SP800-53 v5",
-              "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+              "guid": "aafbab93-5201-419e-8443-d4925c542398"
             }
           ]
         }
@@ -4538,7 +4538,7 @@
       "artifacts": [
         {
           "location": {
-            "uri": "",
+            "uri": "file:///",
             "uriBaseId": "ROOTPATH"
           }
         },
@@ -4556,7 +4556,7 @@
               "uri": "https://raw.githubusercontent.com/sarif-standard/taxonomies/main/NIST_SP800-53_v5.sarif",
               "index": 1
             },
-            "guid": "AAFBAB93-5201-419E-8443-D4925C542398"
+            "guid": "aafbab93-5201-419e-8443-d4925c542398"
           }
         ]
       }


### PR DESCRIPTION
* Hdf: SourceLocation's Line and Ref are optional
   See: https://github.com/mitre/heimdall2/blob/v2.6.59/libs/inspecjs/src/generated_parsers/v_1_0/exec-json.ts#L311
* HdfConverter: Set ArtifactLocation and Region using SourceLocation
* HdfConverter: GitHub requires the uri to have a non-empty string value
   @michaelcfanning The validator at https://sarifweb.azurewebsites.net/Validation only checks that `uri` is present, it doesn't complain when `uri` is set to empty string. However, GitHub does complain, failing with `locationFromSarifResult: expected artifact location` as shown at https://github.com/candrews/jumpstart/actions/runs/5684090175/job/15406260757?pr=884#step:10:23
  How can  I contact whoever runs https://sarifweb.azurewebsites.net/Validation to tell them that it should report a problem when `physicalLocation.artifactLocation.uri=""`?