### PR TITLE
Ship v4.3.6

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,5 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## **Unreleased**
+## **v4.3.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.6)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * DEP: Updated NewtonSoft.JSON to 8.0.3 in Sarif.Converters for .NET targets later than `netstandard2.0`.
 * BUG: Logging improved when work item client is called with invalid work item values.
 * BUG: Resolve `InvalidOperationException` processing `RuleNotCalled` events.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## **Unreleased**
+## **v4.3.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.6)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * DEP: Updated NewtonSoft.JSON to 8.0.3 in Sarif.Converters for .NET targets later than `netstandard2.0`.
 * BUG: Logging improved when work item client is called with invalid work item values.
+* NEW: Add `Path.Combine`, `Path.GetDirectoryName` and `Path.GetFileNameWithoutExtension` to `IFileSystem`.
 
 ## **v4.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.5)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.5) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * BRK: Remove processing of `/u2028` (Unicode line separator) and `/u2029` (Unicode paragraph separator) from `NewLineIndex`.

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -135,20 +135,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         /// <summary>
-        /// Returns the absolute path for the specified path string.
-        /// </summary>
-        /// <param name="path">
-        /// The file or directory for which to obtain absolute path information.
-        /// </param>
-        /// <returns>
-        /// The fully qualified location of <paramref name="path"/>, such as "C:\MyFile.txt".
-        /// </returns>
-        public string PathGetFullPath(string path)
-        {
-            return Path.GetFullPath(path);
-        }
-
-        /// <summary>
         /// Returns the date and time the specified file or directory was last written to.
         /// </summary>
         /// <param name="path">The file or directory for which to obtain write date and time information.</param>
@@ -412,6 +398,62 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var fileVersionInfo = FileVersionInfo.GetVersionInfo(fileName);
             return fileVersionInfo;
+        }
+
+        /// <summary>
+        /// Combines an array of strings into a path.
+        /// </summary>
+        /// <param name="paths">
+        /// An array of parts of the path.
+        /// </param>
+        /// <returns>
+        /// The combined paths.
+        /// </returns>
+        public string PathCombine(params string[] paths)
+        {
+            return Path.Combine(paths);
+        }
+
+        /// <summary>
+        /// Returns the directory information for the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path of a file or directory.
+        /// </param>
+        /// <returns>
+        /// Directory information for path, or null if path denotes a root directory or is null. Returns <see cref="string.Empty"/> if path does not contain directory information.
+        /// </returns>
+        public string PathGetDirectoryName(string path)
+        { 
+            return Path.GetDirectoryName(path); 
+        }
+
+        /// <summary>
+        /// Returns the absolute path for the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path of a file or directory.
+        /// </param>
+        /// <returns>
+        /// The fully qualified location of <paramref name="path"/>, such as "C:\MyFile.txt".
+        /// </returns>
+        public string PathGetFullPath(string path)
+        {
+            return Path.GetFullPath(path);
+        }
+
+        /// <summary>
+        /// Returns the file name of the specified path string without the extension.
+        /// </summary>
+        /// <param name="path">
+        /// The path of the file.
+        /// </param>
+        /// <returns>
+        /// The string returned by <see cref = "Path.GetFileName(string)"/>, minus the last period (.) and all characters following it.
+        /// </returns>
+        public string PathGetFileNameWithoutExtension(string path) 
+        {
+            return Path.GetFileNameWithoutExtension(path);
         }
     }
 }

--- a/src/Sarif/IFileSystem.cs
+++ b/src/Sarif/IFileSystem.cs
@@ -302,17 +302,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         void FileSetAttributes(string path, FileAttributes fileAttributes);
 
         /// <summary>
-        /// Returns the absolute path for the specified path string.
-        /// </summary>
-        /// <param name="path">
-        /// The file or directory for which to obtain absolute path information.
-        /// </param>
-        /// <returns>
-        /// The fully qualified location of <paramref name="path"/>, such as "C:\MyFile.txt".
-        /// </returns>
-        string PathGetFullPath(string path);
-
-        /// <summary>
         /// Uses <see cref="FileInfo"/> to calculate the size of a file in bytes.
         /// </summary>
         /// <param name="path">
@@ -330,5 +319,49 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <returns>A <see cref="FileVersionInfo"/> containing information about the file. If the file did not
         /// contain version information, the FileVersionInfo contains only the name of the file requested.</returns>
         FileVersionInfo FileVersionInfoGetVersionInfo(string fileName);
+
+        /// <summary>
+        /// Combines an array of strings into a path.
+        /// </summary>
+        /// <param name="paths">
+        /// An array of parts of the path.
+        /// </param>
+        /// <returns>
+        /// The combined paths.
+        /// </returns>
+        string PathCombine(params string[] paths);
+
+        /// <summary>
+        /// Returns the directory information for the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path of a file or directory.
+        /// </param>
+        /// <returns>
+        /// Directory information for path, or null if path denotes a root directory or is null. Returns <see cref="string.Empty"/> if path does not contain directory information.
+        /// </returns>
+        string PathGetDirectoryName(string path);
+
+        /// <summary>
+        /// Returns the absolute path for the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path of a file or directory.
+        /// </param>
+        /// <returns>
+        /// The fully qualified location of <paramref name="path"/>, such as "C:\MyFile.txt".
+        /// </returns>
+        string PathGetFullPath(string path);
+
+        /// <summary>
+        /// Returns the file name of the specified path string without the extension.
+        /// </summary>
+        /// <param name="path">
+        /// The path of the file.
+        /// </param>
+        /// <returns>
+        /// The string returned by <see cref = "Path.GetFileName(string)"/>, minus the last period (.) and all characters following it.
+        /// </returns>
+        string PathGetFileNameWithoutExtension(string path);
     }
 }

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.3.5</VersionPrefix>
-    <PreviousVersionPrefix>4.3.4</PreviousVersionPrefix>
+    <VersionPrefix>4.3.6</VersionPrefix>
+    <PreviousVersionPrefix>4.3.5</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
* DEP: Updated NewtonSoft.JSON to 8.0.3 in Sarif.Converters for .NET targets later than `netstandard2.0`.
* BUG: Logging improved when work item client is called with invalid work item values.
* BUG: Resolve `InvalidOperationException` processing `RuleNotCalled` events.
* BUG: Emit optional data arguments for `RuleNotCalled` events in auto-formatted messages. 