### PR TITLE
Add binary vs. textual file enumeration.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,7 +2,6 @@
 
 ## **v4.4.0 UNRELEASED
 * BRK: `EnumeratedArtifact` now sniffs artifacts to distinguish between textual and binary data. The `Contents` property will be null for binary files (use `Bytes` instead).
-* BRK: `EnumeratedArtifact` raises `InvalidOperationException` for non-seekable streams (unless the `SupportNonSeekableStreams` property is set). Non-seekable streams result in performance inefficiencies when expanding.
 * BRK: `MultithreadedZipArchiveArtifactProvider` now distinguishes binary vs. textual data using a hard-coded binary files extensions list. This data will be made configurable in a future change. Current extensions include `.bmp`, `.cer`, `.der`, `.dll`, `.exe`, `.gif`, `.gz`, `.iso`, `.jpe`, `.jpeg`, `.lock`, `.p12`, `.pack`, `.pfx`, `.pkcs12`, `.png`, `.psd`, `.rar`, `.tar`, `.tif`, `.tiff`, `.xcf`, `.zip`.
 * NEW: `EnumeratedArtifact` now automatically detects and populates a `Bytes` property for binary files such as executables and certificates.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -3,7 +3,7 @@
 ## **v4.4.0 UNRELEASED
 * BRK: `EnumeratedArtifact` now sniffs artifacts to distinguish between textual and binary data. The `Contents` property will be null for binary files (use `Bytes` instead).
 * BRK: `EnumeratedArtifact` raises `InvalidOperationException` for non-seekable streams (unless the `SupportNonSeekableStreams` property is set). Non-seekable streams result in performance inefficiencies when expanding.
-* BRK: `MultithreadedZipArchiveArtifactProvider` now distinguishes binary vs. textual data using a hard-coded binary files extensions list. This data will be made configurable in a future change.
+* BRK: `MultithreadedZipArchiveArtifactProvider` now distinguishes binary vs. textual data using a hard-coded binary files extensions list. This data will be made configurable in a future change. Current extensions include `.bmp`, `.cer`, `.der`, `.dll`, `.exe`, `.gif`, `.gz`, `.iso`, `.jpe`, `.jpeg`, `.lock`, `.p12`, `.pack`, `.pfx`, `.pkcs12`, `.png`, `.psd`, `.rar`, `.tar`, `.tif`, `.tiff`, `.xcf`, `.zip`.
 * NEW: `EnumeratedArtifact` now automatically detects and populates a `Bytes` property for binary files such as executables and certificates.
 
 ## **v4.3.7** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.7) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.7) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.7)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.7) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,11 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v4.4.0 UNRELEASED
+* BRK: `EnumeratedArtifact` now sniffs artifacts to distinguish between textual and binary data. The `Contents` property will be null for binary files (use `Bytes` instead).
+* BRK: `EnumeratedArtifact` raises `InvalidOperationException` for non-seekable streams (unless the `SupportNonSeekableStreams` property is set). Non-seekable streams result in performance inefficiencies when expanding.
+* BRK: `MultithreadedZipArchiveArtifactProvider` now distinguishes binary vs. textual data using a hard-coded binary files extensions list. This data will be made configurable in a future change.
+* NEW: `EnumeratedArtifact` now automatically detects and populates a `Bytes` property for binary files such as executables and certificates.
+
 ## **v4.3.7** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.3.7) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.3.7) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.3.7)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.3.7) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.3.)
 * DEP: Updated NewtonSoft.JSON to 8.0.3 in Sarif.Converters for .NET targets later than `netstandard2.0`.
 * BUG: Logging improved when work item client is called with invalid work item values.

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                     DriverEventSource.Log.ReadArtifactStart(filePath);
                     // Reading the length property faults in the file contents.
-                    long sizeInBytes = perFileContext.CurrentTarget.Contents.Length;
+                    long sizeInBytes = perFileContext.CurrentTarget.SizeInBytes.Value;
                     DriverEventSource.Log.ReadArtifactStop(filePath, sizeInBytes);
 
                     DetermineApplicabilityAndAnalyze(perFileContext, skimmers, disabledSkimmers);

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 // This is our client-side, disk-based file retrieval case.
-                Stream = FileSystem.FileOpenRead(Uri.LocalPath);
+                this.Stream = FileSystem.FileOpenRead(Uri.LocalPath);
             }
 
             if (Stream.CanSeek)
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 RetrieveDataFromNonSeekableStream();
             }
 
-            Stream = null;
+            this.Stream = null;
 
             return (this.contents, this.bytes);
         }

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public Uri Uri { get; set; }
 
-        public bool IsBinary 
-        { 
+        public bool IsBinary
+        {
             get
             {
                 return this.isBinary ?? IsArtifactBinary();
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         internal bool IsArtifactBinary()
         {
-            if (isBinary.HasValue) 
+            if (isBinary.HasValue)
             {
                 return isBinary.Value;
             }
@@ -86,18 +86,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         private (string text, byte[] bytes) GetArtifactData()
         {
             if (this.contents != null)
-            { 
-                return (this.contents, bytes: null); 
+            {
+                return (this.contents, bytes: null);
             }
 
-            if (this.bytes != null) 
+            if (this.bytes != null)
             {
                 return (text: null, this.bytes);
             }
 
             if (Stream == null && this.contents == null && this.bytes == null)
             {
-                if (Uri == null || (Uri.IsAbsoluteUri && !Uri.IsFile)) 
+                if (Uri == null || (Uri.IsAbsoluteUri && !Uri.IsFile))
                 {
                     throw new InvalidOperationException();
                 }
@@ -109,8 +109,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             bool isText = false;
 
-            if (Stream.CanSeek) 
-            { 
+            if (Stream.CanSeek)
+            {
                 // Reset to beginning of stream in case caller neglected to do so.
                 this.Stream.Seek(0, SeekOrigin.Begin);
 
@@ -118,8 +118,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                 int length = this.Stream.Read(header, 0, header.Length);
                 isText = FileEncoding.CheckForTextualData(header, 0, length, out this.encoding);
 
-                if (isText) 
-                { 
+                if (isText)
+                {
                     // If we have textual data and the encoding was null, we are UTF8
                     // (which will be a perfectly valid encoding for ASCII as well).
                     this.encoding ??= Encoding.UTF8;
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
             else
             {
-                if (!SupportNonSeekableStreams) 
+                if (!SupportNonSeekableStreams)
                 {
                     throw new InvalidOperationException("Stream is not seekable. Provide a seekable stream or set the 'SupportNonSeekableStreams' property.");
                 }

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     this.SizeInBytes = (long)this.Stream.Length;
                 }
-                else if (Uri != null && Uri?.IsAbsoluteUri && Uri.IsFile)
+                else if (Uri != null && Uri.IsAbsoluteUri && Uri.IsFile)
                 {
                     this.sizeInBytes = (long)FileSystem.FileInfoLength(Uri.LocalPath);
                 }

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         internal byte[] bytes;
         internal string contents;
 
-        private bool? isBinary;
         private Encoding encoding;
 
         public Uri Uri { get; set; }
@@ -28,20 +27,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                return this.isBinary ?? IsArtifactBinary();
+                GetArtifactData();
+                return this.contents == null;
             }
-        }
-
-        internal bool IsArtifactBinary()
-        {
-            if (isBinary.HasValue)
-            {
-                return isBinary.Value;
-            }
-
-            GetArtifactData();
-            this.isBinary = this.contents == null;
-            return this.isBinary.Value;
         }
 
         public Stream Stream { get; set; }
@@ -151,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             // Reset to beginning of stream in case caller neglected to do so.
             this.Stream.Seek(0, SeekOrigin.Begin);
 
-            byte[] header = new byte[4096];
+            byte[] header = new byte[1024];
             int length = this.Stream.Read(header, 0, header.Length);
             isText = FileEncoding.CheckForTextualData(header, 0, length, out this.encoding);
 

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -50,15 +50,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         internal IFileSystem FileSystem { get; set; }
 
-        /// <summary>
-        /// Gets or sets a property that determines whether the enumerated artifact
-        /// can obtain data from a non-seekable stream. This operation will be
-        /// less performant in any case where an artifact is a textual file (as
-        /// the file will first be converted to a byte array to determine
-        /// whether it is textual and subsequently turned into a string if it is).
-        /// </summary>
-        public bool SupportNonSeekableStreams { get; set; }
-
         public string Contents
         {
             get => GetArtifactData().text;
@@ -113,10 +104,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         private void RetrieveDataFromNonSeekableStream()
         {
             bool isText;
-            if (!SupportNonSeekableStreams)
-            {
-                throw new InvalidOperationException("Stream is not seekable. Provide a seekable stream or set the 'SupportNonSeekableStreams' property.");
-            }
 
             this.bytes = new byte[Stream.Length];
             int length = this.Stream.Read(this.bytes, 0, this.bytes.Length);

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -97,9 +97,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (Stream == null && this.contents == null && this.bytes == null)
             {
-                if (Uri == null || (Uri.IsAbsoluteUri && !Uri.IsFile))
+                if (Uri == null ||
+                    !Uri.IsAbsoluteUri ||
+                    (Uri.IsAbsoluteUri && !Uri.IsFile))
                 {
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException("An absolute URI pointing to a file location was not available.");
                 }
 
                 // This is our client-side, disk-based file retrieval case.

--- a/src/Sarif/FileEncodings.cs
+++ b/src/Sarif/FileEncodings.cs
@@ -31,15 +31,15 @@
 #endregion
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public class FileEncoding
-    {        
+    {
         /// <summary>
         /// Detects if contains textual data.
         /// </summary>

--- a/src/Sarif/FileEncodings.cs
+++ b/src/Sarif/FileEncodings.cs
@@ -1,0 +1,137 @@
+﻿#region *   License     *
+/*
+    SimpleHelpers - FileEncoding   
+
+    Copyright © 2014 Khalid Salomão
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the “Software”), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE. 
+
+    License: http://www.opensource.org/licenses/mit-license.php
+    Website: https://github.com/khalidsalomao/SimpleHelpers.Net
+ */
+#endregion
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class FileEncoding
+    {        
+        /// <summary>
+        /// Detects if contains textual data.
+        /// </summary>
+        /// <param name="rawData">The raw data.</param>
+        public static bool CheckForTextualData(byte[] rawData, out Encoding encoding)
+        {
+            return CheckForTextualData(rawData, 0, rawData.Length, out encoding);
+        }
+
+        /// <summary>
+        /// Detects if contains textual data.
+        /// </summary>
+        /// <param name="rawData">The raw data.</param>
+        /// <param name="start">The start.</param>
+        /// <param name="count">The count.</param>
+        public static bool CheckForTextualData(byte[] rawData, int start, int count, out Encoding encoding)
+        {
+            encoding = null;
+
+            if (rawData.Length < count || count < 4 || start + 1 >= count)
+            {
+                return true;
+            }
+
+            if (CheckForByteOrderMark(rawData, out encoding, start))
+            {
+                return true;
+            }
+
+            // http://stackoverflow.com/questions/910873/how-can-i-determine-if-a-file-is-binary-or-text-in-c
+            // http://www.gnu.org/software/diffutils/manual/html_node/Binary.html
+            // count the number od null bytes sequences
+            // considering only sequences of 2 0s: "\0\0" or control characters below 10
+            int nullSequences = 0;
+            int controlSequences = 0;
+            for (int i = start + 1; i < count; i++)
+            {
+                if (rawData[i - 1] == 0 && rawData[i] == 0)
+                {
+                    if (++nullSequences > 1)
+                    {
+                        break;
+                    }
+                }
+                else if (rawData[i - 1] == 0 && rawData[i] < 10)
+                {
+                    ++controlSequences;
+                }
+            }
+
+            // is text if there is no null byte sequences or less than 10% of the buffer has control characters
+            return nullSequences == 0 && (controlSequences <= (rawData.Length / 10));
+        }
+
+        /// <summary>
+        /// Detects if data has bytes order mark to indicate its encoding for textual data.
+        /// </summary>
+        /// <param name="rawData">The raw data.</param>
+        /// <param name="start">The start.</param>
+        /// <returns></returns>
+        public static bool CheckForByteOrderMark(byte[] rawData, out Encoding encoding, int start = 0)
+        {
+            encoding = null;
+            if (rawData.Length - start < 4)
+            {
+                return false;
+            }
+
+            // Detect encoding correctly (from Rick Strahl's blog)
+            // http://www.west-wind.com/weblog/posts/2007/Nov/28/Detecting-Text-Encoding-for-StreamReader
+            if (rawData[start] == 0xef && rawData[start + 1] == 0xbb && rawData[start + 2] == 0xbf)
+            {
+                encoding = Encoding.UTF8;
+                return true;
+            }
+            else if (rawData[start] == 0xfe && rawData[start + 1] == 0xff)
+            {
+                encoding = Encoding.Unicode;
+                return true;
+            }
+            else if (rawData[start] == 0 && rawData[start + 1] == 0 && rawData[start + 2] == 0xfe && rawData[start + 3] == 0xff)
+            {
+                encoding = Encoding.UTF32;
+                return true;
+            }
+            else if (rawData[start] == 0x2b && rawData[start + 1] == 0x2f && rawData[start + 2] == 0x76)
+            {
+                encoding = Encoding.UTF7;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Sarif/IEnumeratedArtifact.cs
+++ b/src/Sarif/IEnumeratedArtifact.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         string Contents { get; set; }
 
+        byte[] Bytes { get; set; }
+
         long? SizeInBytes { get; set; }
     }
 }

--- a/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         private readonly ZipArchive zipArchive;
         private ISet<string> binaryExtensions;
 
-        public ISet<string> BinaryExtensions 
-        { 
+        public ISet<string> BinaryExtensions
+        {
             get
             {
                 this.binaryExtensions ??= CreateDefaultBinaryExtensionsSet();

--- a/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 foreach (ZipArchiveEntry entry in this.zipArchive.Entries)
                 {
-                    yield return new ZipArchiveArtifact(this.zipArchive, entry, this.binaryExtensions);
+                    yield return new ZipArchiveArtifact(this.zipArchive, entry, BinaryExtensions);
                 }
             }
         }

--- a/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class MultithreadedZipArchiveArtifactProvider : ArtifactProvider
+    {
+        private readonly ZipArchive zipArchive;
+
+        public MultithreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
+        {
+            this.zipArchive = zipArchive;
+
+            this.binaryExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+
+            this.binaryExtensions.Add(".bmp");
+            this.binaryExtensions.Add(".cab");
+            this.binaryExtensions.Add(".cer");
+            this.binaryExtensions.Add(".der");
+            this.binaryExtensions.Add(".dll");
+            this.binaryExtensions.Add(".exe");
+            this.binaryExtensions.Add(".gif");
+            this.binaryExtensions.Add(".gz");
+            this.binaryExtensions.Add(".iso");
+            this.binaryExtensions.Add(".jpe");
+            this.binaryExtensions.Add(".jpeg");
+            this.binaryExtensions.Add(".lock");
+            this.binaryExtensions.Add(".p12");
+            this.binaryExtensions.Add(".pack");
+            this.binaryExtensions.Add(".pfx");
+            this.binaryExtensions.Add(".pkcs12");
+            this.binaryExtensions.Add(".png");
+            this.binaryExtensions.Add(".psd");
+            this.binaryExtensions.Add(".rar");
+            this.binaryExtensions.Add(".tar");
+            this.binaryExtensions.Add(".tif");
+            this.binaryExtensions.Add(".tiff");
+            this.binaryExtensions.Add(".xcf");
+            this.binaryExtensions.Add(".zip");
+        }
+
+        private readonly HashSet<string> binaryExtensions;
+
+        public override IEnumerable<IEnumeratedArtifact> Artifacts
+        {
+            get
+            {
+                foreach (ZipArchiveEntry entry in this.zipArchive.Entries)
+                {
+                    yield return new ZipArchiveArtifact(this.zipArchive, entry, this.binaryExtensions);
+                }
+            }
+        }
+    }
+
+}

--- a/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/MultithreadedZipArchiveArtifactProvider.cs
@@ -10,41 +10,56 @@ namespace Microsoft.CodeAnalysis.Sarif
     public class MultithreadedZipArchiveArtifactProvider : ArtifactProvider
     {
         private readonly ZipArchive zipArchive;
+        private ISet<string> binaryExtensions;
+
+        public ISet<string> BinaryExtensions 
+        { 
+            get
+            {
+                this.binaryExtensions ??= CreateDefaultBinaryExtensionsSet();
+                return this.binaryExtensions;
+            }
+
+            set { this.binaryExtensions = value; }
+        }
 
         public MultithreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
         {
             this.zipArchive = zipArchive;
-
-            this.binaryExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-
-            this.binaryExtensions.Add(".bmp");
-            this.binaryExtensions.Add(".cab");
-            this.binaryExtensions.Add(".cer");
-            this.binaryExtensions.Add(".der");
-            this.binaryExtensions.Add(".dll");
-            this.binaryExtensions.Add(".exe");
-            this.binaryExtensions.Add(".gif");
-            this.binaryExtensions.Add(".gz");
-            this.binaryExtensions.Add(".iso");
-            this.binaryExtensions.Add(".jpe");
-            this.binaryExtensions.Add(".jpeg");
-            this.binaryExtensions.Add(".lock");
-            this.binaryExtensions.Add(".p12");
-            this.binaryExtensions.Add(".pack");
-            this.binaryExtensions.Add(".pfx");
-            this.binaryExtensions.Add(".pkcs12");
-            this.binaryExtensions.Add(".png");
-            this.binaryExtensions.Add(".psd");
-            this.binaryExtensions.Add(".rar");
-            this.binaryExtensions.Add(".tar");
-            this.binaryExtensions.Add(".tif");
-            this.binaryExtensions.Add(".tiff");
-            this.binaryExtensions.Add(".xcf");
-            this.binaryExtensions.Add(".zip");
         }
 
-        private readonly HashSet<string> binaryExtensions;
+        public ISet<string> CreateDefaultBinaryExtensionsSet()
+        {
+
+            ISet<string> result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            result.Add(".bmp");
+            result.Add(".cab");
+            result.Add(".cer");
+            result.Add(".der");
+            result.Add(".dll");
+            result.Add(".exe");
+            result.Add(".gif");
+            result.Add(".gz");
+            result.Add(".iso");
+            result.Add(".jpe");
+            result.Add(".jpeg");
+            result.Add(".lock");
+            result.Add(".p12");
+            result.Add(".pack");
+            result.Add(".pfx");
+            result.Add(".pkcs12");
+            result.Add(".png");
+            result.Add(".psd");
+            result.Add(".rar");
+            result.Add(".tar");
+            result.Add(".tif");
+            result.Add(".tiff");
+            result.Add(".xcf");
+            result.Add(".zip");
+
+            return result;
+        }
 
         public override IEnumerable<IEnumeratedArtifact> Artifacts
         {

--- a/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO.Compression;
 using System.IO;
+using System.IO.Compression;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
                     Stream = entry.Open(),
-                    SupportNonSeekableStreams = true,
                 };
 
                 // This step will fault in all artifact contents, whether textual

--- a/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Compression;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -16,11 +15,18 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             foreach (ZipArchiveEntry entry in zipArchive.Entries)
             {
-                artifacts.Add(new EnumeratedArtifact(Sarif.FileSystem.Instance)
+                var artifact = new EnumeratedArtifact(Sarif.FileSystem.Instance)
                 {
                     Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
-                    Contents = new StreamReader(entry.Open()).ReadToEnd()
-                });
+                    Stream = entry.Open(),
+                    SupportNonSeekableStreams = true,
+                };
+
+                // This step will fault in all artifact contents, whether textual
+                // or binary, and clear the zip stream, which is the point.
+                artifact.Contents = artifact.Contents;
+
+                artifacts.Add(artifact);
             }
 
             Artifacts = artifacts;

--- a/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
+++ b/src/Sarif/SinglethreadedZipArchiveArtifactProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class SinglethreadedZipArchiveArtifactProvider : ArtifactProvider
+    {
+        public SinglethreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
+        {
+            var artifacts = new List<IEnumeratedArtifact>();
+
+            foreach (ZipArchiveEntry entry in zipArchive.Entries)
+            {
+                artifacts.Add(new EnumeratedArtifact(Sarif.FileSystem.Instance)
+                {
+                    Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
+                    Contents = new StreamReader(entry.Open()).ReadToEnd()
+                });
+            }
+
+            Artifacts = artifacts;
+        }
+    }
+}

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -21,8 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, ISet<string> binaryExtensions)
         {
-            this.entry = entry;
-            this.archive = archive;
+            this.entry = entry ?? throw new ArgumentNullException(nameof(entry));
+            this.archive = archive ?? throw new ArgumentNullException(nameof(archive));
+
             this.binaryExtensions = binaryExtensions;
             this.uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute);
         }
@@ -35,9 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 lock (this.archive)
                 {
-                    return entry != null
-                        ? entry.Open()
-                        : null;
+                    return entry.Open();
                 }
             }
             set => throw new NotImplementedException();

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+
+    public class ZipArchiveArtifact : IEnumeratedArtifact
+    {
+        private readonly HashSet<string> binaryExtensions;
+        private readonly ZipArchive archive;
+        private ZipArchiveEntry entry;
+        private readonly Uri uri;
+        private string contents;
+        private byte[] bytes;
+
+        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, HashSet<string> binaryExtensions)
+        {
+            this.entry = entry;
+            this.archive = archive;
+            this.binaryExtensions = binaryExtensions;
+            this.uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute);
+        }
+
+        public Uri Uri => this.uri;
+
+        public Stream Stream
+        {
+            get
+            {
+                lock (this.archive)
+                {
+                    return entry != null
+                        ? entry.Open()
+                        : null;
+                }
+            }
+            set => throw new NotImplementedException();
+        }
+
+        public Encoding Encoding { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public string Contents
+        {
+            get => GetArtifactData().text;
+            set => this.contents = value;
+        }
+
+        public byte[] Bytes
+        {
+            get => GetArtifactData().bytes;
+            set => this.bytes = value;
+        }
+
+        private (string text, byte[] bytes) GetArtifactData()
+        {
+            if (this.contents == null && this.bytes == null)
+            {
+                lock (this.archive)
+                {
+                    if (this.contents == null && this.bytes == null)
+                    {
+                        string extension = Path.GetExtension(Uri.ToString());
+                        if (this.binaryExtensions.Contains(extension))
+                        {
+                            this.bytes = new byte[Stream.Length];
+                            Stream.Read(this.bytes, 0, this.bytes.Length);
+                        }
+                        else
+                        {
+                            this.contents = new StreamReader(Stream).ReadToEnd();
+                        }
+                    }
+                }
+                this.entry = null;
+            }
+
+            return (this.contents, this.bytes);
+        }
+
+        public long? SizeInBytes
+        {
+            get
+            {
+                lock (this.archive)
+                {
+                    if (this.entry != null)
+                    {
+                        return this.entry.Length;
+                    }
+
+                    return this.contents != null 
+                        ? this.contents.Length
+                        : this.bytes.Length;
+                }
+            }
+            set => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         private string contents;
         private byte[] bytes;
 
-        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, ISet<string> binaryExtensions)
+        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, ISet<string> binaryExtensions = null)
         {
             this.entry = entry ?? throw new ArgumentNullException(nameof(entry));
             this.archive = archive ?? throw new ArgumentNullException(nameof(archive));
 
-            this.binaryExtensions = binaryExtensions;
+            this.binaryExtensions = binaryExtensions ?? new HashSet<string>();
             this.uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute);
         }
 
@@ -34,6 +34,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
+                if (this.entry == null)
+                {
+                    return null;
+                }
+
                 lock (this.archive)
                 {
                     return entry.Open();
@@ -42,18 +47,31 @@ namespace Microsoft.CodeAnalysis.Sarif
             set => throw new NotImplementedException();
         }
 
-        public Encoding Encoding { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        /// <summary>
+        /// Raises NotImplementedException as we can't retrieve or set encoding
+        /// currently. Assessing this data requires decompressing the archive
+        /// stream. Currently, our encoding detection isn't highly developed.
+        /// In the future, we should consider eliminating the Encoding property
+        /// entirely from IEnumeratedArtifact or do the work of handling the
+        /// range of text encodings.
+
+        /// </summary>
+        public Encoding Encoding 
+        { 
+            get => throw new NotImplementedException(); 
+            set => throw new NotImplementedException(); 
+        }
 
         public string Contents
         {
             get => GetArtifactData().text;
-            set => this.contents = value;
+            set => throw new NotImplementedException();
         }
 
         public byte[] Bytes
         {
             get => GetArtifactData().bytes;
-            set => this.bytes = value;
+            set => throw new NotImplementedException();
         }
 
         private (string text, byte[] bytes) GetArtifactData()

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO.Compression;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         return this.entry.Length;
                     }
 
-                    return this.contents != null 
+                    return this.contents != null
                         ? this.contents.Length
                         : this.bytes.Length;
                 }

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -56,10 +56,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// range of text encodings.
 
         /// </summary>
-        public Encoding Encoding 
-        { 
-            get => throw new NotImplementedException(); 
-            set => throw new NotImplementedException(); 
+        public Encoding Encoding
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
         public string Contents

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis.Sarif
 
     public class ZipArchiveArtifact : IEnumeratedArtifact
     {
-        private readonly HashSet<string> binaryExtensions;
+        private readonly ISet<string> binaryExtensions;
         private readonly ZipArchive archive;
         private ZipArchiveEntry entry;
         private readonly Uri uri;
         private string contents;
         private byte[] bytes;
 
-        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, HashSet<string> binaryExtensions)
+        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry, ISet<string> binaryExtensions)
         {
             this.entry = entry;
             this.archive = archive;

--- a/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
+using System.Text;
 
 using FluentAssertions;
 
@@ -123,10 +124,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             mockFileSystem.Setup(x => x.DirectoryGetDirectories(It.IsAny<string>())).Returns(Array.Empty<string>());
             mockFileSystem.Setup(x => x.DirectoryGetFiles(inputLogDirectory, fileToBeValidated)).Returns(new string[] { filePathToBeValidated });
             mockFileSystem.Setup(x => x.FileReadAllText(filePathToBeValidated)).Returns(logText);
+            mockFileSystem.Setup(x => x.FileOpenRead(filePathToBeValidated)).Returns(new MemoryStream(Encoding.UTF8.GetBytes(filePathToBeValidated)));
             mockFileSystem.Setup(x => x.FileExists(baselineFilePath)).Returns(true);
             mockFileSystem.Setup(x => x.DirectoryEnumerateFiles(It.IsAny<string>(), fileToBeValidated, SearchOption.TopDirectoryOnly)).Returns(new string[] { filePathToBeValidated });
             mockFileSystem.Setup(x => x.FileReadAllText(baselineFilePath)).Returns(baselineText);
             mockFileSystem.Setup(x => x.FileReadAllText(It.IsNotIn<string>(filePathToBeValidated))).Returns<string>(path => File.ReadAllText(path));
+            mockFileSystem.Setup(x => x.FileOpenRead(baselineFilePath)).Returns(new MemoryStream(Encoding.UTF8.GetBytes(baselineText)));
             mockFileSystem.Setup(x => x.FileWriteAllText(It.IsAny<string>(), It.IsAny<string>()));
             mockFileSystem.Setup(x => x.FileCreate(outputLogFilePath)).Returns((string path) => File.Create(path));
             mockFileSystem.Setup(x => x.FileCreate(baselineFilePath)).Returns((string path) => File.Create(path));
@@ -141,8 +144,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             SarifLog actualLog = JsonConvert.DeserializeObject<SarifLog>(actualLogFileContents);
             Run run = actualLog.Runs[0];
 
-            // guid/correlation guid/provenance detection time changes every time 
-            // remove them to not failuring the comparing
+            // Guid/correlation guid/provenance detection time change for every analysis run.
+            // Remove them to not fail the comparison checks.
             foreach (Result result in run.Results)
             {
                 result.Guid = null;

--- a/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/BaselineOptionTests.cs
@@ -144,8 +144,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             SarifLog actualLog = JsonConvert.DeserializeObject<SarifLog>(actualLogFileContents);
             Run run = actualLog.Runs[0];
 
-            // Guid/correlation guid/provenance detection time change for every analysis run.
-            // Remove them to not fail the comparison checks.
+            // Guid/correlation guid/provenance detection times change for every analysis run.
+            // Remove these in order not to fail the comparison checks.
             foreach (Result result in run.Results)
             {
                 result.Guid = null;

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 using FluentAssertions;
 
@@ -517,6 +518,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             mockFileSystem.Setup(x => x.DirectoryGetDirectories(It.IsAny<string>())).Returns(Array.Empty<string>());
             mockFileSystem.Setup(x => x.DirectoryEnumerateFiles(inputLogDirectory, inputLogFileName, SearchOption.TopDirectoryOnly)).Returns(new string[] { inputLogFilePath });
             mockFileSystem.Setup(x => x.FileReadAllText(inputLogFilePath)).Returns(v2LogText);
+            mockFileSystem.Setup(x => x.FileOpenRead(inputLogFilePath)).Returns(new MemoryStream(Encoding.UTF8.GetBytes(v2LogText)));
             mockFileSystem.Setup(x => x.FileReadAllText(It.IsNotIn<string>(inputLogFilePath))).Returns<string>(path => File.ReadAllText(path));
 
             // Some rules are disabled by default, so create a configuration file that explicitly

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -1288,6 +1288,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             return filePath;
         }
 
+        private static string GetSampleFileToTest()
+        {
+            string filePath = typeof(AnalyzeCommandBaseTests).Assembly.Location;
+            filePath = Path.GetDirectoryName(filePath);
+            filePath = Path.Combine(filePath, "SampleTestFile.txt");
+
+            if (!File.Exists(filePath))
+            {
+                File.WriteAllText(filePath, $"{Guid.NewGuid()}");
+            }
+
+            return filePath;
+        }
+
         [Fact]
         public void AnalyzeCommandBase_UpdateLocationsAndMessageWithCurrentUri()
         {

--- a/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/ValidateCommandTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Design.Serialization;
 using System.IO;
+using System.Text;
 
 using FluentAssertions;
 
@@ -47,6 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             mockFileSystem.Setup(x => x.DirectoryExists(LogFileDirectoryWithSpace)).Returns(true);
             mockFileSystem.Setup(x => x.DirectoryEnumerateFiles(LogFileDirectoryWithSpace, It.IsAny<string>(), SearchOption.TopDirectoryOnly)).Returns(new[] { LogFileName });
             mockFileSystem.Setup(x => x.FileReadAllText(logFilePath)).Returns(RewriteCommandTests.MinimalCurrentV2Text);
+            mockFileSystem.Setup(x => x.FileOpenRead(logFilePath)).Returns(new MemoryStream(Encoding.UTF8.GetBytes(RewriteCommandTests.MinimalCurrentV2Text)));
             mockFileSystem.Setup(x => x.FileReadAllText(SchemaFilePath)).Returns(SchemaFileContents);
 
             var validateCommand = new ValidateCommand(mockFileSystem.Object);

--- a/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
+++ b/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
+using System.Text;
 
 using FluentAssertions;
 
@@ -17,45 +20,89 @@ namespace Test.UnitTests.Sarif
     {
 
         [Fact]
-        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytes()
+        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytesBeforeRetrievingContents()
         {
-            string entryContents = "test";
-            ZipArchive zip = CreateZipArchive("test.zip", entryContents);
+            string entryContents = $"{Guid.NewGuid}";
+            ZipArchive zip = CreateZipArchiveWithTextContents("test.txt", entryContents);
             var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
-            foreach (IEnumeratedArtifact artifact in artifactProvider.Artifacts)
-            {
-                long? size = artifact.SizeInBytes;
-                artifact.SizeInBytes.Should().Be(entryContents.Length);
-            }
+
+            ValidateTextContents(artifactProvider.Artifacts, entryContents);
         }
 
         [Fact]
-        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytesAfterRetrievingContent()
+        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytesBeforeRetrievingBytes()
         {
-            string entryContents = "test";
-            ZipArchive zip = CreateZipArchive("test.zip", entryContents);
+            string entryContents = $"{Guid.NewGuid()}";
+
+            // Note that even thought we populate an archive with text contents, the extension
+            // of the archive entry indicates a binary file. So we expect binary data on expansion.
+            ZipArchive zip = CreateZipArchiveWithTextContents("test.exe", entryContents);
+            var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
+
+            ValidateBinaryContents(artifactProvider.Artifacts, Encoding.UTF8.GetBytes(entryContents));
+        }
+
+        [Fact]
+        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytesAfterRetrievingContents()
+        {
+            string entryContents = $"{Guid.NewGuid()}";
+            ZipArchive zip = CreateZipArchiveWithTextContents("test.txt", entryContents);
+            var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
+
+            ValidateTextContents(artifactProvider.Artifacts, entryContents);
+        }
+
+        [Fact]
+        public void MultithreadedZipArchiveArtifactProvider_RetrieveSizeInBytesAfterRetrievingBytes()
+        {
+            string filePath = this.GetType().Assembly.Location;
+            using FileStream reader = File.OpenRead(filePath);
+
+            int headerSize = 1024;
+            byte[] data = new byte[1024];
+            reader.Read(data, 0, data.Length);
+
+            ZipArchive zip = CreateZipArchiveWithBinaryContents("test.dll", data);
             var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
             foreach (IEnumeratedArtifact artifact in artifactProvider.Artifacts)
             {
-                string content = artifact.Contents;
-                long? size = artifact.SizeInBytes;
-                artifact.SizeInBytes.Should().Be(entryContents.Length);
+                artifact.Bytes.Should().NotBeNull();
+                artifact.Bytes.Length.Should().Be(headerSize);
+                artifact.SizeInBytes.Should().Be(headerSize);
+
+                artifact.Contents.Should().BeNull();
             }
         }
 
         [Fact]
         public void MultithreadedZipArchiveArtifactProvider_SizeInBytesAndContentsAreAvailable()
         {
-            string entryContents = "test";
-            ZipArchive zip = CreateZipArchive("test.zip", entryContents);
+            string entryContents = $"{Guid.NewGuid()}";
+            ZipArchive zip = CreateZipArchiveWithTextContents("test.csv", entryContents);
             var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
-            foreach (IEnumeratedArtifact artifact in artifactProvider.Artifacts)
-            {
-                artifact.SizeInBytes.Should().Be(entryContents.Length);
-            }
+
+            ValidateTextContents(artifactProvider.Artifacts, entryContents);
         }
 
-        private static ZipArchive CreateZipArchive(string fileName, string content)
+        private void ValidateTextContents(IEnumerable<IEnumeratedArtifact> artifacts, string entryContents)
+        {
+            artifacts.Count().Should().Be(1);
+            IEnumeratedArtifact artifact = artifacts.First();
+            artifact.Contents.Should().Be(entryContents);
+            artifact.SizeInBytes.Should().Be(entryContents.Length);
+            artifact.Bytes.Should().BeNull();
+        }
+
+        private void ValidateBinaryContents(IEnumerable<IEnumeratedArtifact> artifacts, byte[] bytes)
+        {
+            artifacts.Count().Should().Be(1);
+            IEnumeratedArtifact artifact = artifacts.First();
+            artifact.Bytes.Should().BeEquivalentTo(bytes);
+            artifact.SizeInBytes.Should().Be(bytes.Length);
+            artifact.Contents.Should().BeNull();
+        }
+
+        private static ZipArchive CreateZipArchiveWithTextContents(string fileName, string contents)
         {
             var stream = new MemoryStream();
             using (var populateArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
@@ -63,8 +110,22 @@ namespace Test.UnitTests.Sarif
                 ZipArchiveEntry entry = populateArchive.CreateEntry(fileName, CompressionLevel.NoCompression);
                 using (var errorWriter = new StreamWriter(entry.Open()))
                 {
-                    errorWriter.Write(content);
+                    errorWriter.Write(contents);
                 }
+            }
+            stream.Flush();
+            stream.Position = 0;
+
+            return new ZipArchive(stream, ZipArchiveMode.Read);
+        }
+
+        private static ZipArchive CreateZipArchiveWithBinaryContents(string fileName, byte[] bytes)
+        {
+            var stream = new MemoryStream();
+            using (var populateArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                ZipArchiveEntry entry = populateArchive.CreateEntry(fileName, CompressionLevel.NoCompression);
+                entry.Open().Write(bytes);
             }
             stream.Flush();
             stream.Position = 0;

--- a/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
+++ b/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
@@ -59,7 +59,7 @@ namespace Test.UnitTests.Sarif
             using FileStream reader = File.OpenRead(filePath);
 
             int headerSize = 1024;
-            byte[] data = new byte[1024];
+            byte[] data = new byte[headerSize];
             reader.Read(data, 0, data.Length);
 
             ZipArchive zip = CreateZipArchiveWithBinaryContents("test.dll", data);

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -22,6 +22,14 @@ namespace Test.UnitTests.Sarif
         [Fact]
         public void EnumeratedArtifact_TextFileEncodingsAreProperlyDetected()
         {
+            // This test is just a placeholder. We do not have logic below
+            // that reliably produces disk files with appropriate BOMs/file
+            // formats to properly test the encoding detection from the new
+            // helpers we have added. This test passes but is very incomplete.
+            // If/when we have additional demands to support esoteric encodings
+            // in analysis, we can build this out. Currently, things are not
+            // guaranteed to work reliably except in ASCII, UTF8, Unicode.
+
             string guid = Guid.NewGuid().ToString();
 
 #pragma warning disable SYSLIB0001 // Type or member is obsolete

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -3,11 +3,15 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
+using Moq;
 
 using Xunit;
 
@@ -16,7 +20,186 @@ namespace Test.UnitTests.Sarif
     public class EnumeratedArtifactTests
     {
         [Fact]
-        public void EnumeratedArtifact_FileSizeShouldNotFaultInContents()
+        public void EnumeratedArtifact_TextFileEncodingsAreProperlyDetected()
+        {
+            string guid = Guid.NewGuid().ToString();
+
+#pragma warning disable SYSLIB0001 // Type or member is obsolete
+            foreach (Encoding encoding in new[] { Encoding.UTF8 } ) 
+            {
+                byte[] bytes = encoding.GetBytes(guid);
+
+                using var tempFile = new TempFile();
+                File.WriteAllBytes(tempFile.Name, bytes);
+
+                using var stream = new MemoryStream(File.ReadAllBytes(tempFile.Name));
+
+                var fileSystem = new Mock<IFileSystem>();
+                fileSystem
+                    .Setup(f => f.FileExists(It.IsAny<string>()))
+                    .Returns(true);
+
+                fileSystem
+                    .Setup(f => f.FileOpenRead(It.IsAny<string>()))
+                    .Returns(stream);
+
+                var artifact = new EnumeratedArtifact(fileSystem.Object)
+                {
+                    Uri = new Uri(@"c:\SomeFile.txt"),
+                    Stream = stream,
+                };
+
+                artifact.Encoding.Should().Be(encoding);
+            }
+#pragma warning restore SYSLIB0001 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_BinaryFile_OnDisk()
+        {
+            string filePath = this.GetType().Assembly.Location;
+
+            var artifact = new EnumeratedArtifact(new FileSystem())
+            {
+                Uri = new Uri(filePath)
+            };
+
+            int fileSize = (int)new FileInfo(filePath).Length;
+
+            ValidateBinaryArtifact(artifact, fileSize);
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_TextFile_OnDisk()
+        {
+            using var tempFile = new TempFile();
+            string filePath = tempFile.Name;
+
+            File.WriteAllText(filePath, $"{Guid.NewGuid}");
+
+            var artifact = new EnumeratedArtifact(new FileSystem())
+            {
+                Uri = new Uri(filePath)
+            };
+
+            int fileSize = (int)new FileInfo(filePath).Length;
+
+            ValidateTextArtifact(artifact, fileSize);
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_BinaryFile_SeekableStream()
+        {
+            string filePath = this.GetType().Assembly.Location;
+
+            // To ensure that this test operates strictly against the
+            // stream we provider, we will force the file system to
+            // return null if the object attempts to load anything
+            // from disk.
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(f => f.FileOpenRead(It.IsAny<string>()))
+                .Returns((Stream)null);
+
+            var artifact = new EnumeratedArtifact(fileSystem.Object)
+            {
+                Uri = new Uri(filePath),
+                Stream = new MemoryStream(File.ReadAllBytes(filePath)),
+            };
+
+            int fileSize = (int)new FileInfo(filePath).Length;
+
+            ValidateBinaryArtifact(artifact, fileSize);
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_TextFile_SeekableStream()
+        {
+            using var tempFile = new TempFile();
+            string filePath = tempFile.Name;
+
+            File.WriteAllText(filePath, $"{Guid.NewGuid}");
+
+            var artifact = new EnumeratedArtifact(new FileSystem())
+            {
+                Uri = new Uri(filePath),
+                Stream = new MemoryStream(File.ReadAllBytes(filePath)),
+            };
+
+            int fileSize = (int)new FileInfo(filePath).Length;
+
+            // Ensure that we don't have a file on disk and that the
+            // enumerated artifact is operating strictly from the stream.
+            tempFile.Dispose();
+            File.Exists(filePath).Should().BeFalse();
+
+            ValidateTextArtifact(artifact, fileSize);
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_TextFile_NonSeekableStream()
+        {
+            string guid = $"{Guid.NewGuid()}";
+            ZipArchive archive = CreateZipArchive("MyTextualFile.txt", Encoding.UTF8.GetBytes(guid));
+
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                var artifact = new EnumeratedArtifact(FileSystem.Instance)
+                {
+                    Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
+                    SupportNonSeekableStreams = true,
+                    Stream = entry.Open(),
+                };
+
+                ValidateTextArtifact(artifact, guid.Length);
+            }
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_BinaryFile_NonSeekableStream()
+        {
+
+        }
+
+        [Fact]
+        public void EnumeratedArtifact_TextFile_NonSeekableStreamRaiseExceptions()
+        {
+            string guid = $"{Guid.NewGuid()}";
+            ZipArchive archive = CreateZipArchive("MyTextualFile.txt", Encoding.UTF8.GetBytes(guid));
+
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                var artifact = new EnumeratedArtifact(FileSystem.Instance)
+                {
+                    Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
+                    Stream = entry.Open(),
+                };
+
+                Assert.Throws<InvalidOperationException>(() => ValidateTextArtifact(artifact, guid.Length));
+            }
+        }
+
+        private void ValidateBinaryArtifact(EnumeratedArtifact artifact, int sizeInBytes)
+        {
+            artifact.Bytes.Should().NotBeNull();
+            artifact.Bytes.Length.Should().Be(sizeInBytes);
+            artifact.SizeInBytes.Should().Be(sizeInBytes);
+
+            artifact.Contents.Should().BeNull();
+        }
+
+        private void ValidateTextArtifact(EnumeratedArtifact artifact, int sizeInBytes)
+        {
+            artifact.Contents.Should().NotBeNull();
+            artifact.Contents.Length.Should().Be(sizeInBytes);
+            artifact.SizeInBytes.Should().Be(sizeInBytes);
+
+            artifact.Bytes.Should().BeNull();
+        }
+
+
+        [Fact]
+        public void EnumeratedArtifact_FileSizeShouldNotFaultInContentsFromDisk()
         {
             string filePath = this.GetType().Assembly.Location;
             var enumeratedArtifact = new EnumeratedArtifact(FileSystem.Instance)
@@ -66,6 +249,20 @@ namespace Test.UnitTests.Sarif
             enumeratedArtifact.contents.Should().BeNull();
             enumeratedArtifact.SizeInBytes.Should().Be((long)contentBytes.Length);
             enumeratedArtifact.Contents.Should().Be(contents);
+        }
+
+        private static ZipArchive CreateZipArchive(string fileName, byte[] content)
+        {
+            var stream = new MemoryStream();
+            using (var populateArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                ZipArchiveEntry entry = populateArchive.CreateEntry(fileName, CompressionLevel.NoCompression);
+                entry.Open().Write(content, 0, content.Length);                
+            }
+            stream.Flush();
+            stream.Position = 0;
+
+            return new ZipArchive(stream, ZipArchiveMode.Read);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -221,6 +221,7 @@ namespace Test.UnitTests.Sarif
             artifact.Bytes.Should().NotBeNull();
             artifact.Bytes.Length.Should().Be(sizeInBytes);
             artifact.SizeInBytes.Should().Be(sizeInBytes);
+            artifact.IsBinary.Should().BeTrue();
 
             artifact.Contents.Should().BeNull();
         }
@@ -230,6 +231,7 @@ namespace Test.UnitTests.Sarif
             artifact.Contents.Should().NotBeNull();
             artifact.Contents.Length.Should().Be(sizeInBytes);
             artifact.SizeInBytes.Should().Be(sizeInBytes);
+            artifact.IsBinary.Should().BeFalse();
 
             artifact.Bytes.Should().BeNull();
         }

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -189,14 +189,14 @@ namespace Test.UnitTests.Sarif
         }
 
         [Fact]
-        public void EnumeratedArtifact_TextFile_SizeInBytesWithNoUriReturnsNull()
+        public void EnumeratedArtifact_TextFile_SizeInBytesWithRelativeUriReturnsNull()
         {
             var artifact = new EnumeratedArtifact(new FileSystem())
             {
-                Contents = $"{Guid.NewGuid}",
+                Uri = new Uri("/test.txt", UriKind.Relative)
             };
 
-            artifact.SizeInBytes.Should().BeNull();
+            Assert.Throws<InvalidOperationException>(() => artifact.SizeInBytes);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -25,7 +25,7 @@ namespace Test.UnitTests.Sarif
             string guid = Guid.NewGuid().ToString();
 
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
-            foreach (Encoding encoding in new[] { Encoding.UTF8 } ) 
+            foreach (Encoding encoding in new[] { Encoding.UTF8 })
             {
                 byte[] bytes = encoding.GetBytes(guid);
 
@@ -257,7 +257,7 @@ namespace Test.UnitTests.Sarif
             using (var populateArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
             {
                 ZipArchiveEntry entry = populateArchive.CreateEntry(fileName, CompressionLevel.NoCompression);
-                entry.Open().Write(content, 0, content.Length);                
+                entry.Open().Write(content, 0, content.Length);
             }
             stream.Flush();
             stream.Position = 0;

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -32,7 +32,6 @@ namespace Test.UnitTests.Sarif
 
             string guid = Guid.NewGuid().ToString();
 
-#pragma warning disable SYSLIB0001 // Type or member is obsolete
             foreach (Encoding encoding in new[] { Encoding.UTF8 })
             {
                 byte[] bytes = encoding.GetBytes(guid);
@@ -59,7 +58,6 @@ namespace Test.UnitTests.Sarif
 
                 artifact.Encoding.Should().Be(encoding);
             }
-#pragma warning restore SYSLIB0001 // Type or member is obsolete
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/EnumeratedArtifactTests.cs
@@ -155,7 +155,6 @@ namespace Test.UnitTests.Sarif
                 var artifact = new EnumeratedArtifact(FileSystem.Instance)
                 {
                     Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
-                    SupportNonSeekableStreams = true,
                     Stream = entry.Open(),
                 };
 
@@ -180,7 +179,6 @@ namespace Test.UnitTests.Sarif
                 var artifact = new EnumeratedArtifact(FileSystem.Instance)
                 {
                     Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
-                    SupportNonSeekableStreams = true,
                     Stream = entry.Open(),
                 };
 
@@ -197,23 +195,6 @@ namespace Test.UnitTests.Sarif
             };
 
             Assert.Throws<InvalidOperationException>(() => artifact.SizeInBytes);
-        }
-
-        [Fact]
-        public void EnumeratedArtifact_TextFile_NonSeekableStreamRaiseExceptions()
-        {
-            string guid = $"{Guid.NewGuid()}";
-            ZipArchive archive = CreateZipArchive("MyTextualFile.txt", Encoding.UTF8.GetBytes(guid));
-
-            foreach (ZipArchiveEntry entry in archive.Entries)
-            {
-                var artifact = new EnumeratedArtifact(FileSystem.Instance)
-                {
-                    Stream = entry.Open(),
-                };
-
-                Assert.Throws<InvalidOperationException>(() => ValidateTextArtifact(artifact, guid.Length));
-            }
         }
 
         private void ValidateBinaryArtifact(EnumeratedArtifact artifact, int sizeInBytes)
@@ -290,7 +271,7 @@ namespace Test.UnitTests.Sarif
             enumeratedArtifact.Contents.Should().Be(contents);
         }
 
-        private static ZipArchive CreateZipArchive(string fileName, byte[] content)
+        internal static ZipArchive CreateZipArchive(string fileName, byte[] content)
         {
             var stream = new MemoryStream();
             using (var populateArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))

--- a/src/Test.UnitTests.Sarif/ZipArchiveArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/ZipArchiveArtifactTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Xunit;
+
+namespace Test.UnitTests.Sarif
+{
+    public class ZipArchiveArtifactTests
+    {
+        [Fact]
+        public void ZipArchiveArtifact_BytesAndContentsCannotBeSet()
+        {
+            (ZipArchive archive, ZipArchiveEntry entry) testData = GetTextArchiveData();
+            var zipArchiveArtifact = new ZipArchiveArtifact(testData.archive, testData.entry);
+
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.Contents = string.Empty);
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.Bytes = new byte[] { });
+        }
+
+        [Fact]
+        public void ZipArchiveArtifact_EncodingNotImplemented()
+        {
+            (ZipArchive archive, ZipArchiveEntry entry) testData = GetTextArchiveData();
+            var zipArchiveArtifact = new ZipArchiveArtifact(testData.archive, testData.entry);
+
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.Encoding);
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.Encoding = Encoding.UTF8);
+        }
+
+        [Fact]
+        public void ZipArchiveArtifact_SettingStreamNotImplemented()
+        {
+            (ZipArchive archive, ZipArchiveEntry entry) testData = GetTextArchiveData();
+            var zipArchiveArtifact = new ZipArchiveArtifact(testData.archive, testData.entry);
+
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.Stream = null);
+        }
+
+        [Fact]
+        public void ZipArchiveArtifact_SettingSizeInBytesNotImplemented()
+        {
+            (ZipArchive archive, ZipArchiveEntry entry) testData = GetTextArchiveData();
+            var zipArchiveArtifact = new ZipArchiveArtifact(testData.archive, testData.entry);
+
+            Assert.Throws<NotImplementedException>(() => zipArchiveArtifact.SizeInBytes = null);
+        }
+
+        [Fact]
+        public void ZipArchiveArtifact_NonNullArchiveAndEntryAreRequired()
+        {
+            (ZipArchive archive, ZipArchiveEntry entry) testData = GetTextArchiveData();
+
+            Assert.Throws<ArgumentNullException>(() => new ZipArchiveArtifact(archive: null, testData.entry));
+            Assert.Throws<ArgumentNullException>(() => new ZipArchiveArtifact(testData.archive, entry: null));
+        }
+
+
+        private (ZipArchive archive, ZipArchiveEntry entry) GetTextArchiveData()
+        {
+            byte[] contents = Encoding.UTF8.GetBytes($"{Guid.NewGuid()}");
+            ZipArchive archive = EnumeratedArtifactTests.CreateZipArchive("MyZippedFile.txt", contents);
+            ZipArchiveEntry entry = archive.Entries.First();
+
+            return (archive, entry);
+        }
+    }
+}


### PR DESCRIPTION
* BRK: `EnumeratedArtifact` now sniffs artifacts to distinguish between textual and binary data. The `Contents` property will be null for binary files (use `Bytes` instead).
* BRK: `EnumeratedArtifact` raises `InvalidOperationException` for non-seekable streams (unless the `SupportNonSeekableStreams` property is set). Non-seekable streams result in performance inefficiencies when expanding.
* BRK: `MultithreadedZipArchiveArtifactProvider` now distinguishes binary vs. textual data using a hard-coded binary files extensions list. This data will be made configurable in a future change.
* NEW: `EnumeratedArtifact` now automatically detects and populates a `Bytes` property for binary files such as executables and certificates.

Previously, artifact enumeration assumed all data consisted of text. This breaks attempts to load/examine binary data.

In `EnumeratedArtifact`, we now examine the beginning of all seekable streams to detect whether we are seeing textual or binary data. We do so using an OSS snippet that looks for null/control characters in that data. This code also attempts to retrieve a range of text file encodings but this capability is not verified. Binary files are retrieved as byte arrays. Text files go to the existing `Contents` property. 

If we have a non-seekable stream, what we have to do is retrieve the file as a byte array and then subsequently convert it to text if we determine that it is textual. This is a performance degradation from our previous implementation and so we require users to explicitly set a `SupportNonSeekableStreams` property to ensure they know what they are opting into. 

Separately, the `MultithreadedZipArchiveArtifactProvider` *does* enumerate non-seekable streams, since they comprise compressed data. This provider uses a specialized `ZipArchiveArtifact` kind. Rather than accepting the costs to double-transform a text stream to bytes and then a decoded string, we simply hard-code a set of binary file extensions and only retrieve these as bytes. This property is settable. This isn't a really ideal solution but works for our immediate scenarios. You could imagine updating this class to optionally allow for the non-performant behavior (expand as bytes, sniff to classify as binary or text, convert text to strings). This would allow for higher fidelity classification without requiring advance knowledge of file extensions.

Code coverage information:

94.38% : `EnumeratedArtifact`
97.22% : `MultithreadedZipArtifactProvider`
93.59% : `ZipArchiveArtifact`