### PR TITLE
Add `--timeout-in-millisecond` parameter to `AnalyzeOptionsBase`

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -7,6 +7,7 @@
 * BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
+* NEW: Add `--timeout-in-millisecond` parameter to `AnalyzeOptionsBase`, which will override context settings.
 
 ## **v4.4.1 UNRELEASED
 * DEP: Update reference to `System.Collections.Immutable` 5.0.0 for `Sarif` and `Sarif.Converters`.

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -134,6 +134,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public long? MaxFileSizeInKilobytes { get; set; }
 
         [Option(
+            "timeout-in-millisecond",
+            HelpText = "A timeout value expressed in milliseconds.")]
+        public int? TimeoutInMilliseconds { get; set; }
+
+        [Option(
             "deny-regex",
             HelpText = "A regular expression used to suppress scanning for any file or directory path that matches the regex.")]
         public string GlobalFilePathDenyRegex { get; set; }

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -309,6 +309,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             context.PluginFilePaths = options.PluginFilePaths?.Any() == true ? options.PluginFilePaths?.ToImmutableHashSet() : context.PluginFilePaths;
             context.InsertProperties = options.InsertProperties?.Any() == true ? InitializeStringSet(options.InsertProperties) : context.InsertProperties;
             context.MaxFileSizeInKilobytes = options.MaxFileSizeInKilobytes != null ? options.MaxFileSizeInKilobytes.Value : context.MaxFileSizeInKilobytes;
+            context.TimeoutInMilliseconds = options.TimeoutInMilliseconds != null ? Math.Max(options.TimeoutInMilliseconds.Value, 0) : context.TimeoutInMilliseconds;
             context.TargetFileSpecifiers = options.TargetFileSpecifiers?.Any() == true ? InitializeStringSet(options.TargetFileSpecifiers) : context.TargetFileSpecifiers;
             context.InvocationPropertiesToLog = options.InvocationPropertiesToLog?.Any() == true ? InitializeStringSet(options.InvocationPropertiesToLog) : context.InvocationPropertiesToLog;
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 Kind = new[] { optionsKind, ResultKind.Fail },
                 Level = new[] { optionsLevel },
+                TimeoutInMilliseconds = 60000,
             };
 
             var context = new TestAnalysisContext()
@@ -161,6 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             context.ResultKinds.Should().BeEquivalentTo(new ResultKindSet(new[] { optionsKind, ResultKind.Fail }));
             context.FailureLevels.Should().BeEquivalentTo(new FailureLevelSet(new[] { optionsLevel }));
+            context.TimeoutInMilliseconds.Should().Be(60000);
         }
 
         [Fact]
@@ -182,6 +184,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             multithreadedAnalyzeCommand.InitializeGlobalContextFromOptions(options, ref context);
 
             context.FailureLevels.Should().BeEquivalentTo(failureLevels);
+            context.TimeoutInMilliseconds.Should().Be(int.MaxValue);
         }
 
         [Fact]


### PR DESCRIPTION
Add `--timeout-in-millisecond` parameter to `AnalyzeOptionsBase`, which will override context settings.