### PR TITLE
Add realized configuration peristence mechanism. Namespace removal.

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -37,6 +37,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public string ConfigurationFilePath { get; set; }
 
         [Option(
+            "output-config",
+            HelpText = "Path to a policy file to which all analysis settings from the current run will be saved.")]
+        public string OutputConfigurationFilePath { get; set; }
+
+        [Option(
             'q',
             "quiet",
             HelpText = "Suppress all console output (except for catastrophic tool runtime or configuration errors).")]

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             "automation-guid",
             HelpText = "A guid that will be persisted to the 'Run.AutomationDetails.Guid' property. See section '3.17.4' of the SARIF specification for more information.")]
-        public Guid? AutomationGuid { get; set; }
+        public Guid AutomationGuid { get; set; }
 
         public Formatting Formatting => this.PrettyPrint || (!this.PrettyPrint && !this.Minify)
             ? Formatting.Indented

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -825,12 +825,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     : null;
             }
 
-            if (!File.Exists(configurationFilePath)) 
-            { 
+            if (!File.Exists(configurationFilePath))
+            {
                 string fileName = Path.GetFileNameWithoutExtension(configurationFilePath);
                 string spamDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 fileName = Path.Combine(spamDirectory, $"{fileName}.xml");
-                
+
                 if (fileSystem.FileExists(fileName))
                 {
                     return fileName;

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -293,22 +294,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             context.Logger ??= InitializeLogger(context);
 
             // Finally, handle the remaining options.
-
+            context.PostUri = options.PostUri ?? context.PostUri;
             context.AutomationId = options.AutomationId ?? context.AutomationId;
             context.Threads = options.Threads > 0 ? options.Threads : context.Threads;
-            context.AutomationGuid = options.AutomationGuid ?? context.AutomationGuid;
+            context.AutomationGuid = options.AutomationGuid != default ? options.AutomationGuid : context.AutomationGuid;
             context.OutputFilePath = options.OutputFilePath ?? context.OutputFilePath;
-            context.EventsFilePath = Environment.GetEnvironmentVariable("SPMI_ETW") ?? options.EventsFilePath ?? context.EventsFilePath;
-            context.PostUri = options.PostUri != null ? options.PostUri : context.PostUri;
+            context.BaselineFilePath = options.BaselineFilePath ?? context.BaselineFilePath;
             context.Recurse = options.Recurse != null ? options.Recurse.Value : context.Recurse;
             context.Traces = options.Trace.Any() ? InitializeStringSet(options.Trace) : context.Traces;
-            context.BaselineFilePath = options.BaselineFilePath != null ? options.BaselineFilePath : context.BaselineFilePath;
+            context.GlobalFilePathDenyRegex = options.GlobalFilePathDenyRegex ?? context.GlobalFilePathDenyRegex;
+            context.OutputConfigurationFilePath = options.OutputConfigurationFilePath ?? context.OutputConfigurationFilePath;
             context.DataToInsert = options.DataToInsert?.Any() == true ? options.DataToInsert.ToFlags() : context.DataToInsert;
             context.DataToRemove = options.DataToRemove?.Any() == true ? options.DataToRemove.ToFlags() : context.DataToRemove;
+            context.EventsFilePath = Environment.GetEnvironmentVariable("SPMI_ETW") ?? options.EventsFilePath ?? context.EventsFilePath;
             context.OutputFileOptions = options.OutputFileOptions?.Any() == true ? options.OutputFileOptions.ToFlags() : context.OutputFileOptions;
             context.PluginFilePaths = options.PluginFilePaths?.Any() == true ? options.PluginFilePaths?.ToImmutableHashSet() : context.PluginFilePaths;
             context.InsertProperties = options.InsertProperties?.Any() == true ? InitializeStringSet(options.InsertProperties) : context.InsertProperties;
-            context.GlobalFilePathDenyRegex = options.GlobalFilePathDenyRegex != null ? options.GlobalFilePathDenyRegex : context.GlobalFilePathDenyRegex;
             context.MaxFileSizeInKilobytes = options.MaxFileSizeInKilobytes != null ? options.MaxFileSizeInKilobytes.Value : context.MaxFileSizeInKilobytes;
             context.TargetFileSpecifiers = options.TargetFileSpecifiers?.Any() == true ? InitializeStringSet(options.TargetFileSpecifiers) : context.TargetFileSpecifiers;
             context.InvocationPropertiesToLog = options.InvocationPropertiesToLog?.Any() == true ? InitializeStringSet(options.InvocationPropertiesToLog) : context.InvocationPropertiesToLog;
@@ -824,12 +825,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     : null;
             }
 
+            if (!File.Exists(configurationFilePath)) 
+            { 
+                string fileName = Path.GetFileNameWithoutExtension(configurationFilePath);
+                string spamDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                fileName = Path.Combine(spamDirectory, $"{fileName}.xml");
+                
+                if (fileSystem.FileExists(fileName))
+                {
+                    return fileName;
+                }
+            }
+
             return configurationFilePath;
         }
 
         protected virtual TContext InitializeConfiguration(string configurationFileName, TContext context)
         {
             context.Policy ??= new PropertiesDictionary();
+
             configurationFileName = GetConfigurationFileName(configurationFileName, context.FileSystem);
             context.ConfigurationFilePath = configurationFileName;
 

--- a/src/Sarif.Multitool.Library/ValidateCommand.cs
+++ b/src/Sarif.Multitool.Library/ValidateCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 AutomationIdProperty,
                 BaselineFilePathProperty,
                 ChannelSizeProperty,
+                OutputConfigurationFilePathProperty,
                 DataToInsertProperty,
                 DataToRemoveProperty,
                 EventsFilePathProperty,
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             set => this.Policy.SetProperty(ChannelSizeProperty, value);
         }
 
-        public virtual Guid? AutomationGuid
+        public virtual Guid AutomationGuid
         {
             get => this.Policy.GetProperty(AutomationGuidProperty);
             set => this.Policy.SetProperty(AutomationGuidProperty, value);
@@ -142,10 +143,12 @@ namespace Microsoft.CodeAnalysis.Sarif
             set => this.Policy.SetProperty(OutputFilePathProperty, value);
         }
 
-        public string ConfigurationFilePath
+        public string ConfigurationFilePath { get; set; }
+
+        public string OutputConfigurationFilePath
         {
-            get => this.Policy.GetProperty(ConfigurationFilePathProperty);
-            set => this.Policy.SetProperty(ConfigurationFilePathProperty, value);
+            get => this.Policy.GetProperty(OutputConfigurationFilePathProperty);
+            set => this.Policy.SetProperty(OutputConfigurationFilePathProperty, value);
         }
 
         public string EventsFilePath
@@ -272,9 +275,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 "CoreSettings", nameof(ChannelSize), defaultValue: () => 50000,
                 "The capacity of the channels for analyzing scan targets and logging results.");
 
-        public static PerLanguageOption<Guid?> AutomationGuidProperty { get; } =
-            new PerLanguageOption<Guid?>(
-                "CoreSettings", nameof(AutomationGuid), defaultValue: () => null,
+        public static PerLanguageOption<Guid> AutomationGuidProperty { get; } =
+            new PerLanguageOption<Guid>(
+                "CoreSettings", nameof(AutomationGuid), defaultValue: () => default,
                 "A guid that will be persisted to the 'Run.AutomationDetails.Guid' property. " +
                 "See section '3.17.4' of the SARIF specification for more information.");
 
@@ -304,10 +307,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                                 "CoreSettings", nameof(PostUri), defaultValue: () => string.Empty,
                                 "A SARIF-accepting endpoint to publish the output log to.");
 
-        public static PerLanguageOption<string> ConfigurationFilePathProperty { get; } =
+        public static PerLanguageOption<string> OutputConfigurationFilePathProperty { get; } =
                             new PerLanguageOption<string>(
-                                "CoreSettings", nameof(ConfigurationFilePath), defaultValue: () => string.Empty,
-                                "The path to write all SARIF log file results to.");
+                                "CoreSettings", nameof(OutputConfigurationFilePath), defaultValue: () => string.Empty,
+                                "The path to write all resolved configuration (by current command-line) to.");
 
         public static PerLanguageOption<OptionallyEmittedData> DataToInsertProperty { get; } =
                     new PerLanguageOption<OptionallyEmittedData>(

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -224,8 +224,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             return this.AutomationDetails?.Description != null ||
                 !string.IsNullOrWhiteSpace(this.AutomationDetails?.Id) ||
-                this.AutomationDetails?.Guid != null ||
-                this.AutomationDetails?.CorrelationGuid != null;
+                (this.AutomationDetails?.Guid != null && this.AutomationDetails.Guid.Value != Guid.Empty) ||
+                (this.AutomationDetails?.CorrelationGuid != null && this.AutomationDetails.CorrelationGuid != Guid.Empty);
         }
 
         public bool ShouldSerializeInvocations()

--- a/src/Sarif/IAnalysisContext.cs
+++ b/src/Sarif/IAnalysisContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public string AutomationId { get; set; }
 
-        public Guid? AutomationGuid { get; set; }
+        public Guid AutomationGuid { get; set; }
 
         FilePersistenceOptions OutputFileOptions { get; set; }
 

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -201,6 +201,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             this.Clear();
 
+            if (stream.CanSeek) 
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
             var settings = new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Ignore,

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             this.Clear();
 
-            if (stream.CanSeek) 
+            if (stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }

--- a/src/Sarif/PropertiesDictionaryExtensionMethods.cs
+++ b/src/Sarif/PropertiesDictionaryExtensionMethods.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             propertyBagType = propertyBag.GetType();
             propertyBagTypeName = propertyBagType.Name;
 
-            if (propertyBagTypeName != "PropertyBag")
+            if (propertyBagTypeName != "PropertiesDictionary")
             {
                 propertyBagTypeName = NormalizeTypeName(propertyBag.GetType().FullName);
             }
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 writer.WriteAttributeString(KEY_ID, name);
             }
 
-            if (propertyBagTypeName != "PropertyBag")
+            if (propertyBagTypeName != "PropertiesDictionary")
             {
                 writer.WriteAttributeString(TYPE_ID, propertyBagTypeName);
             }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1190,12 +1190,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Theory]
-        [InlineData(null, false, "")]
-        [InlineData("", false, "")]
+        [InlineData(null, false, null)]
+        [InlineData("", false, null)]
         [InlineData(null, true, "default.configuration.xml")]
         [InlineData("", true, "default.configuration.xml")]
-        [InlineData("default", false, "")]
-        [InlineData("default", true, "")]
+        [InlineData("default", false, null)]
+        [InlineData("default", true, null)]
         [InlineData("test-newconfig.xml", false, "test-newconfig.xml")]
         [InlineData("test-newconfig.xml", true, "test-newconfig.xml")]
         public void AnalyzeCommandBase_LoadConfigurationFile(string configValue, bool defaultFileExists, string expectedFileName)
@@ -1220,7 +1220,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (string.IsNullOrEmpty(expectedFileName))
             {
-                context.ConfigurationFilePath.Should().Be(string.Empty);
+                context.ConfigurationFilePath.Should().Be(null);
             }
             else
             {
@@ -1833,7 +1833,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     runWithCaching.AutomationDetails.Id.Should().Be(options.AutomationId);
                 }
 
-                if (options.AutomationGuid != null)
+                if (options.AutomationGuid != default)
                 {
                     runWithCaching.AutomationDetails.Guid.Should().Be(options.AutomationGuid);
                 }
@@ -1852,7 +1852,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         private static void EnhanceOptions(TestAnalyzeOptions current, TestAnalyzeOptions enhancement)
         {
             current.AutomationId ??= enhancement?.AutomationId;
-            current.AutomationGuid = enhancement.AutomationGuid;
+            current.AutomationGuid = enhancement == null ? default : enhancement.AutomationGuid;
         }
 
         private static IFileSystem CreateDefaultFileSystemForResultsCaching(IList<string> files, bool generateSameInput = false)

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1520,7 +1520,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 new TestAnalyzeOptions
                 {
                     AutomationId = string.Empty,
-                    AutomationGuid = null
+                    AutomationGuid = default
                 },
                 new TestAnalyzeOptions
                 {
@@ -1530,7 +1530,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 new TestAnalyzeOptions
                 {
                     AutomationId = null,
-                    AutomationGuid = null
+                    AutomationGuid = default
                 },
                 new TestAnalyzeOptions
                 {
@@ -1540,7 +1540,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 new TestAnalyzeOptions
                 {
                     AutomationId = string.Empty,
-                    AutomationGuid = null
+                    AutomationGuid = default
                 },
                 new TestAnalyzeOptions
                 {
@@ -1852,7 +1852,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         private static void EnhanceOptions(TestAnalyzeOptions current, TestAnalyzeOptions enhancement)
         {
             current.AutomationId ??= enhancement?.AutomationId;
-            current.AutomationGuid ??= enhancement?.AutomationGuid;
+            current.AutomationGuid = enhancement.AutomationGuid;
         }
 
         private static IFileSystem CreateDefaultFileSystemForResultsCaching(IList<string> files, bool generateSameInput = false)

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1823,7 +1823,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 runWithCaching.Artifacts.Should().NotBeEmpty();
 
-                if (string.IsNullOrWhiteSpace(options.AutomationId) && options.AutomationGuid == null)
+                if (string.IsNullOrWhiteSpace(options.AutomationId) && options.AutomationGuid == default)
                 {
                     runWithCaching.AutomationDetails.Should().Be(null);
                 }

--- a/src/Test.Utilities.Sarif/DirectoryHelpers.cs
+++ b/src/Test.Utilities.Sarif/DirectoryHelpers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Reflection;
 


### PR DESCRIPTION
Provides a mechanism to persist all realized configuration, as specified on the command-line (including any serialized config file that's been loaded) to an output file.

This persisted configuration file can be round-tripped to the tool to render the identical analysis configuration.

This allows users to render a very complex command-line, and then to capture it in a single file that can provide a simplified command-line experience (i.e., you simply pass the XML via the `-c` switch) or so that the detailed configuration can be manually adjusted (for example, to create a specialized min-bar of analysis checks, by disabling certain rules). Currently not all of our settings (and rule disablement is a good example) is available on the command-line.