### PR TITLE
Improve testing for post log. Do not emit post log messages when '--quiet' is enabled.

### DIFF
--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -256,7 +256,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             catch (Exception ex)
             {
                 Console.WriteLine(ex.ToString());
-                globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
+                Errors.LogErrorPostingLogFile(globalContext, globalContext.PostUri);
+                globalContext.RuntimeExceptions ??= new List<Exception>();
+                globalContext.RuntimeExceptions.Add(ex);
                 throw new ExitApplicationException<ExitReason>(DriverResources.MSG_UnexpectedApplicationExit, ex)
                 {
                     ExitReason = ExitReason.ExceptionPostingLogFile

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -253,6 +253,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 {
                     Console.WriteLine(result.Item2);
                 }
+
+                if (result.Item1 == false && !result.Item2.Contains("skipped"))
+                {
+                    globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -220,6 +220,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 };
             }
         }
+
         protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
             using var httpClient = new HttpClientWrapper();
@@ -256,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             catch (Exception ex)
             {
                 Console.WriteLine(ex.ToString());
-                Errors.LogErrorPostingLogFile(globalContext, globalContext.PostUri);
+                globalContext.RuntimeErrors |= RuntimeConditions.ExceptionPostingLogFile;
                 globalContext.RuntimeExceptions ??= new List<Exception>();
                 globalContext.RuntimeExceptions.Add(ex);
                 throw new ExitApplicationException<ExitReason>(DriverResources.MSG_UnexpectedApplicationExit, ex)

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 using System.Security;
 
@@ -223,11 +222,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
         protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
-            using var httpClient = new HttpClient();
+            using var httpClient = new HttpClientWrapper();
             SarifPost(globalContext, httpClient);
         }
 
-        internal static void SarifPost(IAnalysisContext globalContext, HttpClient httpClient)
+        internal static void SarifPost(IAnalysisContext globalContext, HttpClientWrapper httpClient)
         {
             if (string.IsNullOrWhiteSpace(globalContext.PostUri) ||
                 string.IsNullOrWhiteSpace(globalContext.OutputFilePath) ||

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             using var streamContent = new StreamContent(stream);
-            return await httpClient.PostAsync(postUri, streamContent);
+            return await httpClient.PostAsync(postUri.ToString(), streamContent);
         }
 
         /// <summary>

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public static async Task<(bool, string)> Post(Uri postUri,
                                                       string filePath,
                                                       IFileSystem fileSystem,
-                                                      HttpClient httpClient)
+                                                      HttpClientWrapper httpClient)
         {
             string postMessage = null;
 
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="postUri"></param>
         /// <param name="stream"></param>
         /// <param name="httpClient"></param>
-        public static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClient httpClient)
+        public static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClientWrapper httpClient)
         {
             if (postUri == null)
             {

--- a/src/Sarif/HttpClientWrapper.cs
+++ b/src/Sarif/HttpClientWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// Clients should use this class rather directly using the .NET http client classes, so they
     /// can mock the IHttpClient interface in unit tests.
     /// </remarks>
-    public class HttpClientWrapper : IHttpClient
+    public class HttpClientWrapper : IHttpClient, IDisposable
     {
         // .NET http client 
         private readonly HttpClient httpClient;
@@ -28,12 +29,21 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         /// <summary>
+        /// Allow HttpClient to be injected, can accepted httpclient with mocked HttpMessageHandler for easier unit testing
+        /// </summary>
+        /// <param name="handler"></param>
+        public HttpClientWrapper(HttpMessageHandler handler)
+        {
+            this.httpClient = new HttpClient(handler);
+        }
+
+        /// <summary>
         /// Send a GET request to the specified Uri as an asynchronous operation
         /// if cache doesn't have this Uri entry, otherwize return it from cache
         /// </summary>
         /// <param name="requestUri">The Uri the request is sent to.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task<HttpResponseMessage> GetAsync(string requestUri)
+        public virtual Task<HttpResponseMessage> GetAsync(string requestUri)
         {
             return httpClient.GetAsync(requestUri);
         }
@@ -44,7 +54,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="requestUri">The Uri the request is sent to.</param>
         /// <param name="content">The HTTP request content sent to the server.</param>
         /// <returns>The task object representing the asynchronous operation</returns>
-        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+        public virtual Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+        {
+            return httpClient.PostAsync(requestUri, content);
+        }
+
+        /// <summary>
+        /// Send a POST request to the specified Uri as an asynchronous operation.
+        /// </summary>
+        /// <param name="requestUri">The Uri the request is sent to.</param>
+        /// <param name="content">The HTTP request content sent to the server.</param>
+        /// <returns>The task object representing the asynchronous operation</returns>
+        public virtual Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content)
         {
             return httpClient.PostAsync(requestUri, content);
         }
@@ -55,9 +76,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="requestUri">The Uri the request is sent to.</param>
         /// <param name="content">The HTTP request content sent to the server.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
+        public virtual Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
         {
             return httpClient.PutAsync(requestUri, content);
+        }
+
+        public void Dispose()
+        {
+            this.httpClient?.Dispose();
         }
     }
 }

--- a/src/Sarif/HttpClientWrapper.cs
+++ b/src/Sarif/HttpClientWrapper.cs
@@ -22,10 +22,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Allow HttpClient to be injected, can accepted httpclient with mocked HttpMessageHandler for easier unit testing
         /// </summary>
-        /// <param name="httpClient"></param>
-        public HttpClientWrapper(HttpClient httpClient = null)
+        public HttpClientWrapper()
         {
-            this.httpClient = httpClient ?? new HttpClient();
+            this.httpClient = new HttpClient();
+        }
+
+        /// <summary>
+        /// Allow HttpClient to be injected, can accepted httpclient with mocked HttpMessageHandler for easier unit testing
+        /// </summary>
+        /// <param name="httpClient"></param>
+        public HttpClientWrapper(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
         }
 
         /// <summary>
@@ -55,17 +63,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="content">The HTTP request content sent to the server.</param>
         /// <returns>The task object representing the asynchronous operation</returns>
         public virtual Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
-        {
-            return httpClient.PostAsync(requestUri, content);
-        }
-
-        /// <summary>
-        /// Send a POST request to the specified Uri as an asynchronous operation.
-        /// </summary>
-        /// <param name="requestUri">The Uri the request is sent to.</param>
-        /// <param name="content">The HTTP request content sent to the server.</param>
-        /// <returns>The task object representing the asynchronous operation</returns>
-        public virtual Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content)
         {
             return httpClient.PostAsync(requestUri, content);
         }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/PluginDriverCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/PluginDriverCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -60,26 +61,93 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
-        public async Task PluginDriverCommand_ShouldThrowExitApplicationExceptionIfUnhandledExceptionOccurs()
+        public void PluginDriverCommand_NoExceptionIfLogFileDoesNotExist()
         {
             string postUri = "https://github.com/microsoft/sarif-sdk";
-            string outputFilePath = string.Empty;
+            string outputFilePath = $"{Guid.NewGuid()}.txt";
+            using var httpClient = new HttpClient();
+
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem
+                .Setup(f => f.FileExists(It.IsAny<string>()))
+                .Returns(false);
 
-            Exception exception = await Record.ExceptionAsync(async () =>
+            var context = new TestAnalysisContext
             {
-                mockFileSystem
-                    .Setup(f => f.FileExists(It.IsAny<string>()))
-                    .Throws(new NullReferenceException());
+                PostUri = postUri,
+                OutputFilePath = outputFilePath,
+                FileSystem = mockFileSystem.Object
+            };
 
-                await PluginDriverCommand<AnalyzeOptionsBase>.PostLogFile(postUri,
-                                                                          outputFilePath,
-                                                                          mockFileSystem.Object,
-                                                                          httpClient: null);
-            });
+            PluginDriverCommand<AnalyzeOptionsBase>.SarifPost(context, httpClient);
+        }
 
-            // TBD change this to an end-to-end test that injects an unhandled exception in post method.
-            exception.Should().BeOfType(typeof(ArgumentNullException));
+        [Fact]
+        public void PluginDriverCommand_NoExceptionIfOutputPathIsNull()
+        {
+            string postUri = "https://github.com/microsoft/sarif-sdk";
+            string outputFilePath = $"{Guid.NewGuid()}.txt";
+            using var httpClient = new HttpClient();
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem
+                .Setup(f => f.FileExists(It.IsAny<string>()))
+                .Returns(true);
+
+            var context = new TestAnalysisContext
+            {
+                PostUri = postUri,
+                OutputFilePath = null,
+                FileSystem = mockFileSystem.Object
+            };
+
+            PluginDriverCommand<AnalyzeOptionsBase>.SarifPost(context, httpClient);
+        }
+
+        [Fact]
+        public void PluginDriverCommand_NoExceptionIfPostUriNotPresent()
+        {
+            string outputFilePath = $"{Guid.NewGuid()}.txt";
+            using var httpClient = new HttpClient();
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem
+                .Setup(f => f.FileExists(It.IsAny<string>()))
+                .Returns(true);
+
+            var context = new TestAnalysisContext
+            {
+                PostUri = null,
+                OutputFilePath = outputFilePath,
+                FileSystem = mockFileSystem.Object
+            };
+
+            PluginDriverCommand<AnalyzeOptionsBase>.SarifPost(context, httpClient);
+        }
+
+        [Fact]
+        public void PluginDriverCommand_ThrowsExitApplicationExceptionOnUnhandledException()
+        {
+            string postUri = "https://github.com/microsoft/sarif-sdk";
+            string outputFilePath = $"{Guid.NewGuid()}.txt";
+           
+            var mockHttpClient = new Mock<HttpClient>();
+
+            mockHttpClient
+                .Setup(c => c.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>()))
+                .Throws(new InvalidOperationException());
+
+            var context = new TestAnalysisContext
+            {
+                PostUri = postUri,
+                OutputFilePath = outputFilePath,
+            };
+
+            Exception exception = Record.Exception(() =>
+                    PluginDriverCommand<AnalyzeOptionsBase>.SarifPost(context,
+                                                                      mockHttpClient.Object));
+
+            exception.Should().BeOfType(typeof(InvalidOperationException));
         }
     }
 }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/PluginDriverCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/PluginDriverCommandTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 using FluentAssertions;
 
@@ -65,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string postUri = "https://github.com/microsoft/sarif-sdk";
             string outputFilePath = $"{Guid.NewGuid()}.txt";
-            using var httpClient = new HttpClient();
+            using var httpClient = new HttpClientWrapper();
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem
@@ -87,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string postUri = "https://github.com/microsoft/sarif-sdk";
             string outputFilePath = $"{Guid.NewGuid()}.txt";
-            using var httpClient = new HttpClient();
+            using var httpClient = new HttpClientWrapper();
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem
@@ -108,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public void PluginDriverCommand_NoExceptionIfPostUriNotPresent()
         {
             string outputFilePath = $"{Guid.NewGuid()}.txt";
-            using var httpClient = new HttpClient();
+            using var httpClient = new HttpClientWrapper();
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem
@@ -130,8 +129,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string postUri = "https://github.com/microsoft/sarif-sdk";
             string outputFilePath = $"{Guid.NewGuid()}.txt";
-           
-            var mockHttpClient = new Mock<HttpClient>();
+
+            var mockHttpClient = new Mock<HttpClientWrapper>();
 
             mockHttpClient
                 .Setup(c => c.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>()))
@@ -147,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     PluginDriverCommand<AnalyzeOptionsBase>.SarifPost(context,
                                                                       mockHttpClient.Object));
 
-            exception.Should().BeOfType(typeof(InvalidOperationException));
+            exception.Should().BeOfType(typeof(ArgumentException));
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                                             filePath,
                                             fileSystem.Object,
                                             httpClient: new HttpClientWrapper(httpMock));
-            logPosted.Item1.Should().BeFalse("the server returns a BadRequest even though there are error level ToolExecutionNotifications");
+            logPosted.Item1.Should().BeFalse("a status code of 'BadRequest' should fail the call even though we posted error-level 'ToolExcecutionNotifications'");
             logPosted.Item2.Should().Contain("status code 'BadRequest'");
         }
 

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -216,14 +216,14 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             {
                 await SarifLog.Post(postUri: null,
                                     new MemoryStream(),
-                                    new HttpClient());
+                                    new HttpClientWrapper());
             });
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
                 await SarifLog.Post(new Uri("https://github.com/microsoft/sarif-sdk"),
                                     null,
-                                    new HttpClient());
+                                    new HttpClientWrapper());
             });
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             logPosted = await SarifLog.Post(postUri,
                                             filePath,
                                             fileSystem.Object,
-                                            httpClient: new HttpClient(httpMock));
+                                            httpClient: new HttpClientWrapper(httpMock));
             logPosted.Item1.Should().BeTrue("with results");
             logPosted.Item2.Should().Contain("status code 'OK'");
             logPosted.Item2.Should().Contain(content);
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             logPosted = await SarifLog.Post(postUri,
                                             filePath,
                                             fileSystem.Object,
-                                            httpClient: new HttpClient(httpMock));
+                                            httpClient: new HttpClientWrapper(httpMock));
             logPosted.Item1.Should().BeTrue("with error level ToolExecutionNotifications");
             logPosted.Item2.Should().Contain("status code 'OK'");
             logPosted.Item2.Should().Contain(content);
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             logPosted = await SarifLog.Post(postUri,
                                             filePath,
                                             fileSystem.Object,
-                                            httpClient: new HttpClient(httpMock));
+                                            httpClient: new HttpClientWrapper(httpMock));
             logPosted.Item1.Should().BeFalse("with warning level ToolExecutionNotifications");
             logPosted.Item2.Should().Contain("was skipped");
 
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             logPosted = await SarifLog.Post(postUri,
                                             filePath,
                                             fileSystem.Object,
-                                            httpClient: new HttpClient(httpMock));
+                                            httpClient: new HttpClientWrapper(httpMock));
             logPosted.Item1.Should().BeFalse("the server returns a BadRequest even though there are error level ToolExecutionNotifications");
             logPosted.Item2.Should().Contain("status code 'BadRequest'");
         }
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             HttpResponseMessage response =
                 await SarifLog.Post(postUri,
                     CreateSarifLogStream(),
-                    new HttpClient(httpMock));
+                    new HttpClientWrapper(httpMock));
 
             Assert.Throws<HttpRequestException>(() =>
             {
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             {
                 await SarifLog.Post(postUri,
                                     CreateSarifLogStream(),
-                                    new HttpClient(httpMock));
+                                    new HttpClientWrapper(httpMock));
             }
             catch (Exception ex)
             {
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                 await SarifLog.Post(postUri,
                                     filePath,
                                     fileSystem.Object,
-                                    new HttpClient(httpMock));
+                                    new HttpClientWrapper(httpMock));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
* BRK: Change return value of `SarifLog.Post` from `bool` to `(bool, string)` to allow return of status code and content of post response.