### PR TITLE
Update `Azure.Identity` reference from 1.10.2 to 1.11.0 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-29992]

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## UNRELEASED
+* DEP: Update `Azure.Identity` reference from 1.10.2 to 1.11.0 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-29992](https://github.com/advisories/GHSA-wvxc-855f-jvrv).
 * BUG: Resolve process hangs when a file path is provided with a wildcard, but without a `-r` (recurse) flag during the multi-threaded analysis file enumeration phase.
 * BUG: Fix error `ERR997.NoValidAnalysisTargets` when scanning symbolic link files.
 

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Json.Pointer" Version="2.1.0" />

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />


### PR DESCRIPTION
Update `Azure.Identity` reference from 1.10.2 to 1.11.0 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-29992]