### PR TITLE
fix: restore Post's public API accepting HttpClient

### DIFF
--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -78,6 +78,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="httpClient"></param>
         /// <returns>If the SarifLog has been posted successfully.</returns>
         public static async Task<(bool, string)> Post(Uri postUri,
+                                              string filePath,
+                                              IFileSystem fileSystem,
+                                              HttpClient httpClient)
+        {
+            return await Post(postUri, filePath, fileSystem, new HttpClientWrapper(httpClient));
+        }
+
+        internal static async Task<(bool, string)> Post(Uri postUri,
                                                       string filePath,
                                                       IFileSystem fileSystem,
                                                       HttpClientWrapper httpClient)
@@ -126,7 +134,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="postUri"></param>
         /// <param name="stream"></param>
         /// <param name="httpClient"></param>
-        public static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClientWrapper httpClient)
+        public static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClient httpClient)
+        { 
+            return await Post(postUri, stream, new HttpClientWrapper(httpClient));
+        }
+
+        internal static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClientWrapper httpClient)
         {
             if (postUri == null)
             {

--- a/src/Sarif/Core/SarifLog.cs
+++ b/src/Sarif/Core/SarifLog.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="stream"></param>
         /// <param name="httpClient"></param>
         public static async Task<HttpResponseMessage> Post(Uri postUri, Stream stream, HttpClient httpClient)
-        { 
+        {
             return await Post(postUri, stream, new HttpClientWrapper(httpClient));
         }
 

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             {
                 await SarifLog.Post(new Uri("https://github.com/microsoft/sarif-sdk"),
                                     new MemoryStream(),
-                                    null);
+                                    (HttpClientWrapper)null);
             });
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                 await SarifLog.Post(postUri: null,
                                     filePath,
                                     fileSystem.Object,
-                                    httpClient: null);
+                                    httpClient: (HttpClientWrapper)null);
             });
 
             filePath = "SomeFile.txt";
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
                 await SarifLog.Post(postUri: null,
                                     filePath,
                                     fileSystem.Object,
-                                    httpClient: null);
+                                    httpClient: (HttpClientWrapper)null);
             });
         }
 
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             (bool, string) logPosted = await SarifLog.Post(postUri,
                                                            filePath,
                                                            fileSystem.Object,
-                                                           httpClient: null);
+                                                           httpClient: (HttpClientWrapper)null);
             logPosted.Item1.Should().BeFalse("with no results or notifications");
             logPosted.Item2.Should().Contain("was skipped");
 


### PR DESCRIPTION
Fixes the error:

```
error CS1503: Argument 3: cannot convert from 'System.Net.Http.HttpClient' to 'Microsoft.CodeAnalysis.Sarif.HttpClientWrapper'
```

which was introduced by an inadvertant public signature change in https://github.com/microsoft/sarif-sdk/pull/2772

NB: The return type change from `Task<bool>` to `Task<(bool, string)>` was intentional and is left in tact.