### PR TITLE
Fix MessageResourceNames merging

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## **v4.5.2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.1)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.1)
+* BUG: Update Skimmer stack in Multitool.Library to support shared MessageResourceNames collections between base rules and their derivatives.
+* BUG: Fix message strings to always assume {1} is reserved for the rule's service name.
+* BUG: Clean up unused resource strings in Multitool.Library.Rules.RuleResources.resx.
+
+# SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v4.5.1 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.1)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.1)
 * DEP: Add explicit package references to `Sarif` and `Sarif.Driver` to resolve version conflict build error.
   `System.Diagnostics.Debug` 4.3.0,

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,5 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
-## **v4.5.2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.1)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.1)
+## **v4.5.2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.2)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.2)
 * BUG: Update Skimmer stack in Multitool.Library to support shared MessageResourceNames collections between base rules and their derivatives.
 * BUG: Fix message strings to always assume {1} is reserved for the rule's service name.
 * BUG: Clean up unused resource strings in Multitool.Library.Rules.RuleResources.resx.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+## **v4.5.3 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.3)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.3)
+* BUG: Restructure shared MessageResourceNames collections to ensure return of correct error messages.
+
 ## **v4.5.2 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.2)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.2) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.2)
 * BUG: Update Skimmer stack in Multitool.Library to support shared MessageResourceNames collections between base rules and their derivatives.
 * BUG: Fix message strings to always assume {1} is reserved for the rule's service name.

--- a/src/Sarif.Multitool.Library/Rules/ADO1011.ReferenceFinalSchema.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1011.ReferenceFinalSchema.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.ADOReferenceFinalSchema;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1011_ReferenceFinalSchema_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 

--- a/src/Sarif.Multitool.Library/Rules/ADO1013.ProvideRequiredSarifLogProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1013.ProvideRequiredSarifLogProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.ADOProvideRequiredSarifLogProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1013_ProvideRequiredSarifLogProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 

--- a/src/Sarif.Multitool.Library/Rules/ADO1014.ProvideRequiredRunProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1014.ProvideRequiredRunProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -15,6 +16,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1014_ProvideRequiredRunProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>()
+        {
+            nameof(RuleResources.ADO1014_AdoProvideRequiredRunProperties_Error_MissingAutomationDetails_Text),
+            nameof(RuleResources.ADO1014_AdoProvideRequiredRunProperties_Error_MissingAutomationDetailsId_Text)
+        };
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 
         protected override string ServiceName => RuleResources.ServiceName_ADO;
@@ -22,8 +31,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public AdoProvideRequiredRunProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.ADO1014_AdoProvideRequiredRunProperties_Error_MissingAutomationDetails_Text));
-            this.MessageResourceNames.Add(nameof(RuleResources.ADO1014_AdoProvideRequiredRunProperties_Error_MissingAutomationDetailsId_Text));
         }
 
         protected override void Analyze(Run run, string runPointer)

--- a/src/Sarif.Multitool.Library/Rules/ADO1015.ProvideRequiredResultProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1015.ProvideRequiredResultProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -15,6 +16,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1015_ProvideRequiredResultProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>()
+        {
+            nameof(RuleResources.ADO1015_ProvideRequiredResultProperties_Error_MissingRuleId_Text)
+        };
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new(new[] { RuleKind.Ado });
 
         protected override string ServiceName => RuleResources.ServiceName_ADO;
@@ -22,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public AdoProvideRequiredResultProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.ADO1015_ProvideRequiredResultProperties_Error_MissingRuleId_Text));
         }
 
         protected override void Analyze(Result result, string resultPointer)

--- a/src/Sarif.Multitool.Library/Rules/ADO1016.ProvideRequiredLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1016.ProvideRequiredLocationProperties.cs
@@ -2,15 +2,23 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
     public class AdoProvideRequiredLocationProperties
-        : SarifValidationSkimmerBase
+        : BaseProvideRequiredLocationProperties
     {
+        /// <summary>
+        /// ADO1016
+        /// </summary>
         public override string Id => RuleId.ADOProvideRequiredLocationProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1016_ProvideRequiredLocationProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 

--- a/src/Sarif.Multitool.Library/Rules/ADO1017.ProvideRequiredPhysicalLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1017.ProvideRequiredPhysicalLocationProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.ADOProvideRequiredPhysicalLocationProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1017_ProvideRequiredPhysicalLocationProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 

--- a/src/Sarif.Multitool.Library/Rules/ADO1018.ProvideRequiredToolProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO1018.ProvideRequiredToolProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.Json.Pointer;
 
@@ -11,11 +12,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         : BaseProvideRequiredToolProperties
     {
         /// <summary>
-        /// ADO1003
+        /// ADO1018
         /// </summary>
         public override string Id => RuleId.ADOProvideToolDriverProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.ADO1018_ProvideRequiredToolProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>()
+        {
+            nameof(RuleResources.ADO1018_ProvideRequiredToolProperties_Error_MissingDriverFullName_Text)
+        };
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 
@@ -24,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public AdoProvideRequiredToolProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.ADO1018_ProvideRequiredToolProperties_Error_MissingDriverFullName_Text));
         }
 
         protected override void Analyze(Run run, string runPointer)

--- a/src/Sarif.Multitool.Library/Rules/ADO2012.ProvideRequiredReportingDescriptorProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/ADO2012.ProvideRequiredReportingDescriptorProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -15,6 +16,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString { Text = RuleResources.ADO2012_ProvideRequiredReportingDescriptorProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>()
+        {
+            nameof(RuleResources.ADO2012_ProvideRequiredResultProperties_Error_MissingName_Text)
+        };
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ado });
 
         protected override string ServiceName => RuleResources.ServiceName_ADO;
@@ -22,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public AdoProvideRequiredReportingDescriptorProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.ADO2012_ProvideRequiredResultProperties_Error_MissingName_Text));
         }
 
         protected override void Analyze(ReportingDescriptor reportingDescriptor, string reportingDescriptorPointer)

--- a/src/Sarif.Multitool.Library/Rules/Base1011.ReferenceFinalSchema.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1011.ReferenceFinalSchema.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override MultiformatMessageString FullDescription => new MultiformatMessageString();
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1011_ReferenceFinalSchema_Error_Default_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         protected override void Analyze(SarifLog log, string logPointer)
         {

--- a/src/Sarif.Multitool.Library/Rules/Base1013.ProvideRequiredSarifLogProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1013.ProvideRequiredSarifLogProperties.cs
@@ -14,13 +14,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString();
 
-        protected override ICollection<string> MessageResourceNames => new List<string> {
+        private readonly List<string> _baseMessageResourceNames = new List<string>
+        {
             nameof(RuleResources.Base1013_MaximumRunsCount_Note_Default_Text),
             nameof(RuleResources.Base1013_ProvideSchemaVersion_Warning_Default_Text),
             nameof(RuleResources.Base1013_ProvideSchema_Warning_Default_Text),
             nameof(RuleResources.Base1013_ReferenceFinalSchema_Error_Default_Text),
             nameof(RuleResources.Base1013_SarifLogRunsArray_Note_Default_Text)
         };
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public virtual int MaximumRuns { get; set; } = int.MaxValue;
 

--- a/src/Sarif.Multitool.Library/Rules/Base1014.ProvideRequiredRunProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1014.ProvideRequiredRunProperties.cs
@@ -10,13 +10,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1014_ProvideRequiredRunProperties_Error_MissingResultsArray_Text),
             nameof(RuleResources.Base1014_ProvideRequiredRunProperties_Error_MissingTool_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/Base1015.ProvideRequiredResultProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1015.ProvideRequiredResultProperties.cs
@@ -12,8 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1015_ProvideRequiredResultProperties_Error_EmptyLocationsArray_Text),
             nameof(RuleResources.Base1015_ProvideRequiredResultProperties_Error_MissingLocationsArray_Text),
@@ -22,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             nameof(RuleResources.Base1015_ProvideRequiredResultProperties_Error_MissingPartialFingerprints_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/Base1016.ProvideRequiredLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1016.ProvideRequiredLocationProperties.cs
@@ -10,12 +10,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1016_ProvideRequiredLocationProperties_Error_MissingPhysicalLocation_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/Base1017.ProvideRequiredPhysicalLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1017.ProvideRequiredPhysicalLocationProperties.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1017_ProvideRequiredPhysicalLocationProperties_Error_MissingArtifactLocation_Text),
             nameof(RuleResources.Base1017_ProvideRequiredPhysicalLocationProperties_Error_MissingRegion_Text),
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             nameof(RuleResources.SARIF1007_RegionPropertiesMustBeConsistent_Error_RegionStartPropertyMustBePresent_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        private ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/Base1018.ProvideRequiredToolProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base1018.ProvideRequiredToolProperties.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base1018_ProvideRequiredToolProperties_Error_MissingDriverName_Text),
             nameof(RuleResources.Base1018_ProvideRequiredToolProperties_Error_MissingDriverRules_Text),
             nameof(RuleResources.Base1018_ProvideRequiredToolProperties_Error_MissingDriver_Text),
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        protected ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/Base2012.ProvideRequiredReportingDescriptorProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/Base2012.ProvideRequiredReportingDescriptorProperties.cs
@@ -10,12 +10,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     {
         public override string Id => string.Empty;
 
-        private readonly List<string> _messageResourceNames = new List<string>
+        private readonly List<string> _baseMessageResourceNames = new List<string>
         {
             nameof(RuleResources.Base2012_ProvideRequiredReportingDescriptorProperties_Error_MissingIdProperty_Text)
         };
 
-        protected override ICollection<string> MessageResourceNames => _messageResourceNames;
+        private ICollection<string> BaseMessageResourceNames => _baseMessageResourceNames;
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>();
 

--- a/src/Sarif.Multitool.Library/Rules/GH1011.ReferenceFinalSchema.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1011.ReferenceFinalSchema.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.GHASReferenceFinalSchema;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1011_ReferenceFinalSchema };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 

--- a/src/Sarif.Multitool.Library/Rules/GH1013.ProvideRequiredSarifLogProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1013.ProvideRequiredSarifLogProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.GHASProvideRequiredSarifLogProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1013_ProvideRequiredSarifLogProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 

--- a/src/Sarif.Multitool.Library/Rules/GH1014.ProvideRequiredRunProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1014.ProvideRequiredRunProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.GHASProvideRequiredRunProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1014_ProvideRequiredRunProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 

--- a/src/Sarif.Multitool.Library/Rules/GH1015.ProvideRequiredResultProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1015.ProvideRequiredResultProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.GHASProvideRequiredResultProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1015_ProvideRequiredResultProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 

--- a/src/Sarif.Multitool.Library/Rules/GH1016.ProvideRequiredLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1016.ProvideRequiredLocationProperties.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class GHASProvideRequiredLocationProperties
-        : SarifValidationSkimmerBase
+    public class GhasProvideRequiredLocationProperties
+        : BaseProvideRequiredLocationProperties
     {
         /// <summary>
         /// GH1016
@@ -15,11 +16,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1016_ProvideRequiredLocationProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         protected override string ServiceName => RuleResources.ServiceName_GHAS;
 
-        public GHASProvideRequiredLocationProperties()
+        public GhasProvideRequiredLocationProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
         }

--- a/src/Sarif.Multitool.Library/Rules/GH1017.ProvideRequiredPhysicalLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1017.ProvideRequiredPhysicalLocationProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.Json.Pointer;
 
@@ -17,6 +18,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1017_ProvideRequiredPhysicalLocationProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         protected override string ServiceName => RuleResources.ServiceName_GHAS;
@@ -24,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public GhasProvideRequiredPhysicalLocationProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.GH1017_ProvideRequiredPhysicalLocationProperties_Error_MissingArtifactLocationUri_Text));
+            this._messageResourceNames.Add(nameof(RuleResources.GH1017_ProvideRequiredPhysicalLocationProperties_Error_MissingArtifactLocationUri_Text));
         }
 
         protected override void Analyze(PhysicalLocation physicalLocation, string physicalLocationPointer)

--- a/src/Sarif.Multitool.Library/Rules/GH1018.ProvideRequiredToolProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1018.ProvideRequiredToolProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
@@ -14,6 +15,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.GHASProvideRequiredToolProperties;
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH1018_ProvideRequiredToolProperties_FullDescription_Text };
+
+        private readonly List<string> _messageResourceNames = new List<string>();
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
 
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 

--- a/src/Sarif.Multitool.Library/Rules/GH2012.ProvideRequiredReportingDescriptorProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH2012.ProvideRequiredReportingDescriptorProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.Json.Pointer;
 
@@ -17,6 +18,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString() { Text = RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_FullDescription_Text };
 
+        private readonly List<string> _messageResourceNames = new List<string>()
+        {
+            nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingFullDescription_Text),
+            nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingHelpText_Text),
+            nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingHelp_Text),
+            nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingShortDescription_Text)
+        };
+
+        protected override ICollection<string> MessageResourceNames => _messageResourceNames.Concat(BaseMessageResourceNames).ToList();
+
         public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         protected override string ServiceName => RuleResources.ServiceName_GHAS;
@@ -24,10 +35,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public GhasProvideRequiredReportingDescriptorProperties()
         {
             this.DefaultConfiguration.Level = FailureLevel.Error;
-            this.MessageResourceNames.Add(nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingFullDescription_Text));
-            this.MessageResourceNames.Add(nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingHelpText_Text));
-            this.MessageResourceNames.Add(nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingHelp_Text));
-            this.MessageResourceNames.Add(nameof(RuleResources.GH2012_ProvideRequiredReportingDescriptorProperties_Error_MissingShortDescription_Text));
         }
 
         protected override void Analyze(ReportingDescriptor reportingDescriptor, string reportingDescriptorPointer)

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.5.1</VersionPrefix>
-    <PreviousVersionPrefix>4.4.0</PreviousVersionPrefix>
+    <VersionPrefix>4.5.2</VersionPrefix>
+    <PreviousVersionPrefix>4.5.1</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>

--- a/src/build.props
+++ b/src/build.props
@@ -10,8 +10,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>4.5.2</VersionPrefix>
-    <PreviousVersionPrefix>4.5.1</PreviousVersionPrefix>
+    <VersionPrefix>4.5.3</VersionPrefix>
+    <PreviousVersionPrefix>4.5.2</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
The previous architecture seemed to be sort of incompatible with the existing skimmer platform in some cases. This change sets up lists of message strings in the rule and base classes, with the Rule.MessageResourceNames property returning a merged list. It also cleans up some overlooked messiness.