### PR TITLE
Post the response from the endpoint when log file posting succeed or failed

### DIFF
--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -102,19 +102,15 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             HttpResponseMessage response = await Post(postUri, new MemoryStream(fileBytes), httpClient);
-            string responseText = response.Content.ReadAsStringAsync().Result;
+            string responseText = await response.Content.ReadAsStringAsync();
 
-            try
+            if (!response.IsSuccessStatusCode)
             {
-                response.EnsureSuccessStatusCode();
-            }
-            catch (Exception)
-            {
-                Console.WriteLine($"Error Posting log file to: {postUri}. Endpoint provided message: {responseText}");
+                Console.WriteLine($"Error Posting log file to: {postUri}. Endpoint provided status code {response.StatusCode} and message: {responseText}");
                 return false;
             }
 
-            Console.WriteLine($"Posted log file successfully to: {postUri}. Endpoint provided message: {responseText}");
+            Console.WriteLine($"Posted log file successfully to: {postUri}. Endpoint provided status code {response.StatusCode} and message: {responseText}");
             return true;
         }
 

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="filePath"></param>
         /// <param name="fileSystem"></param>
         /// <param name="httpClient"></param>
-        /// <returns>If the SarifLog has been posted.</returns>
+        /// <returns>If the SarifLog has been posted successfully.</returns>
         public static async Task<bool> Post(Uri postUri,
                                       string filePath,
                                       IFileSystem fileSystem,
@@ -101,8 +101,20 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            await Post(postUri, new MemoryStream(fileBytes), httpClient);
-            Console.WriteLine($"Posted log file successfully to: {postUri}");
+            HttpResponseMessage response = await Post(postUri, new MemoryStream(fileBytes), httpClient);
+            string responseText = response.Content.ReadAsStringAsync().Result;
+
+            try
+            {
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"Error Posting log file to: {postUri}. Endpoint provided message: {responseText}");
+                return false;
+            }
+
+            Console.WriteLine($"Posted log file successfully to: {postUri}. Endpoint provided message: {responseText}");
             return true;
         }
 

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
         }
 
         [Fact]
-        public async Task SarifLog_PostFile_ShouldPostTests()
+        public async Task SarifLog_PostFile_PostTests()
         {
             using var assertionScope = new AssertionScope();
 
@@ -318,6 +318,17 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                                     fileSystem.Object,
                                     httpClient: new HttpClient(httpMock));
             logPosted.Should().BeFalse("with warning level ToolExecutionNotifications");
+
+            steam = (MemoryStream)CreateSarifLogStreamWithToolExecutionNotifications(FailureLevel.Error);
+            fileSystem
+                .Setup(f => f.FileReadAllBytes(It.IsAny<string>()))
+                .Returns(steam.ToArray());
+            httpMock.Mock(HttpMockHelper.CreateBadRequestResponse());
+            logPosted = await SarifLog.Post(postUri: postUri,
+                                    filePath,
+                                    fileSystem.Object,
+                                    httpClient: new HttpClient(httpMock));
+            logPosted.Should().BeTrue("with error level ToolExecutionNotifications, but the server returns BadRequest");
         }
 
         [Fact]


### PR DESCRIPTION
The response from the endpoint is useful for troubleshooting. 