### PR TITLE
Update default max file size parameter

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,7 @@
 ## UNRELEASED
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
 * DEP: Remove spurious references to `System.Collections.Immutable`.
+* PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 
 ## **v4.4.1 UNRELEASED
 * BUG: Emit `WRN997.OneOrMoreFilesSkippedDueToExceedingSizeLimit` when no valid analysis targets are detected (due to exceeding size limits).

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         "Specifies whether to recurse into child directories when enumerating scan targets. " +
                         "Defaults to 'False'.");
 
-        private const int DefaultMaxFileSizeInKilobytes = 10 * 1024;
+        private const int DefaultMaxFileSizeInKilobytes = 10 * 1000;
         public static PerLanguageOption<long> MaxFileSizeInKilobytesProperty { get; } =
             new PerLanguageOption<long>(
                 $"CoreSettings", nameof(MaxFileSizeInKilobytes), defaultValue: () => DefaultMaxFileSizeInKilobytes,

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         "Specifies whether to recurse into child directories when enumerating scan targets. " +
                         "Defaults to 'False'.");
 
-        private const int DefaultMaxFileSizeInKilobytes = 10 * 1000;
+        private const int DefaultMaxFileSizeInKilobytes = 10 * 1000; // 10 MB
         public static PerLanguageOption<long> MaxFileSizeInKilobytesProperty { get; } =
             new PerLanguageOption<long>(
                 $"CoreSettings", nameof(MaxFileSizeInKilobytes), defaultValue: () => DefaultMaxFileSizeInKilobytes,

--- a/src/Sarif/AnalyzeContextBase.cs
+++ b/src/Sarif/AnalyzeContextBase.cs
@@ -370,14 +370,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                         "Specifies whether to recurse into child directories when enumerating scan targets. " +
                         "Defaults to 'False'.");
 
+        private const int DefaultMaxFileSizeInKilobytes = 10 * 1024;
         public static PerLanguageOption<long> MaxFileSizeInKilobytesProperty { get; } =
             new PerLanguageOption<long>(
-                $"CoreSettings", nameof(MaxFileSizeInKilobytes), defaultValue: () => 1024,
+                $"CoreSettings", nameof(MaxFileSizeInKilobytes), defaultValue: () => DefaultMaxFileSizeInKilobytes,
                 $"{Environment.NewLine}" +
                 $"    Scan targets that fall below this size threshold (in kilobytes) will not be analyzed.{Environment.NewLine}" +
                 $"    It is legal to set this value to 0 (in order to potentially complete an analysis that{Environment.NewLine}" +
                 $"    records what scan targets would have been analyzed, given current configuration.{Environment.NewLine}" +
-                $"    Negative values will be discarded in favor of the default of {MaxFileSizeInKilobytesProperty?.DefaultValue() ?? 1024} KB.");
+                $"    Negative values will be discarded in favor of the default of {MaxFileSizeInKilobytesProperty?.DefaultValue() ?? DefaultMaxFileSizeInKilobytes} KB.");
 
 
         public static PerLanguageOption<int> EventsBufferSizeInMegabytesProperty { get; } =


### PR DESCRIPTION
Recent experience suggests the default max-file-size-in-kb parameter is too small.  This change proposes updating it to reflect common practice.