### PR TITLE
Better UX emitting `FailureLevel.Note` debug messages on the console.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -5,6 +5,7 @@
 
 ## **v4.4.1 UNRELEASED
 * BUG: Emit `WRN997.OneOrMoreFilesSkippedDueToExceedingSizeLimit` when no valid analysis targets are detected (due to exceeding size limits).
+* BUG: Emit `FailureLevel.Note` messages with label `info` (rather than `fail`) in `ConsoleLogger`.
 
 ## **v4.4.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.4.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.4.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.4.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.4.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.4.0)
 * DEP: Add reference to `System.Text.Encoding.CodePages` v8.0.0 (to support Windows 1252 code pages in binary vs. text classification).

--- a/src/Sarif/Writers/BaseLogger.cs
+++ b/src/Sarif/Writers/BaseLogger.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 throw new ArgumentException("At least one kind is required");
             }
 
-            bool failureLevelsEffectivelyEmpty = _failureLevels == null
-                                                    || _failureLevels.Count == 0
-                                                    || (_failureLevels.Count == 1 && _failureLevels.Contains(FailureLevel.None));
+            bool failureLevelsEffectivelyEmpty = _failureLevels == null || _failureLevels.Count == 0;
 
             if (_resultKinds.Contains(ResultKind.Fail))
             {

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -10,9 +10,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 {
     public class ConsoleLogger : BaseLogger, IAnalysisLogger
     {
-        //  TODO:  We directly instantiate this logger in two classes, creating 
-        //  unamanged dependencies.  Fix this pattern with dependency injection or a factory.
-        //  #2272 https://github.com/microsoft/sarif-sdk/issues/2272
         public ConsoleLogger(bool quietConsole, string toolName, FailureLevelSet levels = null, ResultKindSet kinds = null) : base(levels, kinds)
         {
             _quietConsole = quietConsole;

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             WriteLineToConsole(GetMessageText(_toolName, physicalLocation?.ArtifactLocation?.Uri, physicalLocation?.Region, result.RuleId, message, result.Kind, result.Level));
         }
 
-        private static string GetMessageText(
+        public static string GetMessageText(
             string toolName,
             Uri uri,
             Region region,
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 case FailureLevel.None:
                     issueType = kind.ToString().ToLowerInvariant();
                     // Shorten to 'info' for compatibility with previous behavior.
-                    if (issueType == "informational") { issueType = "info"; }
+                    if (issueType == "informational" || issueType == "fail") { issueType = "info"; }
                     break;
 
                 default:

--- a/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/BaseLoggerTests.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
-using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Writers;
@@ -31,7 +27,10 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Writers
                                                                 BaseLogger.Fail);
 
             baseLoggerTestConcrete = new BaseLoggerTestConcrete(new FailureLevelSet(new[] { FailureLevel.None }),
-                                                                new ResultKindSet(new[] { ResultKind.Informational }));
+                                                                new ResultKindSet(new[] { ResultKind.Informational, ResultKind.Fail }));
+
+            baseLoggerTestConcrete = new BaseLoggerTestConcrete(new FailureLevelSet(new[] { FailureLevel.None }),
+                                                                new ResultKindSet(new[] { ResultKind.Fail }));
 
             //  If there are no uncaught exceptions, the test passes.
         }

--- a/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             // The console logger will emit the tool name in cases 
             // where a scan target URI is not available (as uppercase).
             string tool = Guid.NewGuid().ToString().ToUpperInvariant();
-            
+
             string message = Guid.NewGuid().ToString();
 
             var result = new Result

--- a/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/ConsoleLoggerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 
 using FluentAssertions;
 
@@ -12,6 +11,40 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 {
     public class ConsoleLoggerTests
     {
+
+        [Fact]
+        public void ConsoleLogger_EmitsFailureNoneMessagesProperly()
+        {
+            // A failure level of none indicates a debug message.
+            // The console logger will emit the tool name in cases 
+            // where a scan target URI is not available (as uppercase).
+            string tool = Guid.NewGuid().ToString().ToUpperInvariant();
+            
+            string message = Guid.NewGuid().ToString();
+
+            var result = new Result
+            {
+                Level = FailureLevel.None,
+                Message = new Message { Text = message },
+            };
+
+
+            var levels = new FailureLevelSet(new[] { FailureLevel.None });
+
+            var logger = new ConsoleLogger(quietConsole: false,
+                                           toolName: tool,
+                                           levels: levels,
+                                           kinds: BaseLogger.Fail)
+            {
+                CaptureOutput = true
+            };
+
+            logger.Log(null, result);
+
+            string expected = $"{tool}: info {message}{Environment.NewLine}";
+            logger.CapturedOutput.Should().Be(expected);
+        }
+
         [Fact]
         public void ConsoleLogger_EmitsMessageWithCharOffsetRegion()
         {
@@ -19,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             string message = Guid.NewGuid().ToString();
             string uriText = Guid.NewGuid().ToString();
 
-            Uri uri = new Uri(uriText, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriText, UriKind.RelativeOrAbsolute);
 
             var result = new Result
             {
@@ -68,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             string exceptionMessage = "Exception message";
             string toolName = Guid.NewGuid().ToString();
             string uriGuid = Guid.NewGuid().ToString();
-            Uri uri = new Uri(uriGuid, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriGuid, UriKind.RelativeOrAbsolute);
 
             var notification = new Notification
             {

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -1039,7 +1039,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public void SarifLogger_HonorsKindAndLevel()
         {
             IEnumerable<ResultKind> nonEmptyResultKinds = Enum.GetValues(typeof(ResultKind)).Cast<ResultKind>().Where(rk => rk != ResultKind.None).ToList();
-            IEnumerable<FailureLevel> nonEmptyFailureLevels = Enum.GetValues(typeof(FailureLevel)).Cast<FailureLevel>().Where(fl => fl != FailureLevel.None).ToList();
+            IEnumerable<FailureLevel> nonEmptyFailureLevels = Enum.GetValues(typeof(FailureLevel)).Cast<FailureLevel>().ToList();
 
             var allKindLevelCombinations = new List<Result>();
             var rule = new ReportingDescriptor { Id = "RuleId" };
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             SarifLog sarifLog = CreateSarifLog(allKindLevelCombinations, rule, desiredFailureLevels, desiredResultKinds);
             VerifySarifLogHonoredKindAndLevel(desiredFailureLevels, desiredResultKinds, sarifLog);
 
-            desiredResultKinds = new ResultKindSet(new[] { ResultKind.NotApplicable });
+            desiredResultKinds = BaseLogger.Fail;
             desiredFailureLevels = new FailureLevelSet(new[] { FailureLevel.None });
             sarifLog = CreateSarifLog(allKindLevelCombinations, rule, desiredFailureLevels, desiredResultKinds);
             VerifySarifLogHonoredKindAndLevel(desiredFailureLevels, desiredResultKinds, sarifLog);


### PR DESCRIPTION
 Emit `FailureLevel.Note` messages with label `info` (rather than `fail`) in `ConsoleLogger`.

Previously, for debug (i.e., `FailureLevel.Note` messages) we emitted strings like:

`temp.txt(1,1-108): fail TST101/016: '…xxxDid' is an apparent false positive (because it does not contain at least one digit and letter).`

Now we emit `fail` as a more appropriate label for debug messages:

`temp.txt(1,1-108): info TST101/016: '…xxxDid' is an apparent false positive (because it does not contain at least one digit and letter).`


