### PR TITLE
Fixing build/test errors

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,8 @@
 ## UNRELEASED
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
 * DEP: Remove spurious references to `System.Collections.Immutable`.
+* DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to avoid [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7) vulnerability.
+* DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to avoid [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7) vulnerability.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -4,7 +4,7 @@
 * DEP: Remove spurious references to `System.Collections.Immutable`.
 * DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
 * DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
-* BUG: Update `Stack.Create` method to populate missing stack frame `PhysicalLocation` instances when they reference relative file paths.
+* BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,8 +2,9 @@
 ## UNRELEASED
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
 * DEP: Remove spurious references to `System.Collections.Immutable`.
-* DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to avoid [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7) vulnerability.
-* DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to avoid [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7) vulnerability.
+* DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
+* DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
+* BUG: Fix the issue `Stack` object doesn't create corresponding `PhysicalLocation` from stack trace if it contains relative file path.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -4,7 +4,7 @@
 * DEP: Remove spurious references to `System.Collections.Immutable`.
 * DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
 * DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
-* BUG: Fix the issue `Stack` object doesn't create corresponding `PhysicalLocation` from stack trace if it contains relative file path.
+* BUG: Update `Stack.Create` method to populate missing stack frame `PhysicalLocation` instances when they reference relative file paths.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
 

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Json.Pointer" Version="2.1.0" />
     <PackageReference Include="Microsoft.Json.Schema" Version="2.1.0" />
     <PackageReference Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />

--- a/src/Sarif/Core/Stack.cs
+++ b/src/Sarif/Core/Stack.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         {
                             ArtifactLocation = new ArtifactLocation
                             {
-                                Uri = new Uri(fileName)
+                                Uri = new Uri(fileName, UriKind.RelativeOrAbsolute)
                             },
                             Region = new Region
                             {

--- a/src/Sarif/Core/Stack.cs
+++ b/src/Sarif/Core/Stack.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             stack.Frames = new List<StackFrame>();
 
-            var regex = new Regex(StackFrame.AT + @"([^)]+\))(" + StackFrame.IN + "([^:]+:[^:]+)" + StackFrame.LINE + " (.*))?", RegexOptions.Compiled);
+            var regex = new Regex(StackFrame.AT + @"([^)]+\))(" + StackFrame.IN + "([^:]+:?[^:]+)" + StackFrame.LINE + " (.*))?", RegexOptions.Compiled);
 
             foreach (string line in stackTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.None))
             {

--- a/src/Sarif/Core/StackFrame.cs
+++ b/src/Sarif/Core/StackFrame.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (this.Location?.PhysicalLocation?.ArtifactLocation?.Uri != null)
             {
-                string fileName = this.Location.PhysicalLocation.ArtifactLocation.Uri.LocalPath;
+                string fileName = this.Location.PhysicalLocation.ArtifactLocation.Uri.OriginalString;
                 result += IN + fileName;
 
                 if (this.Location?.PhysicalLocation?.Region != null)

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -121,25 +121,34 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
    at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
    at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
    at System.IO.File.Create(String path, Int32 bufferSize)
-   at Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core.StackTests.Stack_CreateFromExceptionWithInnerException() in {0}:line {1}";
+   at Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core.StackTests.Stack_CreateFromExceptionWithInnerException()";
 
             int relativePathLineNumber = 60;
             string relativeFilePath = "/_/src/Test.UnitTests.Sarif/Core/StackTests.cs";
-            var sarifStackWithRelativeFileLocation = Stack.Create(string.Format(stackTraceTemplate, relativeFilePath, relativePathLineNumber));
+            var sarifStackWithRelativeFileLocation = Stack.Create(stackTraceTemplate + $" in {relativeFilePath}:line {relativePathLineNumber}");
 
             sarifStackWithRelativeFileLocation.Frames.Count.Should().Be(7);
             CodeAnalysis.Sarif.StackFrame lastFrame = sarifStackWithRelativeFileLocation.Frames.Last();
             lastFrame.Location.PhysicalLocation.ArtifactLocation.Uri.OriginalString.Should().Be(relativeFilePath);
             lastFrame.Location.PhysicalLocation.Region.StartLine.Should().Be(relativePathLineNumber);
+            lastFrame.ToString().Should().EndWith($" in {relativeFilePath}:line {relativePathLineNumber}");
 
             int absolutePathLineNumber = 33;
             string absoluteFilePath = @"C:\repo\src\Test.UnitTests.Sarif\Core\StackTests.cs";
-            var sarifStackWithAbsoluteFileLocation = Stack.Create(string.Format(stackTraceTemplate, absoluteFilePath, absolutePathLineNumber));
+            var sarifStackWithAbsoluteFileLocation = Stack.Create(stackTraceTemplate + $" in {absoluteFilePath}:line {absolutePathLineNumber}");
 
             sarifStackWithAbsoluteFileLocation.Frames.Count.Should().Be(7);
             lastFrame = sarifStackWithAbsoluteFileLocation.Frames.Last();
             lastFrame.Location.PhysicalLocation.ArtifactLocation.Uri.OriginalString.Should().Be(absoluteFilePath);
             lastFrame.Location.PhysicalLocation.Region.StartLine.Should().Be(absolutePathLineNumber);
+            lastFrame.ToString().Should().EndWith($" in {absoluteFilePath}:line {absolutePathLineNumber}");
+
+            var sarifStackWithoutFileLocation = Stack.Create(stackTraceTemplate);
+
+            sarifStackWithoutFileLocation.Frames.Count.Should().Be(7);
+            lastFrame = sarifStackWithoutFileLocation.Frames.Last();
+            lastFrame.Location.PhysicalLocation.Should().BeNull();
+            lastFrame.ToString().Should().EndWith("Stack_CreateFromExceptionWithInnerException()");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -111,5 +111,35 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             }
             Assert.True(caughtException);
         }
+
+        [Fact]
+        public void Stack_CreateFromStackTraceWithRelativeSourceFileLocation()
+        {
+            string stackTraceTemplate = @"   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
+   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
+   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
+   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
+   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
+   at System.IO.File.Create(String path, Int32 bufferSize)
+   at Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core.StackTests.Stack_CreateFromExceptionWithInnerException() in {0}:line {1}";
+
+            int relativePathLineNumber = 60;
+            string relativeFilePath = "/_/src/Test.UnitTests.Sarif/Core/StackTests.cs";
+            var sarifStackWithRelativeFileLocation = Stack.Create(string.Format(stackTraceTemplate, relativeFilePath, relativePathLineNumber));
+
+            sarifStackWithRelativeFileLocation.Frames.Count.Should().Be(7);
+            CodeAnalysis.Sarif.StackFrame lastFrame = sarifStackWithRelativeFileLocation.Frames.Last();
+            lastFrame.Location.PhysicalLocation.ArtifactLocation.Uri.OriginalString.Should().Be(relativeFilePath);
+            lastFrame.Location.PhysicalLocation.Region.StartLine.Should().Be(relativePathLineNumber);
+
+            int absolutePathLineNumber = 33;
+            string absoluteFilePath = @"C:\repo\src\Test.UnitTests.Sarif\Core\StackTests.cs";
+            var sarifStackWithAbsoluteFileLocation = Stack.Create(string.Format(stackTraceTemplate, absoluteFilePath, absolutePathLineNumber));
+
+            sarifStackWithAbsoluteFileLocation.Frames.Count.Should().Be(7);
+            lastFrame = sarifStackWithAbsoluteFileLocation.Frames.Last();
+            lastFrame.Location.PhysicalLocation.ArtifactLocation.Uri.OriginalString.Should().Be(absoluteFilePath);
+            lastFrame.Location.PhysicalLocation.Region.StartLine.Should().Be(absolutePathLineNumber);
+        }
     }
 }

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
 
     <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 


### PR DESCRIPTION
# Description:

- Fix high severity vulnerability in SqlClient packages which break build. more information:  https://github.com/advisories/GHSA-98g6-xh36-x2p7

- Fix an issue cause StackTests fail if the stack trace contains relative file location.