### PR TITLE
dep: Bump Azure.Identity from 1.10.2 to 1.11.0

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * BUG: Resolve process hangs when a file path is provided with a wildcard, but without a `-r` (recurse) flag during the multi-threaded analysis file enumeration phase.
+* DEP: Update `Azure.Identity` from `1.10.2` to `1.11.0`.
 
 ## **v4.5.4 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.4)
 * BUG: Fix incorrect base class in rule ADO2012.

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Json.Pointer" Version="2.1.0" />

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />


### PR DESCRIPTION
Supercedes !2804 and !2805 which must be merged simultaneously.

---

Bump Azure.Identity in /src/Sarif.Multitool.Library

Bumps [Azure.Identity](https://github.com/Azure/azure-sdk-for-net) from 1.10.2 to 1.11.0.
- [Release notes](https://github.com/Azure/azure-sdk-for-net/releases)
- [Commits](https://github.com/Azure/azure-sdk-for-net/compare/Azure.Identity_1.10.2...Azure.Identity_1.11.0)

---
updated-dependencies:
- dependency-name: Azure.Identity dependency-type: direct:production ...



Bump Azure.Identity from 1.10.2 to 1.11.0 in /src/WorkItems

Bumps [Azure.Identity](https://github.com/Azure/azure-sdk-for-net) from 1.10.2 to 1.11.0.
- [Release notes](https://github.com/Azure/azure-sdk-for-net/releases)
- [Commits](https://github.com/Azure/azure-sdk-for-net/compare/Azure.Identity_1.10.2...Azure.Identity_1.11.0)

---
updated-dependencies:
- dependency-name: Azure.Identity dependency-type: direct:production ...