### PR TITLE
Demote nuget security advisories to warnings.

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -41,6 +41,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- These can change externally, breaking our build. -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors> 
     <HighEntropyVA>true</HighEntropyVA>
     <!-- The line causes the assemblies in a project's referenced NuGet packages to be
          copied to the output directory. If we omit it from a test project, the tests


### PR DESCRIPTION
We have warnings-as-errors enabled for most of our repositories because it keeps out new warnings/regressions.  This doesn't work for CVEs, which are exogenous.  These should be treated as warnings and not break the build or create work stoppages.