### PR TITLE
Release v4.5.0

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,5 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## UNRELEASED
+## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
 * DEP: Remove spurious references to `System.Collections.Immutable`.

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.4.0</VersionPrefix>
-    <PreviousVersionPrefix>4.3.7</PreviousVersionPrefix>
+    <VersionPrefix>4.5.0</VersionPrefix>
+    <PreviousVersionPrefix>4.4.0</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
* DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.
* DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
* DEP: Remove spurious references to `System.Collections.Immutable`.
* DEP: Update `Microsoft.Data.SqlClient` reference from 2.1.2 to 2.1.7 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
* DEP: Update `System.Data.SqlClient` reference from 4.8.5 to 4.8.6 in `WorkItems` to resolve [CVE-2024-0056](https://github.com/advisories/GHSA-98g6-xh36-x2p7).
* BUG: Improve `FileEncoding.IsTextualData` method for detecting binary files.
* BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
* BUG: Fix `UnsupportedOperationException` in `ZipArchiveArtifact`.
* BUG: Fix `MultithreadedAnalyzeCommandBase` to return rich return code with the `--rich-return-code` option.
* NEW: Add `IsBinary` property to `IEnumeratedArtifact` and implement the property in `ZipArchiveArtifact`.
* NEW: Switch to content-based `IsBinary` categorization for `ZipArchiveArtifact`s.
* PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
* PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.
* NEW: Add a new `--timeout-in-seconds` parameter to `AnalyzeOptionsBase`, which will override the `TimeoutInMilliseconds` property in `AnalyzeContextBase`.
* NEW: `--post-uri` will skip sending the SARIF log to the configured endpoint if the file contains no results or fatal execution errors.
* NEW: Add the following rules:  
  `ADO1011.ReferenceFinalSchema`,  
  `ADO1013.ProvideRequiredSarifLogProperties`,  
  `ADO1014.ProvideRequiredRunProperties`,  
  `ADO1015.ProvideRequiredResultProperties`,  
  `ADO1016.ProvideRequiredLocationProperties`,  
  `ADO1017.ProvideRequiredPhysicalLocationProperties`,  
  `ADO1018.ProvideRequiredToolProperties`,  
  `ADO2012.ProvideRequiredReportingDescriptorProperties`,  
  `GH1011.ReferenceFinalSchema`,  
  `GH1013.ProvideRequiredSarifLogProperties`,  
  `GH1014.ProvideRequiredRunProperties`,  
  `GH1015.ProvideRequiredResultProperties`,  
  `GH1016.ProvideRequiredLocationProperties`,  
  `GH1017.ProvideRequiredPhysicalLocationProperties`,  
  `GH1018.ProvideRequiredToolProperties`,  
  `GH2012.ProvideRequiredReportingDescriptorProperties`.
* NEW: Add a new `--rule-kind` parameter to `AnalyzeOptionsBase`, which specifies rule kinds to run (`Sarif`, `Ghas`, `Ado`). Example: `--rule-kind Ado;Sarif`.
