### PR TITLE
Preorder file traversal 

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## UNRELEASED
+* PRF: Switch file system traversal to pre-order with producer-consumer to accelerate time to scan first artifact.
+
 ## **v4.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.5)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.5) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * BRK: Remove processing of `/u2028` (Unicode line separator) and `/u2029` (Unicode paragraph separator) from `NewLineIndex`.
 * BUG: Resolve `KeyNotFoundException: The given key was not present` exception when scanning content that contains Unicode line and paragraph separators (`/u2028` and `/u2029`) when enabling `OptionallyEmittedData.RollingHashPartialFingerprints`. 

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -91,8 +91,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 directoryEnumerationTask = Task.Run(() =>
                 {
-                    EnqueueAllFilesUnderDirectory(directory, filesToProcessChannel.Writer, filter, new SortedSet<string>(StringComparer.Ordinal));
-                    filesToProcessChannel.Writer.Complete();
+                    try
+                    {
+                        EnqueueAllFilesUnderDirectory(directory, filesToProcessChannel.Writer, filter, new SortedSet<string>(StringComparer.Ordinal));
+                    }
+                    finally 
+                    { 
+                        filesToProcessChannel.Writer.Complete(); 
+                    }
                 });
             }
             else

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver
 {

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -76,11 +76,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 #endif
 
             var filesToProcessChannel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { AllowSynchronousContinuations = true, SingleReader = true, SingleWriter = true });
-   //       var filesToProcessChannel = Channel.CreateBounded<string>(new BoundedChannelOptions (1024)
-   //       {
-   //           AllowSynchronousContinuations = true, FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = true 
-   //       } );
-
 
             Task directoryEnumerationTask;
             if (this.recurse)

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -95,9 +95,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     {
                         EnqueueAllFilesUnderDirectory(directory, filesToProcessChannel.Writer, filter, new SortedSet<string>(StringComparer.Ordinal));
                     }
-                    finally 
-                    { 
-                        filesToProcessChannel.Writer.Complete(); 
+                    finally
+                    {
+                        filesToProcessChannel.Writer.Complete();
                     }
                 });
             }
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     this.isEnumerationEnded = true;
 
                     // WhenAll() waits on the task without triggering rethrow of any exceptions.
-                    Task.WhenAll(directoryEnumerationTask); 
+                    Task.WhenAll(directoryEnumerationTask);
                     if (directoryEnumerationTask.IsFaulted)
                     {
                         throw new AggregateException(ex, directoryEnumerationTask.Exception);

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     }
                 }
 
-                Task<int> analyzeTask = Task.Run(() =>
+                var analyzeTask = Task.Run(() =>
                 {
                     return Run(methodLocalContext);
                 }, globalContext.CancellationToken);
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             // 1: First we initiate an asynchronous operation to locate disk files for
             // analysis, as specified in analysis configuration (file names, wildcards).
-            Task<bool> enumerateTargets = Task.Run(() => EnumerateTargetsAsync(globalContext));
+            var enumerateTargets = Task.Run(() => EnumerateTargetsAsync(globalContext));
 
             // 2: A dedicated set of threads pull scan targets and analyze them.
             //    On completing a scan, the thread writes the index of the 
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             //    to ensure determinism in log output. i.e., any scan of the
             //    same targets using the same production code should produce
             //    a log file that is byte-for-byte identical to previous log.
-            Task logResults = Task.Run(() => LogResultsAsync(globalContext));
+            var logResults = Task.Run(() => LogResultsAsync(globalContext));
 
             Task.WhenAll(scanWorkers)
                 .ContinueWith(_ => _resultsWritingChannel.Writer.Complete())

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var logger = new MemoryStreamSarifLogger(dataToInsert: OptionallyEmittedData.Hashes);
             var command = new TestMultithreadedAnalyzeCommand();
-            Uri uri = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
+            var uri = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
 
             var target = new EnumeratedArtifact(FileSystem.Instance) { Uri = uri, Contents = "foo foo" };
 
@@ -748,7 +748,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             int result = command.Run(options: null, ref context);
             context.ValidateCommandExecution(result);
 
-            SarifLog sarifLog = logger.ToSarifLog();
+            var sarifLog = logger.ToSarifLog();
             sarifLog.Runs[0].Should().NotBeNull();
             sarifLog.Runs[0].Results[0].Should().NotBeNull();
             sarifLog.Runs[0].Results.Count.Should().Be(1);


### PR DESCRIPTION
This drops time to first scan from 5s to .5s in one of our large-ish repos.  Could also have systematic benefits, as it "streams" the targets out instead of maintaining a list of all directories in memory.  This could be significant for very large repos. AB#{2117606}