### PR TITLE
Correct `run.language` regex in JSON schema in sarif-2.1.0-rtm.6.json

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## Unreleased
+
+* BUG: Correct `run.language` regex in JSON schema. [#2708]https://github.com/microsoft/sarif-sdk/pull/2708
+
 ## **v4.3.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.0)
 * BUG: Resolve `NullReferenceException` retrieving `MultithreadedZipArchiveArtifactProvider.SizeInBytes` after content have been faulted in.
 

--- a/src/Sarif/Schemata/sarif-2.1.0-rtm.6.json
+++ b/src/Sarif/Schemata/sarif-2.1.0-rtm.6.json
@@ -2354,7 +2354,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "versionControlProvenance": {


### PR DESCRIPTION
In the last PR, only one of two regular expressions was fixed:
https://github.com/microsoft/sarif-sdk/pull/2653