### PR TITLE
Adding support in rolling hash for unicode separators

### DIFF
--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         private static readonly int SPACE = ' ';
         private static readonly int LF = '\n';
         private static readonly int CR = '\r';
+        private static readonly int Unicode_LS = '\u2028';
+        private static readonly int Unicode_PS = '\u2029';
         private static readonly int EOF = 65535;
         private static readonly int BLOCK_SIZE = 100;
         private static readonly Long MOD = new Long(37, 0, false);
@@ -219,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static Dictionary<int, string> RollingHash(string fileText)
         {
-            Dictionary<int, string> rollingHashes = new Dictionary<int, string>();
+            var rollingHashes = new Dictionary<int, string>();
 
             // A rolling view into the input
             int[] window = new int[BLOCK_SIZE];
@@ -230,7 +232,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 lineNumbers[i] = -1;
             }
 
-            Long hashRaw = new Long(0, 0, false);
+            var hashRaw = new Long(0, 0, false);
             Long firstMod = ComputeFirstMod();
 
             // The current index in the window, will wrap around to zero when we reach BLOCK_SIZE
@@ -242,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             // Was the previous character a CR (carriage return)
             bool prevCR = false;
 
-            Dictionary<string, int> hashCounts = new Dictionary<string, int>();
+            var hashCounts = new Dictionary<string, int>();
 
             // Output the current hash and line number to the cache
             Action outputHash = () =>
@@ -284,8 +286,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                     prevCR = false;
                     return;
                 }
-                // replace CR with LF
-                if (current == CR)
+                // replace CR, Unicode line separator and Unicode paragraph separator with LF
+                if (current == CR || current == Unicode_LS || current == Unicode_PS)
                 {
                     current = LF;
                     prevCR = true;

--- a/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             int numberOfTestFiles = 10;
 
-            List<string> filePaths = new List<string>(numberOfTestFiles);
+            var filePaths = new List<string>(numberOfTestFiles);
 
             for (int i = 0; i < numberOfTestFiles; i++)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
 
             //  An custom textwriter.S
             //  Using it should throw an InvalidOperationException when writing a string
-            TestTextWriter testTextWriter = new TestTextWriter();
+            var testTextWriter = new TestTextWriter();
             TextWriter defaultOut = Console.Out;
             Console.SetOut(testTextWriter);
 
@@ -95,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         [Fact]
         public void RollingHash_EmptyString()
         {
-            string testFileText = "";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>();
+            string testFileText = string.Empty;
+            var expectedOutput = new Dictionary<int, string>();
             expectedOutput.Add(1, "c129715d7a2bc9a3:1");
 
             Dictionary<int, string> actualOutput = HashUtilities.RollingHash(testFileText);
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = " a\nb\n  \t\tc\n d";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 { 1, "271789c17abda88f:1" },
                 { 2, "54703d4cd895b18:1" },
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = " hello; \t\nworld!!!\n\n\n  \t\tGreetings\n End";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "8b7cf3e952e7aeb2:1" },
                 {2, "b1ae1287ec4718d9:1" },
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = " hello; \t\nworld!!!\n\n\n  \t\tGreetings\n End\n";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "e9496ae3ebfced30:1" },
                 {2, "fb7c023a8b9ccb3f:1" },
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = "hello; \t\nworld!!!\r\r\r  \t\tGreetings\r End\r";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "e9496ae3ebfced30:1" },
                 {2, "fb7c023a8b9ccb3f:1" },
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = " hello; \t\r\nworld!!!\r\n\r\n\r\n  \t\tGreetings\r\n End\r\n";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "e9496ae3ebfced30:1" },
                 {2, "fb7c023a8b9ccb3f:1" },
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // Assume
             string testFileText = " hello; \t\nworld!!!\r\n\n\r  \t\tGreetings\r End\r\n";
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "e9496ae3ebfced30:1" },
                 {2, "fb7c023a8b9ccb3f:1" },
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
                 testFileText += test;
             }
 
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "a7f2ff13bc495cf2:1" },
                 {2, "a7f2ff13bc495cf2:2" },
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
             // Assume
             string testFileText = "x = 2\nx = 1\nprint(x)\nx = 3\nprint(x)\nx = 4\nprint(x)\n";
 
-            Dictionary<int, string> expectedOutput = new Dictionary<int, string>()
+            var expectedOutput = new Dictionary<int, string>()
             {
                 {1, "e54938cc54b302f1:1" },
                 {2, "bb609acbe9138d60:1" },
@@ -289,6 +289,26 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
                 {6, "2c644846cb18d53e:1" },
                 {7, "f1b89f20de0d133:1" },
                 {8, "c129715d7a2bc9a3:1" }
+            };
+
+            // Act
+            Dictionary<int, string> actualOutput = HashUtilities.RollingHash(testFileText);
+
+            // Assert
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        [Fact]
+        public void RollingHash_UnicodeSeparators()
+        {
+            // Assume
+            string testFileText = "x = 2\u2028x=1\u2029print(x)";
+
+            var expectedOutput = new Dictionary<int, string>()
+            {
+                {1, "8f6ec10ad8d7ec2a:1" },
+                {2, "18717025bc88f409:1" },
+                {3, "28b4d4d726d7c4d:1" }
             };
 
             // Act


### PR DESCRIPTION
This PR makes the following changes:

1. Rolling hash computations now support Unicode line separator `\u2028` and Unicode paragraph separator `\u2029`.
2. Unit tests checking this new logic.
3. Refactoring to conform to coding guidelines: (for example, if explicit type declared in RHS, use `var` in LHS).