### PR TITLE
Fix IsTextualData() callers.

### DIFF
--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -105,7 +105,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             byte[] header = new byte[BinarySniffingHeaderSizeBytes];
             int length = this.Stream.Read(header, 0, header.Length);
-            bool isText = FileEncoding.IsTextualData(header, 0, length);
+
+            // Classifier tries decoding characters as UTF32, so it can only attempt to work on a quarter of the sample.
+            int charsToCheck = Math.Min(length, header.Length) / 4;
+            bool isText = FileEncoding.IsTextualData(header, 0, charsToCheck, length);
 
             TryRewindStream();
 

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             // Classifier tries decoding characters as UTF32, so it can only attempt to work on a quarter of the sample.
             int charsToCheck = Math.Min(length, header.Length) / 4;
-            bool isText = FileEncoding.IsTextualData(header, 0, charsToCheck, length);
+            bool isText = FileEncoding.IsTextualData(header, 0, length);
 
             TryRewindStream();
 

--- a/src/Sarif/FileEncoding.cs
+++ b/src/Sarif/FileEncoding.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         public static bool IsTextualData(byte[] bytes)
         {
-            return IsTextualData(bytes, 0, bytes.Length / 4, bytes.Length);
+            return IsTextualData(bytes, 0, bytes.Length);
         }
 
         /// <summary>
@@ -31,9 +31,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         /// <param name="bytes">The raw data expressed as bytes.</param>
         /// <param name="start">The starting position to being classification.</param>
-        /// <param name="charCount">The maximal count of characters to decode.</param>
         /// <param name="arrayFillSize">The amount of the bytes buffer which contains data.</param>
-        public static bool IsTextualData(byte[] bytes, int start, int charCount, int arrayFillSize)
+        public static bool IsTextualData(byte[] bytes, int start, int arrayFillSize)
         {
             bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
 
@@ -61,11 +60,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return true;
             }
 
-            foreach (Encoding encoding in new[] { Encoding.UTF32, Encoding.Unicode })
+            foreach (Tuple<Encoding, int> encodingInfo in new[] { Tuple.Create<Encoding, int>(Encoding.UTF32, 4), Tuple.Create<Encoding, int>(Encoding.Unicode, 2) })
             {
                 bool encodingSucceeded = true;
 
-                foreach (char c in encoding.GetChars(bytes, start, charCount))
+                foreach (char c in encodingInfo.Item1.GetChars(bytes, start, arrayFillSize / encodingInfo.Item2))
                 {
                     if (c == 0xfffd)
                     {

--- a/src/Sarif/FileEncoding.cs
+++ b/src/Sarif/FileEncoding.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         public static bool IsTextualData(byte[] bytes)
         {
-            return IsTextualData(bytes, 0, bytes.Length);
+            return IsTextualData(bytes, 0, bytes.Length / 4, bytes.Length);
         }
 
         /// <summary>
@@ -31,8 +31,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         /// <param name="bytes">The raw data expressed as bytes.</param>
         /// <param name="start">The starting position to being classification.</param>
-        /// <param name="count">The maximal count of characters to decode.</param>
-        public static bool IsTextualData(byte[] bytes, int start, int count)
+        /// <param name="charCount">The maximal count of characters to decode.</param>
+        /// <param name="arrayFillSize">The amount of the bytes buffer which contains data.</param>
+        public static bool IsTextualData(byte[] bytes, int start, int charCount, int arrayFillSize)
         {
             bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
 
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             bool containsControlCharacters = false;
 
-            for (int i = 0; i < bytes.Length; i++)
+            for (int i = 0; i < Math.Min(bytes.Length, arrayFillSize); i++)
             {
                 containsControlCharacters |= bytes[i] < 0x20;
             }
@@ -60,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 bool encodingSucceeded = true;
 
-                foreach (char c in encoding.GetChars(bytes, start, count))
+                foreach (char c in encoding.GetChars(bytes, start, charCount))
                 {
                     if (c == 0xfffd)
                     {

--- a/src/Sarif/FileEncoding.cs
+++ b/src/Sarif/FileEncoding.cs
@@ -42,6 +42,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentOutOfRangeException(nameof(start), $"Buffer size ({bytes.Length}) not valid for start ({start}) argument.");
             }
 
+            if (start >= arrayFillSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start), $"Buffer fill amount ({arrayFillSize}) not valid for start ({start}) argument.");
+            }
 
             Windows1252 = Windows1252 ?? Encoding.GetEncoding(1252);
 

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                         // Classifier tries decoding characters as UTF32, so it can only attempt to work on a quarter of the sample.
                         int charsToCheck = Math.Min(length, header.Length) / 4;
-                        bool isText = FileEncoding.IsTextualData(header, 0, charsToCheck, length);
+                        bool isText = FileEncoding.IsTextualData(header, 0, length);
 
                         peekable.Rewind();
 

--- a/src/Sarif/ZipArchiveArtifact.cs
+++ b/src/Sarif/ZipArchiveArtifact.cs
@@ -96,7 +96,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                         byte[] header = new byte[PeekWindowBytes];
                         int length = this.Stream.Read(header, 0, header.Length);
-                        bool isText = FileEncoding.IsTextualData(header, 0, length);
+
+                        // Classifier tries decoding characters as UTF32, so it can only attempt to work on a quarter of the sample.
+                        int charsToCheck = Math.Min(length, header.Length) / 4;
+                        bool isText = FileEncoding.IsTextualData(header, 0, charsToCheck, length);
 
                         peekable.Rewind();
 

--- a/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
+++ b/src/Test.UnitTests.Sarif/ArtifactProviderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 
 using FluentAssertions;
 
@@ -73,6 +74,25 @@ namespace Test.UnitTests.Sarif
                 artifact.Bytes.Should().NotBeNull();
                 artifact.Bytes.Length.Should().Be(headerSize);
                 artifact.SizeInBytes.Should().Be(headerSize);
+
+                artifact.Contents.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void MultithreadedZipArchiveArtifactProvider_SmallTextFile()
+        {
+            byte[] data = new byte[4];
+            Encoding.UTF32.GetBytes("a", data);
+
+            // Use the binary zip creator because it lets us write raw bytes that we've encoded.
+            ZipArchive zip = CreateZipArchiveWithBinaryContents("test.dll", data);
+            var artifactProvider = new MultithreadedZipArchiveArtifactProvider(zip, FileSystem.Instance);
+            foreach (IEnumeratedArtifact artifact in artifactProvider.Artifacts)
+            {
+                artifact.Bytes.Should().NotBeNull();
+                artifact.Bytes.Length.Should().Be(data.Length);
+                artifact.SizeInBytes.Should().Be(data.Length);
 
                 artifact.Contents.Should().BeNull();
             }

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         public void Stack_CreateFromStackTrace()
         {
             var dotNetStack = new StackTrace();
-            Stack stack = new Stack(dotNetStack);
+            var stack = new Stack(dotNetStack);
 
             // The .NET StackTrace.ToString() override must preserve a trailing NewLine
             // for compatibility reasons. We do not retain this behavior in ToString()

--- a/src/Test.UnitTests.Sarif/FileEncodingTests.cs
+++ b/src/Test.UnitTests.Sarif/FileEncodingTests.cs
@@ -21,14 +21,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void FileEncoding_NullBytesRaisesException()
         {
-            Assert.Throws<ArgumentNullException>(() => FileEncoding.IsTextualData(null, 1, 1));
+            Assert.Throws<ArgumentNullException>(() => FileEncoding.IsTextualData(null, 1, 1, 1));
         }
 
         [Fact]
         public void FileEncoding_StartExceedsBufferLength()
         {
             // Start argument exceeds buffer size.
-            Assert.Throws<ArgumentOutOfRangeException>(() => FileEncoding.IsTextualData(new byte[1], 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => FileEncoding.IsTextualData(new byte[1], 1, 1, 1));
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/FileEncodingTests.cs
+++ b/src/Test.UnitTests.Sarif/FileEncodingTests.cs
@@ -21,14 +21,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void FileEncoding_NullBytesRaisesException()
         {
-            Assert.Throws<ArgumentNullException>(() => FileEncoding.IsTextualData(null, 1, 1, 1));
+            Assert.Throws<ArgumentNullException>(() => FileEncoding.IsTextualData(null, 1, 1));
         }
 
         [Fact]
         public void FileEncoding_StartExceedsBufferLength()
         {
             // Start argument exceeds buffer size.
-            Assert.Throws<ArgumentOutOfRangeException>(() => FileEncoding.IsTextualData(new byte[1], 1, 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => FileEncoding.IsTextualData(new byte[1], 1, 1));
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var sb = new StringBuilder();
             string unicodeText = "американец";
 
-            foreach (Encoding encoding in new[] { Encoding.Unicode, Encoding.UTF8, Encoding.BigEndianUnicode, Encoding.UTF32 })
+            foreach (Encoding encoding in new[] { Encoding.BigEndianUnicode, Encoding.Unicode, Encoding.UTF8, Encoding.UTF32 })
             {
                 byte[] input = encoding.GetBytes(unicodeText);
                 FileEncoding.IsTextualData(input).Should().BeTrue(because: $"'{unicodeText}' encoded as '{encoding.EncodingName}' should not be classified as binary data");


### PR DESCRIPTION
Previously callers of the binary classifier were confusing the length field to refer to the bytes in the buffer instead of characters to decode.  This corrects that.  It also changes the API to be aware of the file extent of the buffer to avoid scanning data that might not be initialized.