### PR TITLE
Fix SPMI dotnet publish package version conflict errors by explicitly adding related package.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## UNRELEASED
+* DEP: Add explicit package references to `Sarif` and `Sarif.Driver` to resolve version conflict build error.
+  `System.Diagnostics.Debug` 4.3.0,
+  `System.IO.FileSystem.Primitives` 4.3.0
+  `System.Text.Encoding.Extensions` 4.3.0
+
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.
 * DEP: Remove explicit versioning for `System.Memory` and `System.Runtime.CompilerServices.Unsafe`.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,8 +2,8 @@
 ## UNRELEASED
 * DEP: Add explicit package references to `Sarif` and `Sarif.Driver` to resolve version conflict build error.
   `System.Diagnostics.Debug` 4.3.0,
-  `System.IO.FileSystem.Primitives` 4.3.0
-  `System.Text.Encoding.Extensions` 4.3.0
+  `System.IO.FileSystem.Primitives` 4.3.0,
+  `System.Text.Encoding.Extensions` 4.3.0.
 
 ## **v4.5.0 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.0)
 * DEP: Downgrade `System.Text.Encoding.CodePages` from 8.0.0 to 4.3.0 in `Sarif`.

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -43,6 +43,9 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Composition" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description:

In order to build a standalone self-contained .net6.0 application, these build errors need to be resolved.

The similar fixes already made in sarif.csproj (https://github.com/microsoft/sarif-sdk/pull/2765/files)

```
C:\Repos\1ES\SpmiNew1\src\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj : error NU1605: Warning As Error: Dete
cted package downgrade: System.Diagnostics.Debug from 4.3.0 to 4.0.11. Reference the package directly from the
project to select a different version.  [C:\Repos\1ES\SpmiNew1\src\Sarif.PatternMatcher.Cli\Sarif.PatternMatche
r.Cli.csproj]
...
C:\Repos\1ES\SpmiNew1\src\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj : error NU1605: Warning As Error: Dete
cted package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly fro
m the project to select a different version.  [C:\Repos\1ES\SpmiNew1\src\Sarif.PatternMatcher.Cli\Sarif.Pattern
Matcher.Cli.csproj]
...
C:\Repos\1ES\SpmiNew1\src\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj : error NU1605: Warning As Error: Dete
cted package downgrade: System.Text.Encoding.Extensions from 4.3.0 to 4.0.11. Reference the package directly fr
om the project to select a different version.  [C:\Repos\1ES\SpmiNew1\src\Sarif.PatternMatcher.Cli\Sarif.Patter
nMatcher.Cli.csproj]
...
```
