### PR TITLE
Fix #2709 (make OR operator work in multitool queries)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.3.1** UNRELEASED
+* BUG: Correct multitool query OR logic [#2709](https://github.com/microsoft/sarif-sdk/issues/2709)
 * BUG: Improve `HdfConverter` ensure uri data is populated and to provide location and region data property from `SourceLocation`. [#2704](https://github.com/microsoft/sarif-sdk/pull/2704)
 * BUG: Correct `run.language` regex in JSON schema. [#2708]https://github.com/microsoft/sarif-sdk/pull/2708
 

--- a/src/Sarif/Query/Evaluators/ExpressionEvaluators.cs
+++ b/src/Sarif/Query/Evaluators/ExpressionEvaluators.cs
@@ -118,10 +118,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Query.Evaluators
 
         public void Evaluate(ICollection<T> list, BitArray matches)
         {
+            BitArray termMatches = new BitArray(list.Count);
+
             foreach (IExpressionEvaluator<T> term in _terms)
             {
-                // Add each term's matches to the same set
-                term.Evaluate(list, matches);
+                // Get matches for the term
+                termMatches.SetAll(false);
+                term.Evaluate(list, termMatches);
+
+                // Union with matches so far
+                matches.Or(termMatches);
 
                 // Stop if everything has already matched
                 if (matches.TrueCount() == list.Count) { break; }

--- a/src/Test.UnitTests.Sarif.Multitool.Library/QueryCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/QueryCommandTests.cs
@@ -22,6 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             // All Results: No filter
             RunAndVerifyCount(5, new QueryOptions() { Expression = "", InputFilePath = filePath });
 
+            // Or operator
+            RunAndVerifyCount(2, new QueryOptions() { Expression = "Uri >| test_key.pem || Uri >| test_rsa_privkey.pem", InputFilePath = filePath });
+
             // Rule filtering
             RunAndVerifyCount(1, new QueryOptions() { Expression = "RuleId = 'CSCAN0020/0'", InputFilePath = filePath });
             RunAndVerifyCount(4, new QueryOptions() { Expression = "RuleId = 'CSCAN0060/0'", InputFilePath = filePath });
@@ -81,7 +84,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             // result filter: date time
             RunAndVerifyCount(0, new QueryOptions() { Expression = "properties.patchPublicationDate < '2022-04-25T00:00:00'", InputFilePath = filePath });
         }
-
 
         private void RunAndVerifyCount(int expectedCount, QueryOptions options)
         {


### PR DESCRIPTION
We have to create a branch off main to run ADO validations. I will now add you as a contributor, Paul (which means you can create branches directly off main). Thanks for the contribution!

Note that I updated the release notes as well.

@dotpaul