### PR TITLE
Fixing crash in dump-events

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.3.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.3)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.3)
 * BUG: Update `dump-events` command to be resilient in cases where the thread id changes between artifact enumeration start/stop event pairs.
+* BUG: Resolve trace parsing InvalidOperationException exception by updating dump-events command to process PartitionInfoExtension session event as we do PartitionInfoExtensionV2.
 
 ## **v4.3.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.2)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.2)
 * BUG: Correct multitool query OR logic [#2709](https://github.com/microsoft/sarif-sdk/issues/2709)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.3.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.3)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.3)
 * BUG: Update `dump-events` command to be resilient in cases where the thread id changes between artifact enumeration start/stop event pairs.
-* BUG: Resolve trace parsing InvalidOperationException exception by updating dump-events command to process PartitionInfoExtension session event as we do PartitionInfoExtensionV2.
+* BUG: Resolve trace parsing 'InvalidOperationException' by updating 'dump-events' command to process 'PartitionInfoExtension' session event as we do 'PartitionInfoExtensionV2'.
 
 ## **v4.3.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.2)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.2)
 * BUG: Correct multitool query OR logic [#2709](https://github.com/microsoft/sarif-sdk/issues/2709)

--- a/src/Sarif.Driver/DumpEventsCommand.cs
+++ b/src/Sarif.Driver/DumpEventsCommand.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                         case "RuleFired":
                         {
-                            FailureLevel level = (FailureLevel)(int)(uint)traceEvent.PayloadByName("level");
+                            var level = (FailureLevel)(int)(uint)traceEvent.PayloadByName("level");
                             data1 = level;
                             data2 = traceEvent.PayloadByName("matchIdentifier");
                             ruleId = (string)traceEvent.PayloadByName(nameof(ruleId));
@@ -297,17 +297,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                         case "ManifestData":
                         {
                             return;
-
-                        }
-
-                        case "EventTrace/PartitionInfoExtensionV2":
-                        {
-                            eventName = "SessionStarted";
-                            formattedMessage = "Session started.";
-                            break;
                         }
 
                         case "EventTrace/PartitionInfoExtension":
+                        case "EventTrace/PartitionInfoExtensionV2":
                         {
                             eventName = "SessionStarted";
                             formattedMessage = "Session started.";

--- a/src/Sarif.Driver/DumpEventsCommand.cs
+++ b/src/Sarif.Driver/DumpEventsCommand.cs
@@ -299,7 +299,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                             return;
 
                         }
+
                         case "EventTrace/PartitionInfoExtensionV2":
+                        {
+                            eventName = "SessionStarted";
+                            formattedMessage = "Session started.";
+                            break;
+                        }
+
+                        case "EventTrace/PartitionInfoExtension":
                         {
                             eventName = "SessionStarted";
                             formattedMessage = "Session started.";


### PR DESCRIPTION
I'm not 100% sure why this event started getting into my etl logs and triggering crashes, but I suspect the right answer is to treat it as another way of recognizing session start.