### PR TITLE
Remove unused rule from github.config.xml

### DIFF
--- a/policies/github.config.xml
+++ b/policies/github.config.xml
@@ -4,10 +4,6 @@
     <!-- Upgraded from Warning, because GitHub requires this. -->
     <Property Key='RuleEnabled' Value='Error' />
   </Properties>
-  <Properties Key='SARIF2012.ProvideHelpUris.Options'>
-    <!-- Upgraded from Note, because GitHub displays them if available. -->
-    <Property Key='RuleEnabled' Value='Warning' />
-  </Properties>
   <Properties Key='SARIF2016.FileUrisShouldBeRelative.Options'>
     <!-- Not necessary because SARIF2007.ExpressPathsRelativeToRepoRoot is stricter. -->
     <Property Key='RuleEnabled' Value='Disabled' />


### PR DESCRIPTION
The rule is now checking for more than just the HelpUri. Specifically, it requires the name of the rule to use PascalCase. This is confusing because this is not a requirement we have in Code Scanning.

Because Code Scanning do not show the HelpUri in the UI and it is only provided in the API for backwards compatibility, this commit removes the rule altogether.

See https://github.com/github/docs/issues/20872#issuecomment-1534850272