### PR TITLE
Report `WRN997_InvalidTarget` if the path of the scan target contains invalid character. Scan file with URL-decodable name without throwing exceptions.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.1 UNRELEASED
-* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid characters.
-* BUG: When the path of the scan target contains URL Percent-encoding characters, `uri.GetFilePath` should return the original string.
+* BUG: When the path of the scan target contains invalid characters, report `WRN997_InvalidTarget` before analyzing it against any rule, otherwise `ArgumentException: Illegal characters in path` will be thrown.
+* BUG: When the path of the scan target contains URL Percent-encoding characters, it should proceed with analyzing without throwing `System.IO.FileNotFoundException`.
 
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.1 UNRELEASED
-* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid character or encoded character.
+* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid characters or encoded characters.
 
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.1 UNRELEASED
-* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid characters or encoded characters.
+* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid characters.
+* BUG: When the path of the scan target contains URL Percent-encoding characters, `uri.GetFilePath` should return the original string.
 
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## **v4.5.1 UNRELEASED
+* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid character or encoded character.
+
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.
@@ -9,7 +12,6 @@
 * BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * BUG: Fix `UnsupportedOperationException` in `ZipArchiveArtifact`.
 * BUG: Fix `MultithreadedAnalyzeCommandBase` to return rich return code with the `--rich-return-code` option.
-* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid character or encoded character.
 * NEW: Add `IsBinary` property to `IEnumeratedArtifact` and implement the property in `ZipArchiveArtifact`.
 * NEW: Switch to content-based `IsBinary` categorization for `ZipArchiveArtifact`s.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.3 UNRELEASED
-* BUG: When the path of the scan target contains invalid characters, report `WRN997_InvalidTarget` before analyzing it against any rule, otherwise `ArgumentException: Illegal characters in path` will be thrown.
+* BUG: When the path of the scan target contains invalid characters, report `WRN997_InvalidTarget` before analyzing it against any rule to avoid `ArgumentException: Illegal characters in path`.
 * BUG: When the path of the scan target contains URL percent-encoding characters, it should proceed with analyzing without throwing `System.IO.FileNotFoundException`.
 
 ## **v4.5.2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.2)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.2)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -8,6 +8,7 @@
 * BUG: Update `Stack.Create` method to populate missing `PhysicalLocation` instances when stack frames reference relative file paths.
 * BUG: Fix `UnsupportedOperationException` in `ZipArchiveArtifact`.
 * BUG: Fix `MultithreadedAnalyzeCommandBase` to return rich return code with the `--rich-return-code` option.
+* BUG: Report `WRN997_InvalidTarget` if the path of the scan target contains invalid character or encoded character.
 * NEW: Add `IsBinary` property to `IEnumeratedArtifact` and implement the property in `ZipArchiveArtifact`.
 * PRF: Change default `max-file-size-in-kb` parameter to 10 megabytes.
 * PRF: Add support for efficiently peeking into non-seekable streams for binary/text categorization.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.1 UNRELEASED
 * BUG: When the path of the scan target contains invalid characters, report `WRN997_InvalidTarget` before analyzing it against any rule, otherwise `ArgumentException: Illegal characters in path` will be thrown.
-* BUG: When the path of the scan target contains URL Percent-encoding characters, it should proceed with analyzing without throwing `System.IO.FileNotFoundException`.
+* BUG: When the path of the scan target contains URL percent-encoding characters, it should proceed with analyzing without throwing `System.IO.FileNotFoundException`.
 
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -48,10 +48,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             string normalizedSpecifier = Environment.ExpandEnvironmentVariables(this.specifier);
 
             // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters,
-            // thus 'uri.OriginalString' is used below.
             if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
             {
-                normalizedSpecifier = uri.OriginalString;
+                normalizedSpecifier = uri.GetFilePath();
             }
 
             string filter = Path.GetFileName(normalizedSpecifier);

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string normalizedSpecifier = Environment.ExpandEnvironmentVariables(this.specifier);
 
-            // 'normalizedSpecifier' might be changed if it contains URL Percent-encoding characters.
+            // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters.
             if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
             {
                 normalizedSpecifier = uri.GetFilePath();

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string normalizedSpecifier = Environment.ExpandEnvironmentVariables(this.specifier);
 
-            // normalizedSpecifier might be changed if it contains URL Percent-Encoding characters.
+            // 'normalizedSpecifier' might be changed if it contains URL Percent-encoding characters.
             if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
             {
                 normalizedSpecifier = uri.GetFilePath();

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -47,10 +47,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string normalizedSpecifier = Environment.ExpandEnvironmentVariables(this.specifier);
 
-            // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters.
+            // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters,
+            // thus 'uri.OriginalString' is used below.
             if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
             {
-                normalizedSpecifier = uri.GetFilePath();
+                normalizedSpecifier = uri.OriginalString;
             }
 
             string filter = Path.GetFileName(normalizedSpecifier);

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             string normalizedSpecifier = Environment.ExpandEnvironmentVariables(this.specifier);
 
+            // normalizedSpecifier might be changed if it contains URL Percent-Encoding characters.
             if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
             {
                 normalizedSpecifier = uri.GetFilePath();

--- a/src/Sarif.Driver/PathExtensions.cs
+++ b/src/Sarif.Driver/PathExtensions.cs
@@ -160,10 +160,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         /// <summary>
-        /// Determines whether the input string contains any invalid Path character.
+        /// Determines whether the input string contains any invalid path character.
         /// </summary>
         /// <param name="path">The input string.</param>
-        /// <returns>true if the input string contains invalid Path character; otherwise, false.</returns>
+        /// <returns>true if the input string contains invalid path character; otherwise, false.</returns>
         public static bool ContainsInvalidPathChar(this string path)
         {
             char[] invalidPathChars = Path.GetInvalidPathChars();

--- a/src/Sarif.Driver/PathExtensions.cs
+++ b/src/Sarif.Driver/PathExtensions.cs
@@ -160,6 +160,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         /// <summary>
+        /// Determines whether the input string contains any invalid Path character.
+        /// </summary>
+        /// <param name="path">The input string.</param>
+        /// <returns>true if the input string contains invalid Path character; otherwise, false.</returns>
+        public static bool ContainsInvalidPathChar(this string path)
+        {
+            char[] invalidPathChars = Path.GetInvalidPathChars();
+
+            foreach (char c in path)
+            {
+                if (invalidPathChars.Contains(c))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Replace invalid file name characters in given file name with specified valid character.
         /// </summary>
         /// <param name="fileName">The file name to check if contains invalid file name characters.</param>

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -1222,7 +1222,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public static void AnalyzeTargetHelper(TContext context, IEnumerable<Skimmer<TContext>> skimmers, ISet<string> disabledSkimmers)
         {
-            // This might the public API invoked by other tools
             Uri uri = context.CurrentTarget.Uri;
             string filePath = uri.GetFilePath();
 
@@ -1251,15 +1250,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                         ? Stopwatch.StartNew()
                         : null;
 
-                    DriverEventSource.Log.RuleStart(context.CurrentTarget.Uri.GetFilePath(), skimmer.Id, skimmer.Name);
+                    DriverEventSource.Log.RuleStart(filePath, skimmer.Id, skimmer.Name);
                     skimmer.Analyze(context);
-                    DriverEventSource.Log.RuleStop(context.CurrentTarget.Uri.GetFilePath(), skimmer.Id, skimmer.Name);
+                    DriverEventSource.Log.RuleStop(filePath, skimmer.Id, skimmer.Name);
 
                     if (stopwatch != null)
                     {
-                        string file = uri.GetFilePath();
-                        string directory = Path.GetDirectoryName(file);
-                        file = Path.GetFileName(file);
+                        string directory = Path.GetDirectoryName(filePath);
+                        string file = Path.GetFileName(filePath);
 
                         string id = $"TRC101.{nameof(DefaultTraces.RuleScanTime)}";
                         string timing = $"'{file}' : elapsed {stopwatch.Elapsed} : '{skimmer.Name}' : at '{directory}'";

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         private Channel<uint> _resultsWritingChannel;
         private Channel<uint> readyToScanChannel;
         private ConcurrentDictionary<uint, TContext> _fileContexts;
+        private readonly static string URLPercentEncodingPattern = @"%[0-9][0-9A-Fa-f]";
 
         public static bool RaiseUnhandledExceptionInDriverCode { get; set; }
 
@@ -1227,9 +1228,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             Uri uri = context.CurrentTarget.Uri;
             string originalStr = uri.OriginalString;
             string filePath = uri.GetFilePath();
-            var URLPercentEncodingRegex = new Regex(@"%[0-9][0-9A-Fa-f]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-            if (URLPercentEncodingRegex.IsMatch(originalStr) || filePath.ContainsInvalidPathChar())
+            if (Regex.IsMatch(originalStr, URLPercentEncodingPattern) || filePath.ContainsInvalidPathChar())
             {
                 Warnings.LogExceptionInvalidTarget(context);
                 return;

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
@@ -42,7 +41,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         private Channel<uint> _resultsWritingChannel;
         private Channel<uint> readyToScanChannel;
         private ConcurrentDictionary<uint, TContext> _fileContexts;
-        private readonly static string URLPercentEncodingPattern = @"%[0-9][0-9A-Fa-f]";
 
         public static bool RaiseUnhandledExceptionInDriverCode { get; set; }
 
@@ -1226,10 +1224,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             // This might the public API invoked by other tools
             Uri uri = context.CurrentTarget.Uri;
-            string originalStr = uri.OriginalString;
             string filePath = uri.GetFilePath();
 
-            if (Regex.IsMatch(originalStr, URLPercentEncodingPattern) || filePath.ContainsInvalidPathChar())
+            if (filePath.ContainsInvalidPathChar())
             {
                 Warnings.LogExceptionInvalidTarget(context);
                 return;

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 // This is our client-side, disk-based file retrieval case.
-                this.Stream = FileSystem.FileOpenRead(Uri.GetFilePath());
+                this.Stream = FileSystem.FileOpenRead(Uri.OriginalString);
             }
 
             RetrieveDataFromStream();

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 else if (Uri != null && Uri.IsAbsoluteUri && Uri.IsFile)
                 {
-                    this.sizeInBytes = (long)FileSystem.FileInfoLength(Uri.GetFilePath());
+                    this.sizeInBytes = (long)FileSystem.FileInfoLength(Uri.OriginalString);
                 }
                 else if (this.Contents != null)
                 {

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 // This is our client-side, disk-based file retrieval case.
-                this.Stream = FileSystem.FileOpenRead(Uri.LocalPath);
+                this.Stream = FileSystem.FileOpenRead(Uri.GetFilePath());
             }
 
             RetrieveDataFromStream();
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 else if (Uri != null && Uri.IsAbsoluteUri && Uri.IsFile)
                 {
-                    this.sizeInBytes = (long)FileSystem.FileInfoLength(Uri.LocalPath);
+                    this.sizeInBytes = (long)FileSystem.FileInfoLength(Uri.GetFilePath());
                 }
                 else if (this.Contents != null)
                 {

--- a/src/Sarif/SarifExtensionMethods.cs
+++ b/src/Sarif/SarifExtensionMethods.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public static string GetFilePath(this Uri uri)
         {
             if (!uri.IsAbsoluteUri)
-            { 
+            {
                 return uri.OriginalString;
             }
 

--- a/src/Sarif/SarifExtensionMethods.cs
+++ b/src/Sarif/SarifExtensionMethods.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -258,7 +259,19 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static string GetFilePath(this Uri uri)
         {
-            return uri.IsAbsoluteUri ? uri.LocalPath : uri.OriginalString;
+            if (!uri.IsAbsoluteUri)
+            { 
+                return uri.OriginalString;
+            }
+
+            if (Path.GetFileName(uri.OriginalString) != Path.GetFileName(uri.LocalPath))
+            {
+                return uri.OriginalString;
+            }
+            else
+            {
+                return uri.LocalPath;
+            }
         }
 
         public static string FormatForVisualStudio(this Region region)

--- a/src/Sarif/SarifExtensionMethods.cs
+++ b/src/Sarif/SarifExtensionMethods.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         [ThreadStatic]
         private static StringBuilder s_sb;
 
-        private readonly static Regex URLPercentEncodingRegex = new Regex(@"%[0-9][0-9A-Fa-f]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
         public static string CsvEscape(this string value)
         {
             if (string.IsNullOrEmpty(value)) { return string.Empty; }
@@ -260,23 +258,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static string GetFilePath(this Uri uri)
         {
-            string originalString = uri.OriginalString;
-            string originalStringWithoutQuery = originalString.Split('?')[0];
-
-            // 'uri.LocalPath' is not supported for RelativeUri.
-            if (!uri.IsAbsoluteUri)
-            {
-                return originalStringWithoutQuery;
-            }
-
-            if (URLPercentEncodingRegex.IsMatch(originalString))
-            {
-                // If the 'originalString' contains URL percent-encoding characters,
-                // 'uri.LocalPath' will decode them thus changing the path unexpectedly.
-                return originalStringWithoutQuery;
-            }
-
-            return uri.LocalPath;
+            return uri.IsAbsoluteUri ? uri.LocalPath : uri.OriginalString;
         }
 
         public static string FormatForVisualStudio(this Region region)

--- a/src/Sarif/SarifExtensionMethods.cs
+++ b/src/Sarif/SarifExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [ThreadStatic]
         private static StringBuilder s_sb;
 
-        private readonly static string URLPercentEncodingPattern = @"%[0-9][0-9A-Fa-f]";
+        private readonly static Regex URLPercentEncodingRegex = new Regex(@"%[0-9][0-9A-Fa-f]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public static string CsvEscape(this string value)
         {
@@ -269,16 +269,14 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return originalStringWithoutQuery;
             }
 
-            if (Regex.IsMatch(originalString, URLPercentEncodingPattern))
+            if (URLPercentEncodingRegex.IsMatch(originalString))
             {
                 // If the 'originalString' contains URL percent-encoding characters,
                 // 'uri.LocalPath' will decode them thus changing the path unexpectedly.
                 return originalStringWithoutQuery;
             }
-            else
-            {
-                return uri.LocalPath;
-            }
+
+            return uri.LocalPath;
         }
 
         public static string FormatForVisualStudio(this Region region)

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -291,10 +291,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (uri != null)
             {
-                // If a path refers to a URI of form file://blah, we will convert to the local path           
+                // If a path refers to a URI of form file://blah, we will convert to the local path
                 if (uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeFile)
                 {
-                    path = uri.LocalPath;
+                    path = uri.GetFilePath();
                 }
                 else
                 {

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (uri != null)
             {
-                // If a path refers to a URI of form file://blah, we will convert to the local path
+                // If a path refers to a URI of form file://blah, we will convert to the local path.
                 if (uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeFile)
                 {
                     path = uri.GetFilePath();

--- a/src/Sarif/Writers/ConsoleLogger.cs
+++ b/src/Sarif/Writers/ConsoleLogger.cs
@@ -291,10 +291,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (uri != null)
             {
-                // If a path refers to a URI of form file://blah, we will convert to the local path.
+                // If a path refers to a URI of form file://blah,
+                // we will use the 'uri.OriginalString' in case the file name contains URL percent-encoding characters.
                 if (uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeFile)
                 {
-                    path = uri.GetFilePath();
+                    path = uri.OriginalString;
                 }
                 else
                 {

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -47,49 +47,6 @@ namespace Test.UnitTests.Sarif.Driver
         }
 
         [Fact]
-        public void UriGetFilePath_ShouldNotChangeFileName()
-        {
-            var tuples = new List<Tuple<string, string>>
-            {
-                // Test cases of relative URI
-                new Tuple<string, string>("test%2D.md","test%2D.md"),
-                new Tuple<string, string>("\\test%2D.md", "\\test%2D.md"),
-                new Tuple<string, string>("/test%2D.md", "/test%2D.md"),
-                new Tuple<string, string>("/test%2D.md?some-query-string", "/test%2D.md"),
-                new Tuple<string, string>("/test.md", "/test.md"),
-                new Tuple<string, string>("/test.md?some-query-string", "/test.md"),
-
-                // Test cases of absolute URI
-                new Tuple<string, string>("C:\\test%2D.md", "C:\\test%2D.md"),
-                new Tuple<string, string>("C:\\Local%20DFile\\test%2D.md", "C:\\Local%20DFile\\test%2D.md"),
-                new Tuple<string, string>("C:\\Local%20DFile\\test%2D.md?some-query-string", "C:\\Local%20DFile\\test%2D.md"),
-                new Tuple<string, string>("C:\\Local%20DFile\\test.md?some-query-string", "C:\\Local%20DFile\\test.md"),
-
-                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test%2D.md", "https://github.com/microsoft/sarif-sdk/test%2D.md"),
-                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test%2D.md?some-query-string", "https://github.com/microsoft/sarif-sdk/test%2D.md"),
-                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test.md", "/microsoft/sarif-sdk/test.md"),
-                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test.md?some-query-string", "/microsoft/sarif-sdk/test.md"),
-            };
-
-            var sb = new StringBuilder();
-            string filePath = string.Empty;
-            foreach (Tuple<string, string> tuple in tuples)
-            {
-                if (Uri.TryCreate(tuple.Item1, UriKind.RelativeOrAbsolute, out Uri uri))
-                {
-                    filePath = uri.GetFilePath();
-                }
-
-                if (!filePath.Equals(tuple.Item2))
-                {
-                    sb.Append($"'{filePath}' should be '{tuple.Item2}';");
-                }
-            }
-
-            sb.Length.Should().Be(0);
-        }
-
-        [Fact]
         [Trait(TestTraits.WindowsOnly, "true")]
         public void ReplaceInvalidCharInFileName_ShouldCorrectFilePath()
         {

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -34,10 +34,10 @@ namespace Test.UnitTests.Sarif.Driver
         [Fact]
         public void ContainsInvalidPathChar_test()
         {
-            string validPath = "C:\\test.md";
+            string validPath = "test.md";
             validPath.ContainsInvalidPathChar().Should().BeFalse();
 
-            string invalidPath = "C:\\test|.md";
+            string invalidPath = "test|.md";
             invalidPath.ContainsInvalidPathChar().Should().BeTrue();
         }
 

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -32,14 +32,18 @@ namespace Test.UnitTests.Sarif.Driver
         }
 
         [Fact]
-        [Trait(TestTraits.WindowsOnly, "true")]
         public void ContainsInvalidPathChar_test()
         {
             string validPath = "test.md";
             validPath.ContainsInvalidPathChar().Should().BeFalse();
 
-            string invalidPath = "test\t.md";
-            invalidPath.ContainsInvalidPathChar().Should().BeTrue();
+            char[] invalidPathChars = Path.GetInvalidPathChars();
+            if( invalidPathChars.Length != 0 ) 
+            {
+                string invalidPath = "test" + invalidPathChars[0] + ".md";
+                invalidPath.ContainsInvalidPathChar().Should().BeTrue();
+                this._outputHelper.WriteLine($"file: {invalidPath} contains invalid character.");
+            }
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -32,6 +32,16 @@ namespace Test.UnitTests.Sarif.Driver
         }
 
         [Fact]
+        public void ContainsInvalidPathChar_test()
+        {
+            string validPath = "C:\\test.md";
+            validPath.ContainsInvalidPathChar().Should().BeFalse();
+
+            string invalidPath = "C:\\test|.md";
+            invalidPath.ContainsInvalidPathChar().Should().BeTrue();
+        }
+
+        [Fact]
         [Trait(TestTraits.WindowsOnly, "true")]
         public void ReplaceInvalidCharInFileName_ShouldCorrectFilePath()
         {

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -49,30 +49,45 @@ namespace Test.UnitTests.Sarif.Driver
         [Fact]
         public void UriGetFilePath_ShouldNotChangeFileName()
         {
-            string orignalString = "test%2D.md";
+            var tuples = new List<Tuple<string, string>>
+            {
+                // Test cases of relative URI
+                new Tuple<string, string>("test%2D.md","test%2D.md"),
+                new Tuple<string, string>("\\test%2D.md", "\\test%2D.md"),
+                new Tuple<string, string>("/test%2D.md", "/test%2D.md"),
+                new Tuple<string, string>("/test%2D.md?some-query-string", "/test%2D.md"),
+                new Tuple<string, string>("/test.md", "/test.md"),
+                new Tuple<string, string>("/test.md?some-query-string", "/test.md"),
+
+                // Test cases of absolute URI
+                new Tuple<string, string>("C:\\test%2D.md", "C:\\test%2D.md"),
+                new Tuple<string, string>("C:\\Local%20DFile\\test%2D.md", "C:\\Local%20DFile\\test%2D.md"),
+                new Tuple<string, string>("C:\\Local%20DFile\\test%2D.md?some-query-string", "C:\\Local%20DFile\\test%2D.md"),
+                new Tuple<string, string>("C:\\Local%20DFile\\test.md?some-query-string", "C:\\Local%20DFile\\test.md"),
+
+                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test%2D.md", "https://github.com/microsoft/sarif-sdk/test%2D.md"),
+                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test%2D.md?some-query-string", "https://github.com/microsoft/sarif-sdk/test%2D.md"),
+                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test.md", "/microsoft/sarif-sdk/test.md"),
+                new Tuple<string, string>("https://github.com/microsoft/sarif-sdk/test.md?some-query-string", "/microsoft/sarif-sdk/test.md"),
+            };
+
+            var sb = new StringBuilder();
             string filePath = string.Empty;
-
-            if (Uri.TryCreate(orignalString, UriKind.RelativeOrAbsolute, out Uri uri1))
+            foreach (Tuple<string, string> tuple in tuples)
             {
-                filePath = uri1.GetFilePath();
+                if (Uri.TryCreate(tuple.Item1, UriKind.RelativeOrAbsolute, out Uri uri))
+                {
+                    filePath = uri.GetFilePath();
+                }
+
+                if (!filePath.Equals(tuple.Item2))
+                {
+                    sb.Append($"'{filePath}' should be '{tuple.Item2}';");
+                }
             }
 
-            filePath.Should().Be(orignalString);
-
-            orignalString = "C:\\test%2D.md";
-            if (Uri.TryCreate(orignalString, UriKind.RelativeOrAbsolute, out Uri uri2))
-            {
-                filePath = uri2.GetFilePath();
-            }
-
-            filePath.Should().Be(orignalString);
+            sb.Length.Should().Be(0);
         }
-
-
-        //    // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters.
-        //    if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
-        //    {
-        //    normalizedSpecifier = uri.GetFilePath();
 
         [Fact]
         [Trait(TestTraits.WindowsOnly, "true")]

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -47,6 +47,34 @@ namespace Test.UnitTests.Sarif.Driver
         }
 
         [Fact]
+        public void UriGetFilePath_ShouldNotChangeFileName()
+        {
+            string orignalString = "test%2D.md";
+            string filePath = string.Empty;
+
+            if (Uri.TryCreate(orignalString, UriKind.RelativeOrAbsolute, out Uri uri1))
+            {
+                filePath = uri1.GetFilePath();
+            }
+
+            filePath.Should().Be(orignalString);
+
+            orignalString = "C:\\test%2D.md";
+            if (Uri.TryCreate(orignalString, UriKind.RelativeOrAbsolute, out Uri uri2))
+            {
+                filePath = uri2.GetFilePath();
+            }
+
+            filePath.Should().Be(orignalString);
+        }
+
+
+        //    // 'normalizedSpecifier' should not be changed even if it contains URL Percent-encoding characters.
+        //    if (Uri.TryCreate(this.specifier, UriKind.RelativeOrAbsolute, out Uri uri))
+        //    {
+        //    normalizedSpecifier = uri.GetFilePath();
+
+        [Fact]
         [Trait(TestTraits.WindowsOnly, "true")]
         public void ReplaceInvalidCharInFileName_ShouldCorrectFilePath()
         {

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -38,11 +38,11 @@ namespace Test.UnitTests.Sarif.Driver
             validPath.ContainsInvalidPathChar().Should().BeFalse();
 
             char[] invalidPathChars = Path.GetInvalidPathChars();
-            if( invalidPathChars.Length != 0 ) 
+            if (invalidPathChars.Length > 0)
             {
                 string invalidPath = "test" + invalidPathChars[0] + ".md";
+                this._outputHelper.WriteLine($"The invalid path is: {invalidPath}.");
                 invalidPath.ContainsInvalidPathChar().Should().BeTrue();
-                this._outputHelper.WriteLine($"file: {invalidPath} contains invalid character.");
             }
         }
 

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace Test.UnitTests.Sarif.Driver
             string validPath = "test.md";
             validPath.ContainsInvalidPathChar().Should().BeFalse();
 
-            string invalidPath = "test|.md";
+            string invalidPath = "test\t.md";
             invalidPath.ContainsInvalidPathChar().Should().BeTrue();
         }
 

--- a/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/PathExtensionsTests.cs
@@ -32,6 +32,7 @@ namespace Test.UnitTests.Sarif.Driver
         }
 
         [Fact]
+        [Trait(TestTraits.WindowsOnly, "true")]
         public void ContainsInvalidPathChar_test()
         {
             string validPath = "test.md";

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -858,11 +858,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             int result = command.Run(options: null, ref context);
             context.ValidateCommandExecution(result);
+            context.RuntimeErrors.Should().Be(RuntimeConditions.TargetNotValidToAnalyze);
 
             var sarifLog = logger.ToSarifLog();
             sarifLog.Runs[0].Should().NotBeNull();
-            sarifLog.Runs[0].Results[0].Should().NotBeNull();
-            sarifLog.Runs[0].Results.Count.Should().Be(1);
+            sarifLog.Runs[0].Results.Count.Should().Be(0);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -836,12 +836,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var logger = new MemoryStreamSarifLogger(dataToInsert: OptionallyEmittedData.Hashes);
             var command = new TestMultithreadedAnalyzeCommand();
+            var uri = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
 
-            var relativeUriWithEncodedFileName = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
-            var target1 = new EnumeratedArtifact(FileSystem.Instance) { Uri = relativeUriWithEncodedFileName, Contents = "foo foo" };
-
-            var absoluteUriWithEncodedFileName = new Uri("C:\\Local%20DFile\\test%2D.md", UriKind.Absolute);
-            var target2 = new EnumeratedArtifact(FileSystem.Instance) { Uri = absoluteUriWithEncodedFileName, Contents = "foo foo" };
+            var target = new EnumeratedArtifact(FileSystem.Instance) { Uri = uri, Contents = "foo foo" };
 
             var options = new TestAnalyzeOptions
             {
@@ -853,7 +850,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             var context = new TestAnalysisContext
             {
-                TargetsProvider = new ArtifactProvider(new[] { target1, target2 }),
+                TargetsProvider = new ArtifactProvider(new[] { target }),
                 DataToInsert = OptionallyEmittedData.Hashes,
                 Policy = properties,
                 Logger = logger,
@@ -865,7 +862,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var sarifLog = logger.ToSarifLog();
             sarifLog.Runs[0].Should().NotBeNull();
             sarifLog.Runs[0].Results[0].Should().NotBeNull();
-            sarifLog.Runs[0].Results.Count.Should().Be(2);
+            sarifLog.Runs[0].Results.Count.Should().Be(1);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -836,7 +836,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var logger = new MemoryStreamSarifLogger(dataToInsert: OptionallyEmittedData.Hashes);
             var command = new TestMultithreadedAnalyzeCommand();
-            var uri = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
+            var uri = new Uri("/new%20folder/0%1%20%.txt", UriKind.Relative);
 
             var target = new EnumeratedArtifact(FileSystem.Instance) { Uri = uri, Contents = "foo foo" };
 

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/AnalyzeCommandBaseTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var artifact = new EnumeratedArtifact(new FileSystem())
             {
                 Uri = new Uri(@"c:\testfile1.txt"),
-                Contents = new string('x', 1024), // Withing threshold.
+                Contents = new string('x', 1024), // Within threshold.
             };
 
             var anotherArtifact = new EnumeratedArtifact(new FileSystem())
@@ -836,9 +836,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var logger = new MemoryStreamSarifLogger(dataToInsert: OptionallyEmittedData.Hashes);
             var command = new TestMultithreadedAnalyzeCommand();
-            var uri = new Uri("/new%20folder/0%1%20%.txt", UriKind.Relative);
 
-            var target = new EnumeratedArtifact(FileSystem.Instance) { Uri = uri, Contents = "foo foo" };
+            var relativeUriWithEncodedFileName = new Uri("/new folder/0%1%20%.txt", UriKind.Relative);
+            var target1 = new EnumeratedArtifact(FileSystem.Instance) { Uri = relativeUriWithEncodedFileName, Contents = "foo foo" };
+
+            var absoluteUriWithEncodedFileName = new Uri("C:\\Local%20DFile\\test%2D.md", UriKind.Absolute);
+            var target2 = new EnumeratedArtifact(FileSystem.Instance) { Uri = absoluteUriWithEncodedFileName, Contents = "foo foo" };
 
             var options = new TestAnalyzeOptions
             {
@@ -850,7 +853,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             var context = new TestAnalysisContext
             {
-                TargetsProvider = new ArtifactProvider(new[] { target }),
+                TargetsProvider = new ArtifactProvider(new[] { target1, target2 }),
                 DataToInsert = OptionallyEmittedData.Hashes,
                 Policy = properties,
                 Logger = logger,
@@ -862,7 +865,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var sarifLog = logger.ToSarifLog();
             sarifLog.Runs[0].Should().NotBeNull();
             sarifLog.Runs[0].Results[0].Should().NotBeNull();
-            sarifLog.Runs[0].Results.Count.Should().Be(1);
+            sarifLog.Runs[0].Results.Count.Should().Be(2);
         }
 
         [Fact]


### PR DESCRIPTION
When the path of the scan target contains invalid character, the exception 'ArgumentException: Illegal characters in path' was raised for 100++ rule checks, as reported in a bug.

This fix check the path of the scan target before invoking any rule skimmer. If the path contains invalid character or URL encoded character, return `WRN997_InvalidTarget`.

Unit tests are added/updated.

====More detailed description===
In Microsoft.CodeAnalysis.Sarif.RuntimeConditions enum, there are at least 2 different target-related condition:
Fatal one (**Error**):        NoValidAnalysisTargets
Non-fatal (**Warning**): TargetNotValidToAnalyze
If we have 2 files to scan, one is a **normal** file, another is a file with **weird** filename (invalid char or contains %2F)
We won't see NoValidAnalysisTargets, as we do have a valid target.

But when file with weird name continues to flow through the code, it might cause trouble somewhere.
1) if the filename contains URL encoded character, such as "%2F", when URI is made out of the filename. **The filename changed!**, which means it won't be located later.
Eg: Incoming-email-not-synchronized-%2D-%22Ignoring-item%22.md will be changed to Incoming-email-not-synchronized---"Ignoring-item".md
 
2) if the filename contains invalid character as defined by **System.IO.Path.GetInvalidPathChars,** it could throw exception as documented by [Path.GetExtension Method (System.IO) | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getextension?view=net-8.0)