### PR TITLE
HdfConverter: Set precision and tags

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,7 @@
 ## **v4.3.1** UNRELEASED
 * BUG: Improve `HdfConverter` ensure uri data is populated and to provide location and region data property from `SourceLocation`. [#2704](https://github.com/microsoft/sarif-sdk/pull/2704)
 * BUG: Correct `run.language` regex in JSON schema. [#2708]https://github.com/microsoft/sarif-sdk/pull/2708
+* BUG: Improve `HdfConverter` to set `precision` and `tags` as recommended by GitHub. [#2712](https://github.com/microsoft/sarif-sdk/pull/2712)
 
 ## **v4.3.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.0)
 * BUG: Resolve `NullReferenceException` retrieving `MultithreadedZipArchiveArtifactProvider.SizeInBytes` after content have been faulted in.

--- a/src/Sarif.Converters/HdfConverter.cs
+++ b/src/Sarif.Converters/HdfConverter.cs
@@ -135,6 +135,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     }))
             };
             reportingDescriptor.SetProperty("security-severity", SarifSecuritySeverityFromHdfImpact(execJsonControl.Impact).ToString());
+            reportingDescriptor.SetProperty("precision", "very-high");
+            reportingDescriptor.SetProperty("tags", new List<string>() { "security" });
 
             var results = new List<Result>(execJsonControl.Results.Count);
             foreach (ControlResult controlResult in execJsonControl.Results)

--- a/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/HdfConverter/ExpectedOutputs/ValidResults.sarif
@@ -4048,7 +4048,9 @@
                 "text": "User Agent Fuzzer."
               },
               "properties": {
-                "security-severity": "3"
+                "security-severity": "3",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4087,7 +4089,9 @@
                 "text": "Web Browser XSS Protection Not Enabled."
               },
               "properties": {
-                "security-severity": "3"
+                "security-severity": "3",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4126,7 +4130,9 @@
                 "text": "Cookie Slack Detector."
               },
               "properties": {
-                "security-severity": "3"
+                "security-severity": "3",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4165,7 +4171,9 @@
                 "text": "Cookie Slack Detector."
               },
               "properties": {
-                "security-severity": "3"
+                "security-severity": "3",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4207,7 +4215,9 @@
                 "level": "error"
               },
               "properties": {
-                "security-severity": "7"
+                "security-severity": "7",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4246,7 +4256,9 @@
                 "text": "X-Content-Type-Options Header Missing."
               },
               "properties": {
-                "security-severity": "3"
+                "security-severity": "3",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4288,7 +4300,9 @@
                 "level": "error"
               },
               "properties": {
-                "security-severity": "7"
+                "security-severity": "7",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4327,7 +4341,9 @@
                 "text": "X-Frame-Options Header Not Set."
               },
               "properties": {
-                "security-severity": "5"
+                "security-severity": "5",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4366,7 +4382,9 @@
                 "text": "Proxy Disclosure."
               },
               "properties": {
-                "security-severity": "5"
+                "security-severity": "5",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4408,7 +4426,9 @@
                 "level": "error"
               },
               "properties": {
-                "security-severity": "7"
+                "security-severity": "7",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4450,7 +4470,9 @@
                 "level": "error"
               },
               "properties": {
-                "security-severity": "7"
+                "security-severity": "7",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4492,7 +4514,9 @@
                 "level": "error"
               },
               "properties": {
-                "security-severity": "7"
+                "security-severity": "7",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {
@@ -4531,7 +4555,9 @@
                 "text": "Format String Error."
               },
               "properties": {
-                "security-severity": "5"
+                "security-severity": "5",
+                "precision": "very-high",
+                "tags": ["security"]
               },
               "relationships": [
                 {


### PR DESCRIPTION
GitHub recommends that precision be set. Other tools, such as Trivy, set precision="very-high" when there's no available data to determine otherwise, so that's what's done here too.

tags must include "security" for GitHub to process the security-severity and consider the results to be a security finding.

See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object