### PR TITLE
Fix net462 version of the Multitool not working issue

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.3.5** UNRELEASED
-* BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool. [#2721](https://github.com/microsoft/sarif-sdk/issues/2721)
+* BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool. [#2722](https://github.com/microsoft/sarif-sdk/issues/2722)
 
 ## **v4.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)
 * BUG: Disable certain console outputs (such as reporting of threads count) when `AnalyzeContextBase.Quiet` is set.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## **v4.3.5** UNRELEASED
+* BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool. [#2721](https://github.com/microsoft/sarif-sdk/issues/2721)
+
 ## **v4.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)
 * BUG: Disable certain console outputs (such as reporting of threads count) when `AnalyzeContextBase.Quiet` is set.
 

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -29,6 +29,8 @@
           exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\Sarif*;bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\WorkItems.dll;" />
     <file src="bld\bin\Signing\net462\**"
           target="tools\net462" />
+    <file src="bld\bin\Signing\net461\**"
+          target="tools\net462" />
 
     <!-- netcoreapp3.1 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.1\**"


### PR DESCRIPTION
* BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool.

The issue is from we changed from net472 to 461 and 462,
most of them are built for 461, we need to copy them or will have them missing in the package.

![image](https://github.com/microsoft/sarif-sdk/assets/81775155/d9dd3d00-b0f0-4883-aca3-0f92c236d1ba)

