### PR TITLE
User facing output to file diff

### DIFF
--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -23,8 +23,6 @@ using Newtonsoft.Json.Serialization;
 
 using Xunit.Abstractions;
 
-using YamlDotNet.Core.Tokens;
-
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public abstract class FileDiffingUnitTests


### PR DESCRIPTION
This change retrieves and persists user-facing output generated by functional tests. These strings are to be persisted alongside the generated `.sarif` files in the `Expected` directory in `TestData`. We are experimenting with this capability in one SARIF Driver framework use case. Once it's proven/refined, we should push that code deeper into the test API.