### PR TITLE
Update version to 4.3.4

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## **v4.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)
+* BUG: Disable certain console outputs (such as reporting of threads count) when `AnalyzeContextBase.Quiet` is set.
+
 ## **v4.3.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.3)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.3)
 * BUG: Update `dump-events` command to be resilient in cases where the thread id changes between artifact enumeration start/stop event pairs.
 * BUG: Resolve trace parsing `InvalidOperationException` by updating `dump-events` command to process `PartitionInfoExtension` session event as we do `PartitionInfoExtensionV2`.

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Sarif.Writers;
 namespace Microsoft.CodeAnalysis.Sarif.Driver
 {
     [Verb("analyze", HelpText = "Analyze one or more binary files for security and correctness issues.")]
-    public abstract class AnalyzeOptionsBase : CommonOptionsBase
+    public class AnalyzeOptionsBase : CommonOptionsBase
     {
         [Value(0,
                HelpText = "One or more specifiers to a file, directory, or filter pattern that resolves to one or more binaries to analyze.")]

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -14,8 +14,6 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 
-using Mono.Cecil.Cil;
-
 using Moq;
 
 using Newtonsoft.Json;
@@ -709,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                 SarifLog log = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(path));
                 Assert.NotNull(log);
-                Assert.Equal<int>(1, log.Runs.Count);
+                Assert.Single<Run>(log.Runs);
 
                 run = log.Runs.First();
             }

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -31,18 +31,18 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Coyote" Version="$(CoyoteVersion)" />
     <PackageReference Include="Microsoft.Coyote.Test" Version="$(CoyoteVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.3.3</VersionPrefix>
-    <PreviousVersionPrefix>4.3.2</PreviousVersionPrefix>
+    <VersionPrefix>4.3.4</VersionPrefix>
+    <PreviousVersionPrefix>4.3.3</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
* BUG: Disable certain console outputs (such as reporting of threads count) when `AnalyzeContextBase.Quiet` is set.

Minor update. Test binaries updated. Options base is now creatable (a non-breaking change).