### PR TITLE
Http mock test helper improvement

### DIFF
--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -309,7 +308,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
 
             httpMock.Mock(
                 new HttpRequestMessage(HttpMethod.Post, postUri) { Content = new StreamContent(CreateSarifLogStream()) },
-                HttpMockHelper.BadRequestResponse);
+                HttpMockHelper.CreateBadRequestResponse());
 
             HttpResponseMessage response =
                 await SarifLog.Post(postUri,
@@ -368,7 +367,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                 {
                     Content = new StreamContent(CreateSarifLogStream())
                 },
-                HttpMockHelper.OKResponse);
+                HttpMockHelper.CreateOKResponse());
 
             try
             {

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -306,9 +306,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             var postUri = new Uri("https://sarif-post/example.com");
             var httpMock = new HttpMockHelper();
 
-            httpMock.Mock(
-                new HttpRequestMessage(HttpMethod.Post, postUri) { Content = new StreamContent(CreateSarifLogStream()) },
-                HttpMockHelper.CreateBadRequestResponse());
+            httpMock.Mock(HttpMockHelper.CreateBadRequestResponse());
 
             HttpResponseMessage response =
                 await SarifLog.Post(postUri,
@@ -327,12 +325,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             var postUri = new Uri("https://sarif-post/example.com");
             var httpMock = new HttpMockHelper();
 
-            httpMock.Mock(
-                new HttpRequestMessage(HttpMethod.Post, postUri)
-                {
-                    Content = new StreamContent(CreateSarifLogStream())
-                },
-                HttpMockHelper.CreateOKResponse());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
 
             try
             {
@@ -362,12 +355,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                 .Setup(f => f.FileOpenRead(It.IsAny<string>()))
                 .Returns(CreateSarifLogStream());
 
-            httpMock.Mock(
-                new HttpRequestMessage(HttpMethod.Post, postUri)
-                {
-                    Content = new StreamContent(CreateSarifLogStream())
-                },
-                HttpMockHelper.CreateOKResponse());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
 
             try
             {

--- a/src/Test.Utilities.Sarif/HttpMockHelper.cs
+++ b/src/Test.Utilities.Sarif/HttpMockHelper.cs
@@ -116,6 +116,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            // In most cases, we set up one request and response pair.
+            // The matching mechanism is only used for those situations where we need more than one pair.
+            if (this.mockedResponses.Count == 1 && mockedResponses[0].Item1.RequestUri != null)
+            {
+                return Task.FromResult(mockedResponses[0].Item3);
+            }
+
             Tuple<HttpRequestMessage, string, HttpResponseMessage> fakeResponse;
 
             string content = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;

--- a/src/Test.Utilities.Sarif/HttpMockHelper.cs
+++ b/src/Test.Utilities.Sarif/HttpMockHelper.cs
@@ -25,26 +25,40 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new HttpResponseMessage(HttpStatusCode.OK);
         }
 
-        public static readonly HttpResponseMessage NotFoundResponse =
-            new HttpResponseMessage(HttpStatusCode.NotFound);
+        public static HttpResponseMessage CreateNotFoundResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
 
-        public static readonly HttpResponseMessage ForbiddenResponse =
-            new HttpResponseMessage(HttpStatusCode.Forbidden);
+        public static HttpResponseMessage CreateForbiddenResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.Forbidden);
+        }
 
-        public static readonly HttpResponseMessage BadGatewayResponse =
-            new HttpResponseMessage(HttpStatusCode.BadGateway);
+        public static HttpResponseMessage CreateBadGatewayResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.BadGateway);
+        }
 
-        public static readonly HttpResponseMessage BadRequestResponse =
-            new HttpResponseMessage(HttpStatusCode.BadRequest);
+        public static HttpResponseMessage CreateBadRequestResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }
 
-        public static readonly HttpResponseMessage UnauthorizedResponse =
-            new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        public static HttpResponseMessage CreateUnauthorizedResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        }
 
-        public static readonly HttpResponseMessage InternalServerErrorResponse =
-            new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        public static HttpResponseMessage CreateInternalServerErrorResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        }
 
-        public static readonly HttpResponseMessage NonAuthoritativeInformationResponse =
-            new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
+        public static HttpResponseMessage CreateNonAuthoritativeInformationResponse()
+        {
+            return new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
+        }
 
         private readonly List<Tuple<HttpRequestMessage, string, HttpResponseMessage>> mockedResponses =
             new List<Tuple<HttpRequestMessage, string, HttpResponseMessage>>();
@@ -54,13 +68,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             switch (statusCode)
             {
                 case HttpStatusCode.OK: { return CreateOKResponse(); }
-                case HttpStatusCode.NotFound: { return NotFoundResponse; }
-                case HttpStatusCode.Forbidden: { return ForbiddenResponse; }
-                case HttpStatusCode.BadGateway: { return BadGatewayResponse; }
-                case HttpStatusCode.BadRequest: { return BadRequestResponse; }
-                case HttpStatusCode.Unauthorized: { return UnauthorizedResponse; }
-                case HttpStatusCode.InternalServerError: { return InternalServerErrorResponse; }
-                case HttpStatusCode.NonAuthoritativeInformation: { return NonAuthoritativeInformationResponse; }
+                case HttpStatusCode.NotFound: { return CreateNotFoundResponse(); }
+                case HttpStatusCode.Forbidden: { return CreateForbiddenResponse(); }
+                case HttpStatusCode.BadGateway: { return CreateBadGatewayResponse(); }
+                case HttpStatusCode.BadRequest: { return CreateBadRequestResponse(); }
+                case HttpStatusCode.Unauthorized: { return CreateUnauthorizedResponse(); }
+                case HttpStatusCode.InternalServerError: { return CreateInternalServerErrorResponse(); }
+                case HttpStatusCode.NonAuthoritativeInformation: { return CreateNonAuthoritativeInformationResponse(); }
             }
 
             throw new NotImplementedException();

--- a/src/Test.Utilities.Sarif/HttpMockHelper.cs
+++ b/src/Test.Utilities.Sarif/HttpMockHelper.cs
@@ -25,9 +25,6 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new HttpResponseMessage(HttpStatusCode.OK);
         }
 
-        public static readonly HttpResponseMessage OKResponse =
-            new HttpResponseMessage(HttpStatusCode.OK);
-
         public static readonly HttpResponseMessage NotFoundResponse =
             new HttpResponseMessage(HttpStatusCode.NotFound);
 
@@ -56,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (statusCode)
             {
-                case HttpStatusCode.OK: { return OKResponse; }
+                case HttpStatusCode.OK: { return CreateOKResponse(); }
                 case HttpStatusCode.NotFound: { return NotFoundResponse; }
                 case HttpStatusCode.Forbidden: { return ForbiddenResponse; }
                 case HttpStatusCode.BadGateway: { return BadGatewayResponse; }


### PR DESCRIPTION
The problem is the timestamp difference between mocking and retrieving the test result, causing that we may not be able to retrieve the correct result form the cache list, because it compares all headers and the headers contains the timestamp, and also the other fields that generated based on the timestamp.

In most cases, we set up one request and response pair.
The header matching mechanism is only needed for those situations where we need more than one pair.
With this change, 1 to 1 mocking (which is the vast majority) will no longer need to worry about the timestamp.
The rest of the code path is kept for those cases need it.
