### PR TITLE
Do not send empty log

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -8,7 +8,7 @@
 * BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
-* NEW: Command-line argument `--post-uri` will now skip file posting step if the result is empty.
+* NEW: `--post-uri` will skip sending the SARIF log to the configured endpoint if the file contains no results or fatal execution errors.
 
 ## **v4.4.1 UNRELEASED
 * DEP: Update reference to `System.Collections.Immutable` 5.0.0 for `Sarif` and `Sarif.Converters`.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -7,6 +7,7 @@
 * BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
+* NEW: Command-line argument `--post-uri` will now skip file posting step if the result is empty.
 
 ## **v4.4.1 UNRELEASED
 * DEP: Update reference to `System.Collections.Immutable` 5.0.0 for `Sarif` and `Sarif.Converters`.

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -361,12 +361,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     if (httpResponseMessage.StatusCode != HttpStatusCode.InternalServerError &&
                         httpResponseMessage.StatusCode != (HttpStatusCode)422)
                     {
+                        Errors.LogErrorPostingLogFile(globalContext, globalContext.PostUri);
                         globalContext.PostUri = null;
                         succeeded = false;
                     }
                 }
                 catch (Exception e)
                 {
+                    Errors.LogErrorPostingLogFile(globalContext, globalContext.PostUri);
                     globalContext.PostUri = null;
                     succeeded = false;
                     globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -252,8 +252,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if ((globalContext.RuntimeErrors & ~RuntimeConditions.Nonfatal) == RuntimeConditions.None)
             {
                 ProcessBaseline(globalContext);
-                PostLogFile(globalContext);
             }
+
+            // Even if there are fatal errors, if the log file is generated, we can upload it with the ToolExecutionNotifications.
+            PostLogFile(globalContext);
 
             globalContext.Logger = null;
             succeeded = (globalContext.RuntimeErrors & ~RuntimeConditions.Nonfatal) == RuntimeConditions.None;

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -373,7 +373,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     Errors.LogErrorPostingLogFile(globalContext, globalContext.PostUri);
                     globalContext.PostUri = null;
                     succeeded = false;
-                    globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
                     globalContext.RuntimeExceptions ??= new List<Exception>();
                     globalContext.RuntimeExceptions.Add(e);
                 }

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -225,7 +225,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
-            if (string.IsNullOrEmpty(globalContext.PostUri)) { return; }
+            if (string.IsNullOrWhiteSpace(globalContext.PostUri) ||
+                string.IsNullOrWhiteSpace(globalContext.OutputFilePath) ||
+                !globalContext.FileSystem.FileExists(globalContext.OutputFilePath))
+            {
+                return;
+            }
 
             try
             {

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -231,11 +231,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 using (var httpClient = new HttpClient())
                 {
-                    PostLogFile(globalContext.PostUri, globalContext.OutputFilePath, globalContext.FileSystem, httpClient)
+                    bool logFilePosted = PostLogFile(globalContext.PostUri, globalContext.OutputFilePath, globalContext.FileSystem, httpClient)
                         .GetAwaiter()
                         .GetResult();
 
-                    Console.WriteLine($"Posted log file successfully to: {globalContext.PostUri}");
+                    if (logFilePosted)
+                    {
+                        Console.WriteLine($"Posted log file successfully to: {globalContext.PostUri}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Posting of the log file to {globalContext.PostUri} was skipped because the result is empty.");
+                    }
                 }
             }
             catch (Exception ex)
@@ -249,14 +256,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        internal static async Task PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem, HttpClient httpClient)
+        internal static async Task<bool> PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem, HttpClient httpClient)
         {
             if (string.IsNullOrWhiteSpace(postUri))
             {
-                return;
+                return false;
             }
 
-            await SarifLog.Post(new Uri(postUri), outputFilePath, fileSystem, httpClient);
+            return await SarifLog.Post(new Uri(postUri), outputFilePath, fileSystem, httpClient);
         }
     }
 }

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -236,18 +236,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 using (var httpClient = new HttpClient())
                 {
-                    bool logFilePosted = PostLogFile(globalContext.PostUri, globalContext.OutputFilePath, globalContext.FileSystem, httpClient)
+                    PostLogFile(globalContext.PostUri, globalContext.OutputFilePath, globalContext.FileSystem, httpClient)
                         .GetAwaiter()
                         .GetResult();
-
-                    if (logFilePosted)
-                    {
-                        Console.WriteLine($"Posted log file successfully to: {globalContext.PostUri}");
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Posting of the log file to {globalContext.PostUri} was skipped because the result is empty.");
-                    }
                 }
             }
             catch (Exception ex)
@@ -261,14 +252,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        internal static async Task<bool> PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem, HttpClient httpClient)
+        internal static async Task PostLogFile(string postUri, string outputFilePath, IFileSystem fileSystem, HttpClient httpClient)
         {
             if (string.IsNullOrWhiteSpace(postUri))
             {
-                return false;
+                return;
             }
 
-            return await SarifLog.Post(new Uri(postUri), outputFilePath, fileSystem, httpClient);
+            await SarifLog.Post(new Uri(postUri), outputFilePath, fileSystem, httpClient);
         }
     }
 }

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -97,10 +97,12 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (!ShouldSendLog(sarifLog))
             {
+                Console.WriteLine($"Posting of the log file to {postUri} was skipped because the result is empty.");
                 return false;
             }
 
             await Post(postUri, new MemoryStream(fileBytes), httpClient);
+            Console.WriteLine($"Posted log file successfully to: {postUri}");
             return true;
         }
 

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -93,15 +93,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             byte[] fileBytes = fileSystem.FileReadAllBytes(filePath);
-            using var memoryStream = new MemoryStream(fileBytes);
-            SarifLog sarifLog = Load(memoryStream);
+            SarifLog sarifLog = Load(new MemoryStream(fileBytes));
 
             if (!ShouldSendLog(sarifLog))
             {
                 return false;
             }
 
-            await Post(postUri, memoryStream, httpClient);
+            await Post(postUri, new MemoryStream(fileBytes), httpClient);
             return true;
         }
 

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (!ShouldSendLog(sarifLog))
             {
-                Console.WriteLine($"Posting of the log file to {postUri} was skipped because the result is empty.");
+                Console.WriteLine($"Post of log file to {postUri} was skipped because the log contains no results.");
                 return false;
             }
 
@@ -264,17 +264,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                     {
                         foreach (Invocation invocation in run.Invocations)
                         {
-                            if (invocation.ToolConfigurationNotifications?.Count > 0)
-                            {
-                                foreach (Notification notification in invocation.ToolConfigurationNotifications)
-                                {
-                                    if (notification.Level == FailureLevel.Error)
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-
                             if (invocation.ToolExecutionNotifications?.Count > 0)
                             {
                                 foreach (Notification notification in invocation.ToolExecutionNotifications)

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="filePath"></param>
         /// <param name="fileSystem"></param>
         /// <param name="httpClient"></param>
-        /// <returns>If the SarifLog has been posted</returns>
+        /// <returns>If the SarifLog has been posted.</returns>
         public static async Task<bool> Post(Uri postUri,
                                       string filePath,
                                       IFileSystem fileSystem,

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -709,7 +709,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             context.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
 
             // Could not post to the URI specified on the command line: '{0}'.
-            context.Logger.LogConfigurationNotification(
+            context.Logger.LogToolNotification(
                 CreateNotification(
                     uri: null,
                     ERR997_ErrorPostingLogFile,

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         private const string ERR997_NoRulesLoaded = "ERR997.NoRulesLoaded";
         private const string ERR997_FileAlreadyExists = "ERR997.FileAlreadyExists";
         internal const string ERR997_NoPluginsConfigured = "ERR997.NoPluginsConfigured";
-        private const string ERR997_ErrorPostingLogFile = "ERR997.ExceptionPostingLogFile";
+        private const string ERR997_ErrorPostingLogFile = "ERR997.ErrorPostingLogFile";
         private const string ERR997_ExceptionLoadingPlugIn = "ERR997.ExceptionLoadingPlugIn";
         internal const string ERR997_NoValidAnalysisTargets = "ERR997.NoValidAnalysisTargets";
         private const string ERR997_ExceptionAccessingFile = "ERR997.ExceptionAccessingFile";

--- a/src/Sarif/Errors.cs
+++ b/src/Sarif/Errors.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         private const string ERR997_NoRulesLoaded = "ERR997.NoRulesLoaded";
         private const string ERR997_FileAlreadyExists = "ERR997.FileAlreadyExists";
         internal const string ERR997_NoPluginsConfigured = "ERR997.NoPluginsConfigured";
+        private const string ERR997_ErrorPostingLogFile = "ERR997.ExceptionPostingLogFile";
         private const string ERR997_ExceptionLoadingPlugIn = "ERR997.ExceptionLoadingPlugIn";
         internal const string ERR997_NoValidAnalysisTargets = "ERR997.NoValidAnalysisTargets";
         private const string ERR997_ExceptionAccessingFile = "ERR997.ExceptionAccessingFile";
@@ -696,6 +697,28 @@ namespace Microsoft.CodeAnalysis.Sarif
                     persistExceptionStack: false,
                     messageFormat: null,
                     configuredTimeout));
+        }
+
+        public static void LogErrorPostingLogFile(IAnalysisContext context, string postUri)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
+
+            // Could not post to the URI specified on the command line: '{0}'.
+            context.Logger.LogConfigurationNotification(
+                CreateNotification(
+                    uri: null,
+                    ERR997_ErrorPostingLogFile,
+                    ruleId: null,
+                    FailureLevel.Error,
+                    exception: null,
+                    persistExceptionStack: false,
+                    messageFormat: null,
+                    postUri));
         }
     }
 }

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not post to the URI specified on the command line: &apos;{0}&apos;..
+        /// </summary>
+        public static string ERR997_ErrorPostingLogFile {
+            get {
+                return ResourceManager.GetString("ERR997_ErrorPostingLogFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not access a file specified on the command line: &apos;{0}&apos;..
         /// </summary>
         public static string ERR997_ExceptionAccessingFile {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -314,4 +314,7 @@ You can also refer to properties in the result's property bag with 'properties.&
   <data name="WRN997_OneOrMoreFilesSkipped" xml:space="preserve">
     <value>{0} file(s) were skipped for analysis as {1}.</value>
   </data>
+  <data name="ERR997_ErrorPostingLogFile" xml:space="preserve">
+    <value>Could not post to the URI specified on the command line: '{0}'.</value>
+  </data>
 </root>

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -297,29 +297,6 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                                     httpClient: new HttpClient(httpMock));
             logPosted.Should().BeTrue("with results");
 
-            steam = (MemoryStream)CreateSarifLogStreamWithToolConfigurationNotifications(FailureLevel.Error);
-            fileSystem
-                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
-                .Returns(steam.ToArray());
-            httpMock.Mock(HttpMockHelper.CreateOKResponse());
-            logPosted = await SarifLog.Post(postUri: postUri,
-                                    filePath,
-                                    fileSystem.Object,
-                                    httpClient: new HttpClient(httpMock));
-            logPosted.Should().BeTrue("with error level ToolConfigurationNotifications");
-
-            steam = (MemoryStream)CreateSarifLogStreamWithToolConfigurationNotifications(FailureLevel.Warning);
-            fileSystem
-                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
-                .Returns(steam.ToArray());
-            httpMock.Mock(HttpMockHelper.CreateOKResponse());
-            logPosted = await SarifLog.Post(postUri: postUri,
-                                    filePath,
-                                    fileSystem.Object,
-                                    httpClient: new HttpClient(httpMock));
-            logPosted.Should().BeFalse("with warning level ToolConfigurationNotifications");
-
-
             steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Error);
             fileSystem
                 .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
@@ -331,7 +308,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                                     httpClient: new HttpClient(httpMock));
             logPosted.Should().BeTrue("with error level ToolExecutionNotifications");
 
-            steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Note);
+            steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Warning);
             fileSystem
                 .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
                 .Returns(steam.ToArray());
@@ -340,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                                     filePath,
                                     fileSystem.Object,
                                     httpClient: new HttpClient(httpMock));
-            logPosted.Should().BeFalse("with note level ToolExecutionNotifications");
+            logPosted.Should().BeFalse("with warning level ToolExecutionNotifications");
         }
 
         [Fact]
@@ -357,7 +334,6 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
 
             newSarifLog.Should().BeEquivalentTo(sarifLog);
         }
-
 
         [Fact]
         public void SarifLog_SaveToStreamWriterRoundtrips()

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 using Moq;
 
@@ -262,6 +263,87 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
         }
 
         [Fact]
+        public async Task SarifLog_PostFile_ShouldPostTests()
+        {
+            using var assertionScope = new AssertionScope();
+
+            var postUri = new Uri("https://sarif-post/example.com");
+            var httpMock = new HttpMockHelper();
+            string filePath = "SomeFile.sarif";
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(f => f.FileExists(It.IsAny<string>()))
+                .Returns(true);
+
+            // This method creates a bare-bones SARIF file with no results and notifications.
+            var steam = (MemoryStream)CreateSarifLogStream();
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            bool logPosted = await SarifLog.Post(postUri: null,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: null);
+            logPosted.Should().BeFalse("with no results or notifications");
+
+            steam = (MemoryStream)CreateSarifLogStreamWithResult();
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeTrue("with results");
+
+            steam = (MemoryStream)CreateSarifLogStreamWithToolConfigurationNotifications(FailureLevel.Error);
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeTrue("with error level ToolConfigurationNotifications");
+
+            steam = (MemoryStream)CreateSarifLogStreamWithToolConfigurationNotifications(FailureLevel.Warning);
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeFalse("with warning level ToolConfigurationNotifications");
+
+
+            steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Error);
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeTrue("with error level ToolExecutionNotifications");
+
+            steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Note);
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateOKResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeFalse("with note level ToolExecutionNotifications");
+        }
+
+        [Fact]
         public void SarifLog_SaveToMemoryStreamRoundtrips()
         {
             SarifLog sarifLog = GetSarifLogWithMinimalUniqueData();
@@ -376,7 +458,45 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             var memoryStream = new MemoryStream();
             new SarifLog().Save(memoryStream);
             memoryStream.Position = 0;
-            //memoryStream.Seek(0, SeekOrigin.Begin);
+            return memoryStream;
+        }
+
+        private Stream CreateSarifLogStreamWithResult()
+        {
+            var memoryStream = new MemoryStream();
+            var sarifLog = new SarifLog();
+            var result = new Result() { Message = new Message() { Text = "A sample result message." } };
+            var run = new Run();
+            run.Results = new Result[] { result };
+            sarifLog.Runs = new Run[] { run };
+            sarifLog.Save(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        private Stream CreateSarifLogStreamWithToolConfigurationNotifications(FailureLevel level)
+        {
+            var memoryStream = new MemoryStream();
+            var sarifLog = new SarifLog();
+            var run = new Run();
+            run.Invocations = new Invocation[] { new Invocation()
+            { ToolConfigurationNotifications = new Notification[] { new Notification() { Level = level } } } };
+            sarifLog.Runs = new Run[] { run };
+            sarifLog.Save(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        private Stream CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel level)
+        {
+            var memoryStream = new MemoryStream();
+            var sarifLog = new SarifLog();
+            var run = new Run();
+            run.Invocations = new Invocation[] { new Invocation()
+            { ToolExecutionNotifications = new Notification[] { new Notification() { Level = level } } } };
+            sarifLog.Runs = new Run[] { run };
+            sarifLog.Save(memoryStream);
+            memoryStream.Position = 0;
             return memoryStream;
         }
 


### PR DESCRIPTION
* NEW: Command-line argument `--post-uri` will now skip file posting step if the result is empty.

Also found a bug and fixed so that: Even if there are fatal errors, if the log file is generated, we can upload it with the ToolExecutionNotifications.

User facing strings:

![image](https://github.com/microsoft/sarif-sdk/assets/81775155/fa0ae09c-2c30-4040-b5e9-0e3e131dc408)

![image](https://github.com/microsoft/sarif-sdk/assets/81775155/c06ad553-457d-4ab5-9915-901ae0ae8b8b)

Coverage
![image](https://github.com/microsoft/sarif-sdk/assets/81775155/6ef02b1d-3645-413c-8c7f-1ca25b46b7c7)
