### PR TITLE
Newline index: drop support for unicode line and paragraph separators.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## **v4.3.5** UNRELEASED
+## **v4.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)
+* BRK: Remove processing of `/u2028` (Unicode line separator) and `/u2029` (Unicode paragraph separator) from `NewLineIndex`.
 * BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool. [#2722](https://github.com/microsoft/sarif-sdk/issues/2722)
 
 ## **v4.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## **v4.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)
+## **v4.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.5)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.5) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * BRK: Remove processing of `/u2028` (Unicode line separator) and `/u2029` (Unicode paragraph separator) from `NewLineIndex`.
+* BUG: Resolve `KeyNotFoundException: The given key was not present` exception when scanning content that contains Unicode line and paragraph separators (`/u2028` and `/u2029`) when enabling `OptionallyEmittedData.RollingHashPartialFingerprints`. 
 * BUG: Fix `Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Sarif.Multitool.Library, Version=...` when using net462 version of the Multitool. [#2722](https://github.com/microsoft/sarif-sdk/issues/2722)
 
 ## **v4.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.4)

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         private static readonly int SPACE = ' ';
         private static readonly int LF = '\n';
         private static readonly int CR = '\r';
-        private static readonly int Unicode_LS = '\u2028';
-        private static readonly int Unicode_PS = '\u2029';
         private static readonly int EOF = 65535;
         private static readonly int BLOCK_SIZE = 100;
         private static readonly Long MOD = new Long(37, 0, false);
@@ -280,14 +278,16 @@ namespace Microsoft.CodeAnalysis.Sarif
             // was the start of a line then we should output the hash for that line.
             Action<int> processCharacter = (current) =>
             {
-                // skip tabs, spaces, and line feeds that come directly after a carriage return
+                // Skip tabs, spaces, and line feeds that come directly after a carriage return.
                 if (current == SPACE || current == TAB || (prevCR && current == LF))
                 {
                     prevCR = false;
                     return;
                 }
-                // replace CR, Unicode line separator and Unicode paragraph separator with LF
-                if (current == CR || current == Unicode_LS || current == Unicode_PS)
+                // Replace CR with LF.
+                // Note that we do not handle /u2028 (Unicode linefeed)
+                // or /u2029 (Unicode paragraph feed) characters.
+                if (current == CR)
                 {
                     current = LF;
                     prevCR = true;

--- a/src/Sarif/NewLineIndex.cs
+++ b/src/Sarif/NewLineIndex.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         // which is the line in the file at index n.
         private readonly ImmutableArray<int> _lineOffsetStarts;
 
-        // Realistically, no IDE creates start line that honor
+        // Realistically, no IDE create line locations based on the
         // the unicode separators, so we will ignore them.
         internal static char[] s_newLineChars =
         {

--- a/src/Sarif/NewLineIndex.cs
+++ b/src/Sarif/NewLineIndex.cs
@@ -19,12 +19,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         // which is the line in the file at index n.
         private readonly ImmutableArray<int> _lineOffsetStarts;
 
+        // Realistically, no IDE creates start line that honor
+        // the unicode separators, so we will ignore them.
         internal static char[] s_newLineChars =
         {
             '\n',
             '\r',
-            '\u2028', // Unicode line separate
-            '\u2029'  // Unicode paragraph separator
+            //'\u2028', // Unicode line separator
+            //'\u2029'  // Unicode paragraph separator
         };
 
         internal static ImmutableHashSet<char> s_newLineCharSet = ImmutableHashSet.Create(s_newLineChars);

--- a/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
@@ -299,16 +299,14 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         }
 
         [Fact]
-        public void RollingHash_UnicodeSeparators()
+        public void RollingHash_UnicodeSeparatorsAreIgnored()
         {
             // Assume
             string testFileText = "x = 2\u2028x=1\u2029print(x)";
 
             var expectedOutput = new Dictionary<int, string>()
             {
-                {1, "8f6ec10ad8d7ec2a:1" },
-                {2, "18717025bc88f409:1" },
-                {3, "28b4d4d726d7c4d:1" }
+                {1, "f0a8eee29e998ed7:1" },
             };
 
             // Act

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.3.4</VersionPrefix>
-    <PreviousVersionPrefix>4.3.3</PreviousVersionPrefix>
+    <VersionPrefix>4.3.5</VersionPrefix>
+    <PreviousVersionPrefix>4.3.4</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
* BRK: Remove processing of `/u2028` (Unicode line separator) and `/u2029` (Unicode paragraph separator) from `NewLineIndex`.
* BUG: Resolve `KeyNotFoundException: The given key was not present` exception when scanning content that contains Unicode line and paragraph separators (`/u2028` and `/u2029`) when enabling `OptionallyEmittedData.RollingHashPartialFingerprints`. 
