### PR TITLE
Fix hangs when file path is provided with wildcard without recurse flag

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,4 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+
+## UNRELEASED
+* BUG: Resolve hangs when file path is provided with wildchar but without `-r` (recurse) flag during multithreaded analysis file enumeration phase.
+
 ## **v4.5.4 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.4)
 * BUG: Fix incorrect base class in rule ADO2012.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## UNRELEASED
-* BUG: Resolve hangs when file path is provided with wildchar but without `-r` (recurse) flag during multithreaded analysis file enumeration phase.
+* BUG: Resolve hangs when a file path is provided with wildcard but without `-r` (recurse) flag during the multithreaded analysis file enumeration phase.
 
 ## **v4.5.4 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.4)
 * BUG: Fix incorrect base class in rule ADO2012.

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -103,10 +103,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
             else
             {
-                WriteFilesInDirectoryToChannel(directory, filesToProcessChannel, filter, new SortedSet<string>(StringComparer.Ordinal));
-
-                filesToProcessChannel.Writer.Complete();
-                directoryEnumerationTask = Task.CompletedTask;
+                directoryEnumerationTask = Task.Run(() =>
+                {
+                    try
+                    {
+                        WriteFilesInDirectoryToChannel(directory, filesToProcessChannel, filter, new SortedSet<string>(StringComparer.Ordinal));
+                    }
+                    finally
+                    {
+                        filesToProcessChannel.Writer.Complete();
+                        directoryEnumerationTask = Task.CompletedTask;
+                    }
+                });
             }
 
             ChannelReader<string> reader = filesToProcessChannel.Reader;


### PR DESCRIPTION
* BUG: Resolve hangs when a file path is provided with wildcard but without `-r` (recurse) flag during the multithreaded analysis file enumeration phase.