### PR TITLE
Update code to use 'var' where type is explicit.

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -94,7 +94,7 @@ function Invoke-DotNetBuild($solutionFileRelativePath) {
     Write-Information "Building $solutionFileRelativePath..."
 
     $solutionFilePath = Join-Path $SourceRoot $solutionFileRelativePath
-    & dotnet build $solutionFilePath --configuration $Configuration --verbosity $BuildVerbosity --no-incremental -bl -p:WarningsAsErrors="MSB3277"
+    & dotnet build $solutionFilePath --configuration $Configuration --verbosity $BuildVerbosity --no-incremental -bl -p:WarningsAsErrors="MSB3277" /p:EnforceCodeStyleInBuild=true
     
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "Build of $solutionFilePath failed."
@@ -199,13 +199,16 @@ if (-not $NoRestore) {
     }
 }
 
-if (-not $NoObjectModel) {
-    # Generate the SARIF object model classes from the SARIF JSON schema.
-    dotnet msbuild /verbosity:minimal /target:BuildAndInjectObjectModel $SourceRoot\Sarif\Sarif.csproj /fileloggerparameters:Verbosity=detailed`;LogFile=CodeGen.log
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "SARIF object model generation failed."
-    }
-}
+# The SARIF object model is stable. We disable autogenerating it to allow
+# for strict control enforcing style guidelines from command-line builds.
+#if (-not $NoObjectModel) {
+#    # Generate the SARIF object model classes from the SARIF JSON schema.
+#    dotnet msbuild /verbosity:minimal /target:BuildAndInjectObjectModel $SourceRoot\Sarif\Sarif.csproj /fileloggerparameters:Verbosity=detailed`;LogFile=CodeGen.log
+#    if ($LASTEXITCODE -ne 0) {
+#        Exit-WithFailureMessage $ScriptName "SARIF object model generation failed."
+#    }
+#}
+
 
 if (-not $?) {
     Exit-WithFailureMessage $ScriptName "BeforeBuild failed."

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -297,6 +297,7 @@ csharp_style_prefer_local_over_anonymous_function = true:suggestion
 dotnet_diagnostic.SA1602.severity = suggestion
 dotnet_diagnostic.SA1307.severity = silent
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_primary_constructors = true:suggestion
 
 [*Tests.cs]
 
@@ -324,3 +325,4 @@ dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_code_quality_unused_parameters = all:error
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion

--- a/src/Sarif.Converters/AndroidStudioConverter.cs
+++ b/src/Sarif.Converters/AndroidStudioConverter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             LogicalLocations.Clear();
 
-            XmlReaderSettings settings = new XmlReaderSettings
+            var settings = new XmlReaderSettings
             {
                 IgnoreWhitespace = true,
                 IgnoreComments = true,
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             IList<Result> results;
-            using (XmlReader xmlReader = XmlReader.Create(input, settings))
+            using (var xmlReader = XmlReader.Create(input, settings))
             {
                 results = ProcessAndroidStudioLog(xmlReader);
             }
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static string GenerateFullMessage(string description, ImmutableArray<string> hints)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             sb.Append(description);
             foreach (string hint in hints)
             {

--- a/src/Sarif.Converters/AndroidStudioProblem.cs
+++ b/src/Sarif.Converters/AndroidStudioProblem.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 throw reader.CreateException(ConverterResources.AndroidStudioNotProblemElement);
             }
 
-            Builder b = new Builder();
+            var b = new Builder();
             if (!reader.IsEmptyElement)
             {
                 int problemDepth = reader.Depth;

--- a/src/Sarif.Converters/ClangAnalyzerConverter.cs
+++ b/src/Sarif.Converters/ClangAnalyzerConverter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             try
             {
-                XmlReaderSettings settings = new XmlReaderSettings
+                var settings = new XmlReaderSettings
                 {
                     IgnoreWhitespace = true,
                     DtdProcessing = DtdProcessing.Ignore,
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 var results = new List<Result>();
 
-                using (XmlReader xmlReader = XmlReader.Create(input, settings))
+                using (var xmlReader = XmlReader.Create(input, settings))
                 {
                     xmlReader.MoveToContent();
                     xmlReader.ReadStartElement(ClangSchemaStrings.PlistName);
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static IList<object> ReadArray(XmlReader xmlReader)
         {
-            List<object> list = new List<object>();
+            var list = new List<object>();
             bool readerMoved = false; // ReadElementContentAsString moves the reader so prevent double moves.
 
             xmlReader.Read(); // Read past the "array" element start.

--- a/src/Sarif.Converters/ClangTidyConverter.cs
+++ b/src/Sarif.Converters/ClangTidyConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             using var textReader = new StreamReader(input);
             ClangTidyReport report = deserializer.Deserialize<ClangTidyReport>(textReader);
 
-            List<ClangTidyConsoleDiagnostic> logs = new List<ClangTidyConsoleDiagnostic>();
+            var logs = new List<ClangTidyConsoleDiagnostic>();
             if (report != null)
             {
                 string reportPath = (input as FileStream)?.Name;
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private List<ClangTidyConsoleDiagnostic> LoadLogFile(string logFilePath)
         {
-            List<ClangTidyConsoleDiagnostic> returnValue = new List<ClangTidyConsoleDiagnostic>();
+            var returnValue = new List<ClangTidyConsoleDiagnostic>();
 
             var logLines = File.ReadAllLines(logFilePath).ToList();
             foreach (string line in logLines)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     int columnNumber;
                     if (int.TryParse(match.Groups[2].Value, out lineNumber) && int.TryParse(match.Groups[3].Value, out columnNumber))
                     {
-                        ClangTidyConsoleDiagnostic consoleDiagnostic = new ClangTidyConsoleDiagnostic()
+                        var consoleDiagnostic = new ClangTidyConsoleDiagnostic()
                         {
                             LineNumber = lineNumber,
                             ColumnNumber = columnNumber
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             entry = entry ?? throw new ArgumentNullException(nameof(entry));
 
-            Result result = new Result()
+            var result = new Result()
             {
                 RuleId = entry.DiagnosticName,
                 Message = new Message { Text = entry.DiagnosticMessage.Message },
@@ -118,14 +118,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // no level infomation in Clang-Tidy report
             result.Level = FailureLevel.Warning;
 
-            Region region = new Region()
+            var region = new Region()
             {
                 CharOffset = entry.DiagnosticMessage.FileOffset,
                 StartLine = entry.DiagnosticMessage.LineNumber,
                 StartColumn = entry.DiagnosticMessage.ColumnNumber,
             };
 
-            Uri analysisTargetUri = new Uri(entry.DiagnosticMessage.FilePath, UriKind.RelativeOrAbsolute);
+            var analysisTargetUri = new Uri(entry.DiagnosticMessage.FilePath, UriKind.RelativeOrAbsolute);
 
             var physicalLocation = new PhysicalLocation
             {
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Region = region
             };
 
-            Location location = new Location()
+            var location = new Location()
             {
                 PhysicalLocation = physicalLocation
             };
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 foreach (ClangTidyReplacement fix in entry.DiagnosticMessage.Replacements)
                 {
-                    Replacement replacement = new Replacement();
+                    var replacement = new Replacement();
 
                     replacement.DeletedRegion = new Region
                     {
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     Replacements = replacements
                 };
 
-                Fix sarifFix = new Fix(description: null, artifactChanges: new List<ArtifactChange>() { sarifFileChange }, properties: null);
+                var sarifFix = new Fix(description: null, artifactChanges: new List<ArtifactChange>() { sarifFileChange }, properties: null);
                 result.Fixes = new List<Fix> { sarifFix };
             }
 

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 if (KeyIsReservedPropertyName(key)) { continue; }
 
                 string jsonValue = properties[key];
-                JObject root = JObject.Parse(jsonValue);
+                var root = JObject.Parse(jsonValue);
                 string snippet = root["html"].Value<string>();
 
                 int snippetLength = snippet.Length;
@@ -1429,7 +1429,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadFinding(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             string ruleId = reader.ReadAttributeString(SchemaStrings.AttributeRuleId);
 
@@ -1443,7 +1443,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadRequest(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.ClearRequest();
 
             string protocol = reader.ReadAttributeString(SchemaStrings.AttributeProtocol);
@@ -1458,13 +1458,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadBody(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.RequestBody = reader.ReadElementContentAsString();
         }
 
         private static void ReadHeaders(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.ClearHeaders();
 
             reader.ReadChildren(SchemaStrings.ElementHeaders, parent);
@@ -1475,7 +1475,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string name = reader.ReadAttributeString(SchemaStrings.AttributeName);
             string value = reader.ReadAttributeString(SchemaStrings.AttributeValue);
 
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.AddHeader(name, value);
 
             reader.ReadChildren(SchemaStrings.ElementH, parent);
@@ -1483,7 +1483,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadParameters(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.ClearParameters();
 
             reader.ReadChildren(SchemaStrings.ElementParameters, parent);
@@ -1491,7 +1491,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadEvents(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.Signature = null;
             context.MethodEvent = null;
             context.PropagationEvents = null;
@@ -1505,7 +1505,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             reader.ReadChildren(SchemaStrings.ElementPropagationEvent, parent);
 
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.PropagationEvents = context.PropagationEvents ?? new List<ThreadFlowLocation>();
             context.PropagationEvents.Add(context.CurrentThreadFlowLocation);
             context.CurrentThreadFlowLocation = null;
@@ -1514,7 +1514,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadSignature(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             string signature = reader.ReadElementContentAsString();
             context.Signature = CreateStackFrameFromSignature(signature);
         }
@@ -1566,7 +1566,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadProperties(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             if (!_readingProps)
             {
@@ -1608,7 +1608,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 string value = reader.ReadAttributeString(SchemaStrings.AttributeValue);
 
-                Context context = (Context)parent;
+                var context = (Context)parent;
                 context.AddParameter(name, value);
             }
 
@@ -1622,7 +1622,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadStack(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             Debug.Assert(context.CurrentThreadFlowLocation == null);
             context.CurrentThreadFlowLocation = new ThreadFlowLocation
             {
@@ -1644,14 +1644,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadEvidence(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             string evidence = reader.ReadElementContentAsString();
             context.RefineEvidence(evidence);
         }
 
         private static void ReadSource(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             string type = reader.ReadAttributeString(SchemaStrings.AttributeType);
             string name = reader.ReadAttributeString(SchemaStrings.AttributeName);
             context.Sources = context.Sources ?? new HashSet<Tuple<string, string>>();
@@ -1661,7 +1661,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadFrame(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             string frame = reader.ReadElementContentAsString();
             context.CurrentThreadFlowLocation.Stack.Frames.Add(CreateStackFrameFromSignature(frame));
         }
@@ -1670,7 +1670,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             reader.ReadChildren(SchemaStrings.ElementMethodEvent, parent);
 
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.MethodEvent = context.CurrentThreadFlowLocation;
             context.CurrentThreadFlowLocation = null;
             context.Signature = null;

--- a/src/Sarif.Converters/CppCheckConverter.cs
+++ b/src/Sarif.Converters/CppCheckConverter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 throw new ArgumentNullException(nameof(output));
             }
 
-            XmlReaderSettings settings = new XmlReaderSettings
+            var settings = new XmlReaderSettings
             {
                 IgnoreWhitespace = true,
                 DtdProcessing = DtdProcessing.Ignore,
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 XmlResolver = null
             };
 
-            using (XmlReader xmlReader = XmlReader.Create(input, settings))
+            using (var xmlReader = XmlReader.Create(input, settings))
             {
                 ProcessCppCheckLog(xmlReader, output, dataToInsert);
             }

--- a/src/Sarif.Converters/FortifyConverter.cs
+++ b/src/Sarif.Converters/FortifyConverter.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string runDescription = null;
             var results = new List<Result>();
 
-            using (XmlReader reader = XmlReader.Create(input, settings))
+            using (var reader = XmlReader.Create(input, settings))
             {
                 while (reader.Read())
                 {
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         while (StringReference.AreEqual(reader.LocalName, _strings.Issue))
                         {
-                            FortifyIssue fortify = FortifyIssue.Parse(reader, _strings);
+                            var fortify = FortifyIssue.Parse(reader, _strings);
                             results.Add(ConvertFortifyIssueToSarifIssue(fortify));
                         }
                     }
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 SarifUtilities.AddOrUpdateDictionaryEntry(result.PartialFingerprints, "InstanceId", fortify.InstanceId);
             }
 
-            List<string> messageComponents = new List<string>();
+            var messageComponents = new List<string>();
             if (fortify.Abstract != null)
             {
                 messageComponents.Add(fortify.Abstract);

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private XmlReader OpenAuditFvdlReader(Stream fprFileStream)
         {
-            ZipArchive fprArchive = new ZipArchive(fprFileStream);
+            var fprArchive = new ZipArchive(fprFileStream);
             ZipArchiveEntry auditEntry = fprArchive.Entries.Single(e => e.FullName.Equals("audit.fvdl"));
 
             var settings = new XmlReaderSettings
@@ -459,7 +459,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             if (!string.IsNullOrEmpty(fileName))
             {
-                Uri uri = new Uri(fileName, UriKind.RelativeOrAbsolute);
+                var uri = new Uri(fileName, UriKind.RelativeOrAbsolute);
                 var fileData = new Artifact
                 {
                     Encoding = encoding,
@@ -851,7 +851,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             string path = _reader.GetAttribute(_strings.PathAttribute);
 
-            PhysicalLocation location = new PhysicalLocation
+            var location = new PhysicalLocation
             {
                 Region = ParseRegion()
             };
@@ -1057,7 +1057,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     string nodeLabel = _reader.ReadElementContentAsString();
 
                     // Convert to SARIF types.
-                    Node node = new Node(
+                    var node = new Node(
                         new ThreadFlowLocation
                         {
                             Kinds = ConvertActionTypeToLocationKinds(actionType),
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     };
                 }
 
-                using (StringReader reader = new StringReader(text))
+                using (var reader = new StringReader(text))
                 {
                     // Read down to the first line we want to include.
                     for (int i = 0; i < regionStartLine - snippetStartLine; i++)
@@ -1270,7 +1270,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 bool isGuid = Guid.TryParse(NormalizeGuid(ruleGuid), out Guid parsedGuid);
 
-                ReportingDescriptor rule = new ReportingDescriptor
+                var rule = new ReportingDescriptor
                 {
                     Id = ruleGuid,
                     Guid = isGuid ? parsedGuid : (Guid?)null
@@ -1317,7 +1317,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private void AddMessagesToResult(Result result)
         {
             ReportingDescriptor rule = _rules[result.RuleIndex];
-            Message message = new Message();
+            var message = new Message();
 
             string messageText = (rule.ShortDescription ?? rule.FullDescription)?.Text;
 

--- a/src/Sarif.Converters/FortifyIssue.cs
+++ b/src/Sarif.Converters/FortifyIssue.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string friority = xmlReader.ReadOptionalElementContentAsString(strings.Friority);
             xmlReader.IgnoreElement(strings.Tag, IgnoreOptions.Optional | IgnoreOptions.Multiple);
             xmlReader.IgnoreElement(strings.Comment, IgnoreOptions.Optional | IgnoreOptions.Multiple);
-            FortifyPathElement primary = FortifyPathElement.Parse(xmlReader, strings);
+            var primary = FortifyPathElement.Parse(xmlReader, strings);
             FortifyPathElement source;
             if (xmlReader.NodeType == XmlNodeType.Element && StringReference.AreEqual(xmlReader.LocalName, strings.Source))
             {

--- a/src/Sarif.Converters/FxCopConverter.cs
+++ b/src/Sarif.Converters/FxCopConverter.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         internal Result CreateResult(FxCopLogReader.Context context)
         {
-            Result result = new Result();
+            var result = new Result();
 
             string uniqueId = context.GetUniqueId();
 
@@ -726,7 +726,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         public void Read(Context context, Stream input)
         {
-            XmlSchemaSet schemaSet = new XmlSchemaSet();
+            var schemaSet = new XmlSchemaSet();
             Assembly assembly = typeof(FxCopLogReader).Assembly;
             var settings = new XmlReaderSettings
             {
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             using (Stream stream = assembly.GetManifestResourceStream(FxCopLogReader.FxCopReportSchema))
             using (var reader = XmlReader.Create(stream, settings))
             {
-                XmlSchema schema = XmlSchema.Read(reader, new ValidationEventHandler(ReportError));
+                var schema = XmlSchema.Read(reader, new ValidationEventHandler(ReportError));
                 schemaSet.Add(schema);
             }
 
@@ -779,7 +779,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadFxCopReport(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineReport(reader.ReadAttributeString(SchemaStrings.AttributeVersion));
             reader.ReadChildren(SchemaStrings.ElementFxCopReport, parent);
@@ -793,7 +793,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadException(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             string ruleId = reader.ReadAttributeString(SchemaStrings.AttributeKeyword);
             string kind = reader.ReadAttributeString(SchemaStrings.AttributeKind);
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadExceptionType(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             if (context.Exception)
             {
@@ -828,35 +828,35 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadExceptionMessage(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineExceptionMessage(reader.ReadElementContentAsString());
         }
 
         private static void ReadStackTrace(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineStackTrace(reader.ReadElementContentAsString());
         }
 
         private void ReadInnerExceptionType(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineInnerExceptionType(reader.ReadElementContentAsString());
         }
 
         private static void ReadInnerExceptionMessage(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineInnerExceptionMessage(reader.ReadElementContentAsString());
         }
 
         private static void ReadInnerStackTrace(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineInnerStackTrace(reader.ReadElementContentAsString());
         }
@@ -868,7 +868,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadResource(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineResource(reader.ReadAttributeString(SchemaStrings.AttributeName));
             reader.ReadChildren(SchemaStrings.ElementResource, parent);
@@ -882,7 +882,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadRule(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineRule(
                 typeName: reader.ReadAttributeString(SchemaStrings.AttributeTypeName),
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadResolution(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineResolution(
                 name: reader.ReadAttributeString(SchemaStrings.AttributeName),
@@ -915,7 +915,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadTarget(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineTarget(reader.ReadAttributeString(SchemaStrings.AttributeName));
             reader.ReadChildren(SchemaStrings.ElementTarget, parent);
@@ -929,7 +929,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadModule(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineModule(reader.ReadAttributeString(SchemaStrings.AttributeName));
             reader.ReadChildren(SchemaStrings.ElementModule, parent);
@@ -943,7 +943,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadNamespace(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineNamespace(reader.ReadAttributeString(SchemaStrings.AttributeName));
             reader.ReadChildren(SchemaStrings.ElementNamespace, parent);
@@ -957,7 +957,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadType(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             if (context.Exception)
             {
@@ -978,7 +978,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadMember(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             context.RefineMember(reader.ReadAttributeString(SchemaStrings.AttributeName));
             reader.ReadChildren(SchemaStrings.ElementMember, parent);
@@ -992,7 +992,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadMessage(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             string messageId = reader.ReadAttributeString(SchemaStrings.AttributeId);
             string typename = reader.ReadAttributeString(SchemaStrings.AttributeTypeName);
@@ -1022,7 +1022,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadIssue(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
 
             string resolutionName = reader.ReadAttributeString(SchemaStrings.AttributeName);
             string certainty = reader.ReadAttributeString(SchemaStrings.AttributeCertainty);
@@ -1059,7 +1059,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ReadItem(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
+            var context = (Context)parent;
             context.Items = context.Items ?? new List<string>();
             context.Items.Add(reader.ReadElementContentAsString());
         }

--- a/src/Sarif.Converters/PREFastConverter.cs
+++ b/src/Sarif.Converters/PREFastConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             LogicalLocations.Clear();
 
-            XmlReaderSettings settings = new XmlReaderSettings
+            var settings = new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Ignore,
                 XmlResolver = null

--- a/src/Sarif.Converters/PylintConverter.cs
+++ b/src/Sarif.Converters/PylintConverter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             defect = defect ?? throw new ArgumentNullException(nameof(defect));
 
-            Result result = new Result
+            var result = new Result
             {
                 RuleId = $"{defect.MessageId}({defect.Symbol})",
                 Message = new Message { Text = defect.Message },

--- a/src/Sarif.Converters/SemmleQlConverter.cs
+++ b/src/Sarif.Converters/SemmleQlConverter.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </returns>
         private Region MakeRegion(List<string> fields)
         {
-            Region region = new Region
+            var region = new Region
             {
                 StartLine = GetInteger(fields, FieldIndex.StartLine),
                 StartColumn = GetInteger(fields, FieldIndex.StartColumn),

--- a/src/Sarif.Converters/SparseReader.cs
+++ b/src/Sarif.Converters/SparseReader.cs
@@ -110,7 +110,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ReadStartElement();
 
             if (isEmpty)
+            {
                 return; // DONE with this element
+            }
 
             while (!IsEndState(tagName))
             {

--- a/src/Sarif.Converters/TSLintConverter.cs
+++ b/src/Sarif.Converters/TSLintConverter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             entry = entry ?? throw new ArgumentNullException(nameof(entry));
 
-            Result result = new Result()
+            var result = new Result()
             {
                 RuleId = entry.RuleName,
                 Message = new Message { Text = entry.Failure },
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     break;
             }
 
-            Region region = new Region()
+            var region = new Region()
             {
                 // The TSLint logs have line and column start at 0, Sarif has them starting at 1, so add 1 to each
                 StartLine = entry.StartPosition.Line + 1,
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             int length = entry.EndPosition.Position - entry.StartPosition.Position;
             region.CharLength = length > 0 ? length : 0;
 
-            Uri analysisTargetUri = new Uri(entry.Name, UriKind.Relative);
+            var analysisTargetUri = new Uri(entry.Name, UriKind.Relative);
 
             var physicalLocation = new PhysicalLocation
             {
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Region = region
             };
 
-            Location location = new Location()
+            var location = new Location()
             {
                 PhysicalLocation = physicalLocation
             };
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 foreach (TSLintLogFix fix in entry.Fixes)
                 {
-                    Replacement replacement = new Replacement();
+                    var replacement = new Replacement();
 
                     replacement.DeletedRegion = new Region
                     {
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     Replacements = replacements
                 };
 
-                Fix sarifFix = new Fix(description: null, artifactChanges: new List<ArtifactChange>() { sarifFileChange }, properties: null);
+                var sarifFix = new Fix(description: null, artifactChanges: new List<ArtifactChange>() { sarifFileChange }, properties: null);
                 result.Fixes = new List<Fix> { sarifFix };
             }
 

--- a/src/Sarif.Converters/TSLintLogReader.cs
+++ b/src/Sarif.Converters/TSLintLogReader.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             using (TextReader streamReader = new StreamReader(input))
             using (JsonReader reader = new JsonTextReader(streamReader))
             {
-                JToken rootToken = JToken.ReadFrom(reader);
+                var rootToken = JToken.ReadFrom(reader);
                 rootToken = NormalizeLog(rootToken);
                 string normalizedLogContents = rootToken.ToString();
                 using (Stream normalizedLogStream = new MemoryStream(Encoding.UTF8.GetBytes(normalizedLogContents)))

--- a/src/Sarif.Driver/EnumerableExtensions.cs
+++ b/src/Sarif.Driver/EnumerableExtensions.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             // A naïve Knuth Fischer Yates shuffle.
             T swapTemp;
-            List<T> values = sequence.ToList();
+            var values = sequence.ToList();
             int currentlySelecting = values.Count;
             while (currentlySelecting > 1)
             {

--- a/src/Sarif.Driver/Sdk/CommandBase.cs
+++ b/src/Sarif.Driver/Sdk/CommandBase.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var serializer = new JsonSerializer() { ContractResolver = contractResolver };
 
-            using (JsonTextReader reader = new JsonTextReader(new StreamReader(fileSystem.FileOpenRead(filePath))))
+            using (var reader = new JsonTextReader(new StreamReader(fileSystem.FileOpenRead(filePath))))
             {
                 return serializer.Deserialize<T>(reader);
             }
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public static HashSet<string> CreateTargetsSet(IEnumerable<string> targetSpecifiers, bool recurse, IFileSystem fileSystem)
         {
-            HashSet<string> targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string specifier in targetSpecifiers)
             {
                 string normalizedSpecifier = specifier;

--- a/src/Sarif.Driver/Sdk/EntryPointUtilities.cs
+++ b/src/Sarif.Driver/Sdk/EntryPointUtilities.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             IFileSystem fileSystem,
             IEnvironmentVariables environmentVariables)
         {
-            List<string> expandedArguments = new List<string>();
+            var expandedArguments = new List<string>();
 
             foreach (string argument in args)
             {

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             const string TAB = "   ";
             var sb = new StringBuilder();
 
-            SortedDictionary<int, ReportingDescriptor> sortedRuleContexts = new SortedDictionary<int, ReportingDescriptor>();
+            var sortedRuleContexts = new SortedDictionary<int, ReportingDescriptor>();
 
             foreach (ReportingDescriptor rule in skimmers)
             {
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             log.Runs.Add(run);
 
-            SortedDictionary<int, ReportingDescriptor> sortedRules = new SortedDictionary<int, ReportingDescriptor>();
+            var sortedRules = new SortedDictionary<int, ReportingDescriptor>();
 
             foreach (ReportingDescriptor rule in skimmers)
             {

--- a/src/Sarif.Driver/SemanticVersion.cs
+++ b/src/Sarif.Driver/SemanticVersion.cs
@@ -293,9 +293,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         internal static SemanticVersion MakeLegalVersion(string version)
         {
             // split off first NonNumeric or dot character
-            Regex regex = new Regex(@"[^0-9\\.]");
+            var regex = new Regex(@"[^0-9\\.]");
             Match match = regex.Match(version);
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             string tempVersion = string.Empty;
             string versionPart2 = string.Empty;
 

--- a/src/Sarif.Driver/StringExtensions.cs
+++ b/src/Sarif.Driver/StringExtensions.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver
 {
-    /// <summary>Extensions on the <see cref="System.String"/> class.</summary>
+    /// <summary>Extensions on the <see cref="string"/> class.</summary>
     public static class StringExtensions
     {
         /// <summary>Gets a null value for null or whitespace strings. Otherwise passes though the source string unchanged.</summary>

--- a/src/Sarif.Multitool.Library/ApplyPolicyCommand.cs
+++ b/src/Sarif.Multitool.Library/ApplyPolicyCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             try
             {
                 Console.WriteLine($"Applying policy '{options.InputFilePath}' => '{options.OutputFilePath}'...");
-                Stopwatch w = Stopwatch.StartNew();
+                var w = Stopwatch.StartNew();
 
                 bool valid = ValidateOptions(options);
                 if (!valid) { return FAILURE; }

--- a/src/Sarif.Multitool.Library/ConvertCommand.cs
+++ b/src/Sarif.Multitool.Library/ConvertCommand.cs
@@ -57,12 +57,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 {
                     SarifLog sarifLog;
 
-                    JsonSerializer serializer = new JsonSerializer()
+                    var serializer = new JsonSerializer()
                     {
                         Formatting = convertOptions.PrettyPrint ? Formatting.Indented : 0,
                     };
 
-                    using (JsonTextReader reader = new JsonTextReader(new StreamReader(convertOptions.OutputFilePath)))
+                    using (var reader = new JsonTextReader(new StreamReader(convertOptions.OutputFilePath)))
                     {
                         sarifLog = serializer.Deserialize<SarifLog>(reader);
                     }
@@ -71,8 +71,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     visitor.VisitSarifLog(sarifLog);
 
                     using (FileStream stream = File.Create(convertOptions.OutputFilePath))
-                    using (StreamWriter streamWriter = new StreamWriter(stream))
-                    using (JsonTextWriter writer = new JsonTextWriter(streamWriter))
+                    using (var streamWriter = new StreamWriter(stream))
+                    using (var writer = new JsonTextWriter(streamWriter))
                     {
                         serializer.Serialize(writer, sarifLog);
                     }

--- a/src/Sarif.Multitool.Library/MergeCommand.cs
+++ b/src/Sarif.Multitool.Library/MergeCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         public int Run(MergeOptions mergeOptions)
         {
-            Stopwatch w = Stopwatch.StartNew();
+            var w = Stopwatch.StartNew();
             try
             {
                 _options = mergeOptions;

--- a/src/Sarif.Multitool.Library/PageCommand.cs
+++ b/src/Sarif.Multitool.Library/PageCommand.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         private JsonMapNode LoadOrRebuildMap(PageOptions options)
         {
             JsonMapNode root;
-            Stopwatch w = Stopwatch.StartNew();
+            var w = Stopwatch.StartNew();
 
             string mapPath = Path.ChangeExtension(options.InputFilePath, ".map.json");
 
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private void ExtractPage(PageOptions options, JsonMapNode root)
         {
-            Stopwatch w = Stopwatch.StartNew();
+            var w = Stopwatch.StartNew();
             Console.WriteLine($"Extracting {options.Count:n0} results from index {options.Index:n0}\r\n  from \"{options.InputFilePath}\"\r\n  into \"{options.OutputFilePath}\"...");
 
             JsonMapNode runs, run, results;

--- a/src/Sarif.Multitool.Library/QueryCommand.cs
+++ b/src/Sarif.Multitool.Library/QueryCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             bool valid = DriverUtilities.ReportWhetherOutputFileCanBeCreated(options.OutputFilePath, options.Force, _fileSystem);
             if (!valid) { return FAILURE; }
 
-            Stopwatch w = Stopwatch.StartNew();
+            var w = Stopwatch.StartNew();
             int originalTotal = 0;
             int matchCount = 0;
 
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 originalTotal += run.Results.Count;
 
                 // Find matches for Results in the Run
-                BitArray matches = new BitArray(run.Results.Count);
+                var matches = new BitArray(run.Results.Count);
                 evaluator.Evaluate(run.Results, matches);
 
                 // Count the new matches

--- a/src/Sarif.Multitool.Library/RewriteCommand.cs
+++ b/src/Sarif.Multitool.Library/RewriteCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             try
             {
                 Console.WriteLine($"Rewriting '{options.InputFilePath}' => '{options.OutputFilePath}'...");
-                Stopwatch w = Stopwatch.StartNew();
+                var w = Stopwatch.StartNew();
 
                 bool valid = ValidateOptions(options);
                 if (!valid)
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         //  #2271 https://github.com/microsoft/sarif-sdk/issues/2271
         private string SniffVersion(string sarifPath)
         {
-            using (JsonTextReader reader = new JsonTextReader(new StreamReader(_fileSystem.FileOpenRead(sarifPath))))
+            using (var reader = new JsonTextReader(new StreamReader(_fileSystem.FileOpenRead(sarifPath))))
             {
                 while (reader.Read())
                 {

--- a/src/Sarif.Multitool.Library/Rules/SARIF1005.UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF1005.UriMustBeAbsolute.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             {
                 // Ok, it's a well-formed URI of some kind. If it's not absolute, _now_ we
                 // can report it.
-                Uri uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+                var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri)
                 {
                     // {0}: The value of this property is required to be an absolute URI, but '{1}' is a relative URI reference.

--- a/src/Sarif.Multitool.Library/Rules/SARIF2004.OptimizeFileSize.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF2004.OptimizeFileSize.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         private bool HasResultLocationsWithUriAndIndex(string resultPointer)
         {
-            JToken resultToken = resultPointer.ToJToken(Context.InputLogToken);
+            var resultToken = resultPointer.ToJToken(Context.InputLogToken);
             return
                 resultToken.HasProperty(SarifPropertyName.Uri) &&
                 resultToken.HasProperty(SarifPropertyName.Index);
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         private bool HasLocationOnlyArtifacts(string artifactPointer)
         {
-            JToken artifactToken = artifactPointer.ToJToken(Context.InputLogToken);
+            var artifactToken = artifactPointer.ToJToken(Context.InputLogToken);
             return
                 artifactToken.HasProperty(SarifPropertyName.Location) &&
                 artifactToken.Children().Count() == 1;
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         private bool HasIdOnlyRules(string rulePointer)
         {
-            JToken ruleToken = rulePointer.ToJToken(Context.InputLogToken);
+            var ruleToken = rulePointer.ToJToken(Context.InputLogToken);
             return
                 ruleToken.HasProperty(SarifPropertyName.Id) &&
                 ruleToken.Children().Count() == 1;

--- a/src/Sarif.Multitool.Library/Rules/SARIF2004.OptimizeFileSize.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF2004.OptimizeFileSize.cs
@@ -7,8 +7,6 @@ using System.Linq;
 
 using Microsoft.Json.Pointer;
 
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
     public class OptimizeFileSize : SarifValidationSkimmerBase

--- a/src/Sarif.Multitool.Library/Rules/SARIF2006.UrisShouldBeReachable.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF2006.UrisShouldBeReachable.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             if (uriString != null && IsWellFormedUriString(uriString, UriKind.Absolute))
             {
                 // Ok, it's a well-formed absolute URI. If it's not reachable, _now_ we can report it.
-                Uri uri = new Uri(uriString, UriKind.Absolute);
+                var uri = new Uri(uriString, UriKind.Absolute);
                 if (uri.AbsoluteUri != "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json" &&
                     // TODO: Shaopeng to remove after finalized and published.
                     !IsUriReachable(uri.AbsoluteUri))

--- a/src/Sarif.Multitool/AnalyzeTestCommand.cs
+++ b/src/Sarif.Multitool/AnalyzeTestCommand.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/src/Sarif.Multitool/AnalyzeTestContext.cs
+++ b/src/Sarif.Multitool/AnalyzeTestContext.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
 #pragma warning disable CS0618

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         /// <returns>0 on success; nonzero on failure.</returns>
         public static int Main(string[] args)
         {
-            OptionsInterpretter optionsInterpretter = new OptionsInterpretter();
+            var optionsInterpretter = new OptionsInterpretter();
 
             return Parser.Default.ParseArguments<
                 // Keep this in alphabetical order

--- a/src/Sarif/ArtifactProvider.cs
+++ b/src/Sarif/ArtifactProvider.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Autogenerated/Address.cs
+++ b/src/Sarif/Autogenerated/Address.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/AddressComparer.cs
+++ b/src/Sarif/Autogenerated/AddressComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/AddressEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AddressEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Artifact.cs
+++ b/src/Sarif/Autogenerated/Artifact.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/Artifact.cs
+++ b/src/Sarif/Autogenerated/Artifact.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft.  All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ArtifactChange.cs
+++ b/src/Sarif/Autogenerated/ArtifactChange.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ArtifactChangeComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactChangeComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactChangeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactChangeEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactContent.cs
+++ b/src/Sarif/Autogenerated/ArtifactContent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ArtifactContentComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactContentComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactContentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactContentEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactLocation.cs
+++ b/src/Sarif/Autogenerated/ArtifactLocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ArtifactLocationComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactLocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ArtifactLocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ArtifactRoles.cs
+++ b/src/Sarif/Autogenerated/ArtifactRoles.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/Attachment.cs
+++ b/src/Sarif/Autogenerated/Attachment.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/AttachmentComparer.cs
+++ b/src/Sarif/Autogenerated/AttachmentComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/AttachmentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AttachmentEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/BaselineState.cs
+++ b/src/Sarif/Autogenerated/BaselineState.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/CodeFlow.cs
+++ b/src/Sarif/Autogenerated/CodeFlow.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (threadFlows != null)
             {
                 var destination_0 = new List<ThreadFlow>();
-                foreach (var value_0 in threadFlows)
+                foreach (ThreadFlow value_0 in threadFlows)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/CodeFlowComparer.cs
+++ b/src/Sarif/Autogenerated/CodeFlowComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ColumnKind.cs
+++ b/src/Sarif/Autogenerated/ColumnKind.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ComparerExtensions.cs
+++ b/src/Sarif/Autogenerated/ComparerExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ConfigurationOverride.cs
+++ b/src/Sarif/Autogenerated/ConfigurationOverride.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ConfigurationOverrideComparer.cs
+++ b/src/Sarif/Autogenerated/ConfigurationOverrideComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ConfigurationOverrideEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ConfigurationOverrideEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Conversion.cs
+++ b/src/Sarif/Autogenerated/Conversion.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ConversionComparer.cs
+++ b/src/Sarif/Autogenerated/ConversionComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ConversionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ConversionEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Edge.cs
+++ b/src/Sarif/Autogenerated/Edge.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/EdgeComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/EdgeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/EdgeTraversal.cs
+++ b/src/Sarif/Autogenerated/EdgeTraversal.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/EdgeTraversalComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeTraversalComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/EdgeTraversalEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/EdgeTraversalEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExceptionData.cs
+++ b/src/Sarif/Autogenerated/ExceptionData.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -144,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (innerExceptions != null)
             {
                 var destination_0 = new List<ExceptionData>();
-                foreach (var value_0 in innerExceptions)
+                foreach (ExceptionData value_0 in innerExceptions)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/ExceptionDataComparer.cs
+++ b/src/Sarif/Autogenerated/ExceptionDataComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalProperties.cs
+++ b/src/Sarif/Autogenerated/ExternalProperties.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ExternalPropertiesComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertiesComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalPropertiesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertiesEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReference.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReference.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferenceComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferenceComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferenceEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferences.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferences.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferencesComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferencesComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferencesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferencesEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/FailureLevel.cs
+++ b/src/Sarif/Autogenerated/FailureLevel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Fix.cs
+++ b/src/Sarif/Autogenerated/Fix.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/FixComparer.cs
+++ b/src/Sarif/Autogenerated/FixComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/FixEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FixEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Graph.cs
+++ b/src/Sarif/Autogenerated/Graph.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/GraphComparer.cs
+++ b/src/Sarif/Autogenerated/GraphComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/GraphEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/GraphEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/GraphTraversal.cs
+++ b/src/Sarif/Autogenerated/GraphTraversal.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/GraphTraversalComparer.cs
+++ b/src/Sarif/Autogenerated/GraphTraversalComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/GraphTraversalEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/GraphTraversalEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ISarifNode.cs
+++ b/src/Sarif/Autogenerated/ISarifNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Invocation.cs
+++ b/src/Sarif/Autogenerated/Invocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (arguments != null)
             {
                 var destination_0 = new List<string>();
-                foreach (var value_0 in arguments)
+                foreach (string value_0 in arguments)
                 {
                     destination_0.Add(value_0);
                 }
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (responseFiles != null)
             {
                 var destination_1 = new List<ArtifactLocation>();
-                foreach (var value_1 in responseFiles)
+                foreach (ArtifactLocation value_1 in responseFiles)
                 {
                     if (value_1 == null)
                     {
@@ -371,7 +371,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (ruleConfigurationOverrides != null)
             {
                 var destination_2 = new List<ConfigurationOverride>();
-                foreach (var value_2 in ruleConfigurationOverrides)
+                foreach (ConfigurationOverride value_2 in ruleConfigurationOverrides)
                 {
                     if (value_2 == null)
                     {
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (notificationConfigurationOverrides != null)
             {
                 var destination_3 = new List<ConfigurationOverride>();
-                foreach (var value_3 in notificationConfigurationOverrides)
+                foreach (ConfigurationOverride value_3 in notificationConfigurationOverrides)
                 {
                     if (value_3 == null)
                     {
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (toolExecutionNotifications != null)
             {
                 var destination_4 = new List<Notification>();
-                foreach (var value_4 in toolExecutionNotifications)
+                foreach (Notification value_4 in toolExecutionNotifications)
                 {
                     if (value_4 == null)
                     {
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (toolConfigurationNotifications != null)
             {
                 var destination_5 = new List<Notification>();
-                foreach (var value_5 in toolConfigurationNotifications)
+                foreach (Notification value_5 in toolConfigurationNotifications)
                 {
                     if (value_5 == null)
                     {

--- a/src/Sarif/Autogenerated/InvocationComparer.cs
+++ b/src/Sarif/Autogenerated/InvocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Location.cs
+++ b/src/Sarif/Autogenerated/Location.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (logicalLocations != null)
             {
                 var destination_0 = new List<LogicalLocation>();
-                foreach (var value_0 in logicalLocations)
+                foreach (LogicalLocation value_0 in logicalLocations)
                 {
                     if (value_0 == null)
                     {
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (annotations != null)
             {
                 var destination_1 = new List<Region>();
-                foreach (var value_1 in annotations)
+                foreach (Region value_1 in annotations)
                 {
                     if (value_1 == null)
                     {
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (relationships != null)
             {
                 var destination_2 = new List<LocationRelationship>();
-                foreach (var value_2 in relationships)
+                foreach (LocationRelationship value_2 in relationships)
                 {
                     if (value_2 == null)
                     {

--- a/src/Sarif/Autogenerated/LocationComparer.cs
+++ b/src/Sarif/Autogenerated/LocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/LocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/LocationRelationship.cs
+++ b/src/Sarif/Autogenerated/LocationRelationship.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/LocationRelationshipComparer.cs
+++ b/src/Sarif/Autogenerated/LocationRelationshipComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/LocationRelationshipEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LocationRelationshipEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/LogicalLocation.cs
+++ b/src/Sarif/Autogenerated/LogicalLocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/LogicalLocationComparer.cs
+++ b/src/Sarif/Autogenerated/LogicalLocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Message.cs
+++ b/src/Sarif/Autogenerated/Message.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -140,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (arguments != null)
             {
                 var destination_0 = new List<string>();
-                foreach (var value_0 in arguments)
+                foreach (string value_0 in arguments)
                 {
                     destination_0.Add(value_0);
                 }

--- a/src/Sarif/Autogenerated/MessageComparer.cs
+++ b/src/Sarif/Autogenerated/MessageComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/MessageEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/MessageEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/MultiformatMessageString.cs
+++ b/src/Sarif/Autogenerated/MultiformatMessageString.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/MultiformatMessageStringComparer.cs
+++ b/src/Sarif/Autogenerated/MultiformatMessageStringComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/MultiformatMessageStringEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/MultiformatMessageStringEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Node.cs
+++ b/src/Sarif/Autogenerated/Node.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/NodeComparer.cs
+++ b/src/Sarif/Autogenerated/NodeComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/NodeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NodeEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Notification.cs
+++ b/src/Sarif/Autogenerated/Notification.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -179,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (locations != null)
             {
                 var destination_0 = new List<Location>();
-                foreach (var value_0 in locations)
+                foreach (Location value_0 in locations)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/NotificationComparer.cs
+++ b/src/Sarif/Autogenerated/NotificationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/PhysicalLocationComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/PropertyBag.cs
+++ b/src/Sarif/Autogenerated/PropertyBag.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/PropertyBagComparer.cs
+++ b/src/Sarif/Autogenerated/PropertyBagComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/PropertyBagEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PropertyBagEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Rectangle.cs
+++ b/src/Sarif/Autogenerated/Rectangle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/RectangleComparer.cs
+++ b/src/Sarif/Autogenerated/RectangleComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/RectangleEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RectangleEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Region.cs
+++ b/src/Sarif/Autogenerated/Region.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/RegionComparer.cs
+++ b/src/Sarif/Autogenerated/RegionComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/RegionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RegionEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Replacement.cs
+++ b/src/Sarif/Autogenerated/Replacement.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ReplacementComparer.cs
+++ b/src/Sarif/Autogenerated/ReplacementComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingConfiguration.cs
+++ b/src/Sarif/Autogenerated/ReportingConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,8 +6,6 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
-
-using Microsoft.CodeAnalysis.Sarif.Readers;
 
 using Newtonsoft.Json;
 

--- a/src/Sarif/Autogenerated/ReportingConfigurationComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingConfigurationComparer.cs
@@ -1,10 +1,17 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+
+/* Unmerged change from project 'Sarif(net462)'
+Before:
 using System;
 using System.CodeDom.Compiler;
+After:
+using System.CodeDom.Compiler;
+*/
+using System.CodeDom.Compiler;
+
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Sarif.Readers;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Autogenerated/ReportingConfigurationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingConfigurationEqualityComparer.cs
@@ -1,10 +1,17 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+
+/* Unmerged change from project 'Sarif(net462)'
+Before:
 using System;
 using System.CodeDom.Compiler;
+After:
+using System.CodeDom.Compiler;
+*/
+using System.CodeDom.Compiler;
+
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Sarif.Readers;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Autogenerated/ReportingDescriptor.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (deprecatedIds != null)
             {
                 var destination_0 = new List<string>();
-                foreach (var value_0 in deprecatedIds)
+                foreach (string value_0 in deprecatedIds)
                 {
                     destination_0.Add(value_0);
                 }
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (deprecatedGuids != null)
             {
                 var destination_1 = new List<Guid>();
-                foreach (var value_1 in deprecatedGuids)
+                foreach (Guid value_1 in deprecatedGuids)
                 {
                     destination_1.Add(value_1);
                 }
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (deprecatedNames != null)
             {
                 var destination_2 = new List<string>();
-                foreach (var value_2 in deprecatedNames)
+                foreach (string value_2 in deprecatedNames)
                 {
                     destination_2.Add(value_2);
                 }
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (messageStrings != null)
             {
                 MessageStrings = new Dictionary<string, MultiformatMessageString>();
-                foreach (var value_3 in messageStrings)
+                foreach (KeyValuePair<string, MultiformatMessageString> value_3 in messageStrings)
                 {
                     MessageStrings.Add(value_3.Key, new MultiformatMessageString(value_3.Value));
                 }
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (relationships != null)
             {
                 var destination_3 = new List<ReportingDescriptorRelationship>();
-                foreach (var value_4 in relationships)
+                foreach (ReportingDescriptorRelationship value_4 in relationships)
                 {
                     if (value_4 == null)
                     {

--- a/src/Sarif/Autogenerated/ReportingDescriptorComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingDescriptorEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingDescriptorReference.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorReference.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ReportingDescriptorReferenceComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorReferenceComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingDescriptorReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorReferenceEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationshipComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationshipComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Result.cs
+++ b/src/Sarif/Autogenerated/Result.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (locations != null)
             {
                 var destination_0 = new List<Location>();
-                foreach (var value_0 in locations)
+                foreach (Location value_0 in locations)
                 {
                     if (value_0 == null)
                     {
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (stacks != null)
             {
                 var destination_1 = new List<Stack>();
-                foreach (var value_1 in stacks)
+                foreach (Stack value_1 in stacks)
                 {
                     if (value_1 == null)
                     {
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (codeFlows != null)
             {
                 var destination_2 = new List<CodeFlow>();
-                foreach (var value_2 in codeFlows)
+                foreach (CodeFlow value_2 in codeFlows)
                 {
                     if (value_2 == null)
                     {
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (graphs != null)
             {
                 var destination_3 = new List<Graph>();
-                foreach (var value_3 in graphs)
+                foreach (Graph value_3 in graphs)
                 {
                     if (value_3 == null)
                     {
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (graphTraversals != null)
             {
                 var destination_4 = new List<GraphTraversal>();
-                foreach (var value_4 in graphTraversals)
+                foreach (GraphTraversal value_4 in graphTraversals)
                 {
                     if (value_4 == null)
                     {
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (relatedLocations != null)
             {
                 var destination_5 = new List<Location>();
-                foreach (var value_5 in relatedLocations)
+                foreach (Location value_5 in relatedLocations)
                 {
                     if (value_5 == null)
                     {
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (suppressions != null)
             {
                 var destination_6 = new List<Suppression>();
-                foreach (var value_6 in suppressions)
+                foreach (Suppression value_6 in suppressions)
                 {
                     if (value_6 == null)
                     {
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (attachments != null)
             {
                 var destination_7 = new List<Attachment>();
-                foreach (var value_7 in attachments)
+                foreach (Attachment value_7 in attachments)
                 {
                     if (value_7 == null)
                     {
@@ -603,7 +603,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (workItemUris != null)
             {
                 var destination_8 = new List<Uri>();
-                foreach (var value_8 in workItemUris)
+                foreach (Uri value_8 in workItemUris)
                 {
                     destination_8.Add(value_8);
                 }
@@ -619,7 +619,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (fixes != null)
             {
                 var destination_9 = new List<Fix>();
-                foreach (var value_9 in fixes)
+                foreach (Fix value_9 in fixes)
                 {
                     if (value_9 == null)
                     {
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (taxa != null)
             {
                 var destination_10 = new List<ReportingDescriptorReference>();
-                foreach (var value_10 in taxa)
+                foreach (ReportingDescriptorReference value_10 in taxa)
                 {
                     if (value_10 == null)
                     {

--- a/src/Sarif/Autogenerated/ResultComparer.cs
+++ b/src/Sarif/Autogenerated/ResultComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ResultEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ResultKind.cs
+++ b/src/Sarif/Autogenerated/ResultKind.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ResultProvenance.cs
+++ b/src/Sarif/Autogenerated/ResultProvenance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ResultProvenanceComparer.cs
+++ b/src/Sarif/Autogenerated/ResultProvenanceComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ResultProvenanceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultProvenanceEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Run.cs
+++ b/src/Sarif/Autogenerated/Run.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (invocations != null)
             {
                 var destination_0 = new List<Invocation>();
-                foreach (var value_0 in invocations)
+                foreach (Invocation value_0 in invocations)
                 {
                     if (value_0 == null)
                     {
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (versionControlProvenance != null)
             {
                 var destination_1 = new List<VersionControlDetails>();
-                foreach (var value_1 in versionControlProvenance)
+                foreach (VersionControlDetails value_1 in versionControlProvenance)
                 {
                     if (value_1 == null)
                     {
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (originalUriBaseIds != null)
             {
                 OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>();
-                foreach (var value_2 in originalUriBaseIds)
+                foreach (KeyValuePair<string, ArtifactLocation> value_2 in originalUriBaseIds)
                 {
                     OriginalUriBaseIds.Add(value_2.Key, new ArtifactLocation(value_2.Value));
                 }
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (artifacts != null)
             {
                 var destination_2 = new List<Artifact>();
-                foreach (var value_3 in artifacts)
+                foreach (Artifact value_3 in artifacts)
                 {
                     if (value_3 == null)
                     {
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (logicalLocations != null)
             {
                 var destination_3 = new List<LogicalLocation>();
-                foreach (var value_4 in logicalLocations)
+                foreach (LogicalLocation value_4 in logicalLocations)
                 {
                     if (value_4 == null)
                     {
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (graphs != null)
             {
                 var destination_4 = new List<Graph>();
-                foreach (var value_5 in graphs)
+                foreach (Graph value_5 in graphs)
                 {
                     if (value_5 == null)
                     {
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (results != null)
             {
                 var destination_5 = new List<Result>();
-                foreach (var value_6 in results)
+                foreach (Result value_6 in results)
                 {
                     if (value_6 == null)
                     {
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (runAggregates != null)
             {
                 var destination_6 = new List<RunAutomationDetails>();
-                foreach (var value_7 in runAggregates)
+                foreach (RunAutomationDetails value_7 in runAggregates)
                 {
                     if (value_7 == null)
                     {
@@ -520,7 +520,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (redactionTokens != null)
             {
                 var destination_7 = new List<string>();
-                foreach (var value_8 in redactionTokens)
+                foreach (string value_8 in redactionTokens)
                 {
                     destination_7.Add(value_8);
                 }
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (newlineSequences != null)
             {
                 var destination_8 = new List<string>();
-                foreach (var value_9 in newlineSequences)
+                foreach (string value_9 in newlineSequences)
                 {
                     destination_8.Add(value_9);
                 }
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (threadFlowLocations != null)
             {
                 var destination_9 = new List<ThreadFlowLocation>();
-                foreach (var value_10 in threadFlowLocations)
+                foreach (ThreadFlowLocation value_10 in threadFlowLocations)
                 {
                     if (value_10 == null)
                     {
@@ -568,7 +568,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (taxonomies != null)
             {
                 var destination_10 = new List<ToolComponent>();
-                foreach (var value_11 in taxonomies)
+                foreach (ToolComponent value_11 in taxonomies)
                 {
                     if (value_11 == null)
                     {
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (addresses != null)
             {
                 var destination_11 = new List<Address>();
-                foreach (var value_12 in addresses)
+                foreach (Address value_12 in addresses)
                 {
                     if (value_12 == null)
                     {
@@ -604,7 +604,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (translations != null)
             {
                 var destination_12 = new List<ToolComponent>();
-                foreach (var value_13 in translations)
+                foreach (ToolComponent value_13 in translations)
                 {
                     if (value_13 == null)
                     {
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (policies != null)
             {
                 var destination_13 = new List<ToolComponent>();
-                foreach (var value_14 in policies)
+                foreach (ToolComponent value_14 in policies)
                 {
                     if (value_14 == null)
                     {
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (webRequests != null)
             {
                 var destination_14 = new List<WebRequest>();
-                foreach (var value_15 in webRequests)
+                foreach (WebRequest value_15 in webRequests)
                 {
                     if (value_15 == null)
                     {
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (webResponses != null)
             {
                 var destination_15 = new List<WebResponse>();
-                foreach (var value_16 in webResponses)
+                foreach (WebResponse value_16 in webResponses)
                 {
                     if (value_16 == null)
                     {

--- a/src/Sarif/Autogenerated/RunAutomationDetails.cs
+++ b/src/Sarif/Autogenerated/RunAutomationDetails.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/RunAutomationDetailsComparer.cs
+++ b/src/Sarif/Autogenerated/RunAutomationDetailsComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/RunAutomationDetailsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunAutomationDetailsEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/RunComparer.cs
+++ b/src/Sarif/Autogenerated/RunComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SarifLog.cs
+++ b/src/Sarif/Autogenerated/SarifLog.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (runs != null)
             {
                 var destination_0 = new List<Run>();
-                foreach (var value_0 in runs)
+                foreach (Run value_0 in runs)
                 {
                     if (value_0 == null)
                     {
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (inlineExternalProperties != null)
             {
                 var destination_1 = new List<ExternalProperties>();
-                foreach (var value_1 in inlineExternalProperties)
+                foreach (ExternalProperties value_1 in inlineExternalProperties)
                 {
                     if (value_1 == null)
                     {

--- a/src/Sarif/Autogenerated/SarifLogComparer.cs
+++ b/src/Sarif/Autogenerated/SarifLogComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SarifNodeKind.cs
+++ b/src/Sarif/Autogenerated/SarifNodeKind.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -1,9 +1,8 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/SarifVersion.cs
+++ b/src/Sarif/Autogenerated/SarifVersion.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SpecialLocations.cs
+++ b/src/Sarif/Autogenerated/SpecialLocations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/SpecialLocationsComparer.cs
+++ b/src/Sarif/Autogenerated/SpecialLocationsComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SpecialLocationsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SpecialLocationsEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Stack.cs
+++ b/src/Sarif/Autogenerated/Stack.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (frames != null)
             {
                 var destination_0 = new List<StackFrame>();
-                foreach (var value_0 in frames)
+                foreach (StackFrame value_0 in frames)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/StackComparer.cs
+++ b/src/Sarif/Autogenerated/StackComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/StackEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/StackFrame.cs
+++ b/src/Sarif/Autogenerated/StackFrame.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -144,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (parameters != null)
             {
                 var destination_0 = new List<string>();
-                foreach (var value_0 in parameters)
+                foreach (string value_0 in parameters)
                 {
                     destination_0.Add(value_0);
                 }

--- a/src/Sarif/Autogenerated/StackFrameComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/Suppression.cs
+++ b/src/Sarif/Autogenerated/Suppression.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/SuppressionComparer.cs
+++ b/src/Sarif/Autogenerated/SuppressionComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/SuppressionKind.cs
+++ b/src/Sarif/Autogenerated/SuppressionKind.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SuppressionStatus.cs
+++ b/src/Sarif/Autogenerated/SuppressionStatus.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ThreadFlow.cs
+++ b/src/Sarif/Autogenerated/ThreadFlow.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (locations != null)
             {
                 var destination_0 = new List<ThreadFlowLocation>();
-                foreach (var value_0 in locations)
+                foreach (ThreadFlowLocation value_0 in locations)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/ThreadFlowComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ThreadFlowEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ThreadFlowLocation.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -242,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (kinds != null)
             {
                 var destination_0 = new List<string>();
-                foreach (var value_0 in kinds)
+                foreach (string value_0 in kinds)
                 {
                     destination_0.Add(value_0);
                 }
@@ -253,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (taxa != null)
             {
                 var destination_1 = new List<ReportingDescriptorReference>();
-                foreach (var value_1 in taxa)
+                foreach (ReportingDescriptorReference value_1 in taxa)
                 {
                     if (value_1 == null)
                     {
@@ -272,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (state != null)
             {
                 State = new Dictionary<string, MultiformatMessageString>();
-                foreach (var value_2 in state)
+                foreach (KeyValuePair<string, MultiformatMessageString> value_2 in state)
                 {
                     State.Add(value_2.Key, new MultiformatMessageString(value_2.Value));
                 }

--- a/src/Sarif/Autogenerated/ThreadFlowLocationComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocationComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ThreadFlowLocationImportance.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocationImportance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Tool.cs
+++ b/src/Sarif/Autogenerated/Tool.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -124,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (extensions != null)
             {
                 var destination_0 = new List<ToolComponent>();
-                foreach (var value_0 in extensions)
+                foreach (ToolComponent value_0 in extensions)
                 {
                     if (value_0 == null)
                     {

--- a/src/Sarif/Autogenerated/ToolComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ToolComponent.cs
+++ b/src/Sarif/Autogenerated/ToolComponent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -387,7 +388,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (globalMessageStrings != null)
             {
                 GlobalMessageStrings = new Dictionary<string, MultiformatMessageString>();
-                foreach (var value_0 in globalMessageStrings)
+                foreach (KeyValuePair<string, MultiformatMessageString> value_0 in globalMessageStrings)
                 {
                     GlobalMessageStrings.Add(value_0.Key, new MultiformatMessageString(value_0.Value));
                 }
@@ -396,7 +397,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (notifications != null)
             {
                 var destination_0 = new List<ReportingDescriptor>();
-                foreach (var value_1 in notifications)
+                foreach (ReportingDescriptor value_1 in notifications)
                 {
                     if (value_1 == null)
                     {
@@ -414,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (rules != null)
             {
                 var destination_1 = new List<ReportingDescriptor>();
-                foreach (var value_2 in rules)
+                foreach (ReportingDescriptor value_2 in rules)
                 {
                     if (value_2 == null)
                     {
@@ -432,7 +433,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (taxa != null)
             {
                 var destination_2 = new List<ReportingDescriptor>();
-                foreach (var value_3 in taxa)
+                foreach (ReportingDescriptor value_3 in taxa)
                 {
                     if (value_3 == null)
                     {
@@ -450,7 +451,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (locations != null)
             {
                 var destination_3 = new List<ArtifactLocation>();
-                foreach (var value_4 in locations)
+                foreach (ArtifactLocation value_4 in locations)
                 {
                     if (value_4 == null)
                     {
@@ -483,7 +484,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (supportedTaxonomies != null)
             {
                 var destination_4 = new List<ToolComponentReference>();
-                foreach (var value_5 in supportedTaxonomies)
+                foreach (ToolComponentReference value_5 in supportedTaxonomies)
                 {
                     if (value_5 == null)
                     {

--- a/src/Sarif/Autogenerated/ToolComponentComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ToolComponentContents.cs
+++ b/src/Sarif/Autogenerated/ToolComponentContents.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/ToolComponentEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ToolComponentReference.cs
+++ b/src/Sarif/Autogenerated/ToolComponentReference.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/ToolComponentReferenceComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentReferenceComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ToolComponentReferenceEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolComponentReferenceEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/ToolEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/TranslationMetadata.cs
+++ b/src/Sarif/Autogenerated/TranslationMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Sarif/Autogenerated/TranslationMetadataComparer.cs
+++ b/src/Sarif/Autogenerated/TranslationMetadataComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/TranslationMetadataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/TranslationMetadataEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/VersionControlDetails.cs
+++ b/src/Sarif/Autogenerated/VersionControlDetails.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/VersionControlDetailsComparer.cs
+++ b/src/Sarif/Autogenerated/VersionControlDetailsComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/VersionControlDetailsEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/VersionControlDetailsEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/WebRequest.cs
+++ b/src/Sarif/Autogenerated/WebRequest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/WebRequestComparer.cs
+++ b/src/Sarif/Autogenerated/WebRequestComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/WebResponse.cs
+++ b/src/Sarif/Autogenerated/WebResponse.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif

--- a/src/Sarif/Autogenerated/WebResponseComparer.cs
+++ b/src/Sarif/Autogenerated/WebResponseComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 

--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             Result result = null;
 
-            Dictionary<string, object> resultMatchingProperties = new Dictionary<string, object>();
+            var resultMatchingProperties = new Dictionary<string, object>();
             Dictionary<string, object> originalResultMatchingProperties = null;
             if (PreviousResult != null && CurrentResult != null)
             {

--- a/src/Sarif/Baseline/ResultMatching/ExactMatchers/FullFingerprintResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/ExactMatchers/FullFingerprintResultMatcher.cs
@@ -11,14 +11,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
     {
         public IList<MatchedResults> Match(IList<ExtractedResult> baseline, IList<ExtractedResult> current)
         {
-            List<MatchedResults> matchedResults = new List<MatchedResults>();
-            Dictionary<Tuple<string, string>, List<ExtractedResult>> baselineResults = new Dictionary<Tuple<string, string>, List<ExtractedResult>>(FingerprintEqualityCalculator.Instance);
+            var matchedResults = new List<MatchedResults>();
+            var baselineResults = new Dictionary<Tuple<string, string>, List<ExtractedResult>>(FingerprintEqualityCalculator.Instance);
 
             foreach (ExtractedResult result in baseline)
             {
                 foreach (string key in result.Result.Fingerprints.Keys)
                 {
-                    Tuple<string, string> fingerprint = new Tuple<string, string>(key, result.Result.Fingerprints[key]);
+                    var fingerprint = new Tuple<string, string>(key, result.Result.Fingerprints[key]);
                     if (!baselineResults.ContainsKey(fingerprint) || baselineResults[fingerprint] == null)
                     {
                         baselineResults[fingerprint] = new List<ExtractedResult>() { result };
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
             {
                 foreach (string key in result.Result.Fingerprints.Keys)
                 {
-                    Tuple<string, string> fingerprint = new Tuple<string, string>(key, result.Result.Fingerprints[key]);
+                    var fingerprint = new Tuple<string, string>(key, result.Result.Fingerprints[key]);
                     if (baselineResults.ContainsKey(fingerprint) && baselineResults[fingerprint] != null && baselineResults[fingerprint].Count > 0)
                     {
                         ExtractedResult baselineResult = baselineResults[fingerprint].First();

--- a/src/Sarif/Baseline/ResultMatching/ExactMatchers/IdenticalResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/ExactMatchers/IdenticalResultMatcher.cs
@@ -22,13 +22,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
 
         public IList<MatchedResults> Match(IList<ExtractedResult> baseline, IList<ExtractedResult> current)
         {
-            List<MatchedResults> matchedResults = new List<MatchedResults>();
+            var matchedResults = new List<MatchedResults>();
 
             IdenticalResultEqualityComparer comparer = _considerPropertyBagsWhenComparing
                 ? IdenticalResultEqualityComparer.PropertyBagComparingInstance
                 : IdenticalResultEqualityComparer.PropertyBagIgnoringInstance;
 
-            Dictionary<Result, List<ExtractedResult>> baselineResults = new Dictionary<Result, List<ExtractedResult>>(comparer);
+            var baselineResults = new Dictionary<Result, List<ExtractedResult>>(comparer);
 
             foreach (ExtractedResult result in baseline)
             {

--- a/src/Sarif/Baseline/ResultMatching/HeuristicMatchers/ContextRegionHeuristicMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/HeuristicMatchers/ContextRegionHeuristicMatcher.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
             {
                 IEnumerable<ArtifactContent> xContextRegions = x.Result.Locations.Select(loc => loc.PhysicalLocation.ContextRegion.Snippet);
 
-                HashSet<ArtifactContent> yContextRegions = new HashSet<ArtifactContent>(ArtifactContentEqualityComparer.Instance);
+                var yContextRegions = new HashSet<ArtifactContent>(ArtifactContentEqualityComparer.Instance);
                 foreach (ArtifactContent content in y.Result.Locations.Select(loc => loc.PhysicalLocation.ContextRegion.Snippet))
                 {
                     yContextRegions.Add(content);

--- a/src/Sarif/Baseline/ResultMatching/HeuristicMatchers/HeuristicMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/HeuristicMatchers/HeuristicMatcher.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
             int unmodifiedKey = Comparer.GetHashCode(currentResult);
             if (resultDictionary.ContainsKey(unmodifiedKey))
             {
-                List<ExtractedResult> matchingBaselineResult = resultDictionary[unmodifiedKey].Where(b => Comparer.Equals(b, currentResult)).ToList();
+                var matchingBaselineResult = resultDictionary[unmodifiedKey].Where(b => Comparer.Equals(b, currentResult)).ToList();
                 if (matchingBaselineResult.Count == 1)
                 {
                     result = new MatchedResults(matchingBaselineResult[0], currentResult);

--- a/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             List<ExtractedResult> currentResults =
                 current == null ? new List<ExtractedResult>() : ExtractResultsFromRuns(current);
 
-            List<MatchedResults> matchedResults = new List<MatchedResults>();
+            var matchedResults = new List<MatchedResults>();
 
             // Calculate exact mappings using exactResultMatchers.
             CalculateMatches(ExactResultMatchers, baselineResults, currentResults, matchedResults);
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 
         private List<ExtractedResult> ExtractResultsFromRuns(IEnumerable<Run> sarifRuns)
         {
-            List<ExtractedResult> results = new List<ExtractedResult>();
+            var results = new List<ExtractedResult>();
             foreach (Run run in sarifRuns)
             {
                 if (run.Results != null)

--- a/src/Sarif/Baseline/V2/TrustMap.cs
+++ b/src/Sarif/Baseline/V2/TrustMap.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
         /// <param name="component">WhatComponent for a Result attribute used in baselining</param>
         public void Add(WhatComponent component)
         {
-            TrustKey key = new TrustKey(component);
+            var key = new TrustKey(component);
 
             TrustValue value = null;
             if (!_map.TryGetValue(key, out value))

--- a/src/Sarif/Baseline/V2/V2ResultMatcher.cs
+++ b/src/Sarif/Baseline/V2/V2ResultMatcher.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
     {
         public IList<MatchedResults> Match(IList<ExtractedResult> before, IList<ExtractedResult> after)
         {
-            StatefulResultMatcher state = new StatefulResultMatcher(before, after);
+            var state = new StatefulResultMatcher(before, after);
             return state.Match();
         }
     }
@@ -94,10 +94,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
         private void BuildMaps()
         {
             // Identify all locations used in each log
-            HashSet<string> beforeLocationIdentifiers = new HashSet<string>();
+            var beforeLocationIdentifiers = new HashSet<string>();
             _before.ForEach((result) => WhereComparer.AddLocationIdentifiers(result, beforeLocationIdentifiers));
 
-            HashSet<string> afterLocationIdentifiers = new HashSet<string>();
+            var afterLocationIdentifiers = new HashSet<string>();
             _after.ForEach((result) => WhereComparer.AddLocationIdentifiers(result, afterLocationIdentifiers));
 
             // Populate WhatMap and TrustMap to guide subsequent matching
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
         private IList<MatchedResults> BuildMatchList()
         {
-            List<MatchedResults> matches = new List<MatchedResults>();
+            var matches = new List<MatchedResults>();
 
             // 1. Add all Removed Results.
             for (int beforeIndex = 0; beforeIndex < _before.Count; ++beforeIndex)

--- a/src/Sarif/Baseline/V2/WhereComparer.cs
+++ b/src/Sarif/Baseline/V2/WhereComparer.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
             // Otherwise, return empty, so that all Results without matching locations
             // are put in the same "bucket" for matching. (File Rename handling)
-            return String.Empty;
+            return string.Empty;
         }
 
         // Add all Uris and FullyQualifiedLocations in the Result to a set

--- a/src/Sarif/Core/Notification.cs
+++ b/src/Sarif/Core/Notification.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if DEBUG
 using System;
+#endif
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Core/Notification.cs
+++ b/src/Sarif/Core/Notification.cs
@@ -18,10 +18,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             Uri uri = this.Locations?[0].PhysicalLocation?.ArtifactLocation?.Uri;
             if (uri != null) { sb.Append(uri); }
-            
+
             if (this.Descriptor != null) { sb.Append(" : ").Append(this.Descriptor?.Id); }
             if (this.AssociatedRule != null) { sb.Append(" : ").Append(this.AssociatedRule?.Id); }
-            
+
             sb.Append($" : {this.Level}");
 
             if (!string.IsNullOrEmpty(this.Message?.Text))
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 sb.Length = sb.Length - 1;
                 sb.Append('}');
             }
-            
+
             if (this.Exception != null)
             {
                 sb.Append($" : {this.Exception.ToString().Replace(Environment.NewLine, string.Empty)}");

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             // We need the concrete class because the IPropertyBagHolder interface
             // doesn't expose the raw Properties array.
-            PropertyBagHolder otherHolder = other as PropertyBagHolder;
+            var otherHolder = other as PropertyBagHolder;
             Debug.Assert(otherHolder != null);
 
             Properties = other.PropertyNames.Count > 0 ? new Dictionary<string, SerializedPropertyInfo>() : null;

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (this.Results != null)
             {
-                DeferredList<Result> deferredResults = this.Results as DeferredList<Result>;
+                var deferredResults = this.Results as DeferredList<Result>;
 
                 if (deferredResults != null)
                 {
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         internal static Dictionary<string, FailureLevel> ComputePolicies(IEnumerable<ToolComponent> policies)
         {
-            Dictionary<string, FailureLevel> localCache = new Dictionary<string, FailureLevel>();
+            var localCache = new Dictionary<string, FailureLevel>();
 
             // checking if we have have policies
             if (policies == null || !policies.Any())

--- a/src/Sarif/Core/Stack.cs
+++ b/src/Sarif/Core/Stack.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="stackTrace"></param>
         public static Stack Create(string stackTrace)
         {
-            Stack stack = new Stack();
+            var stack = new Stack();
 
             if (string.IsNullOrEmpty(stackTrace))
             {
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (this.Frames == null) { return "[No frames]"; }
 
-            StringBuilder sb = new StringBuilder(255);
+            var sb = new StringBuilder(255);
 
             for (int i = 0; i < this.Frames.Count; i++)
             {

--- a/src/Sarif/Core/StackFrame.cs
+++ b/src/Sarif/Core/StackFrame.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Assembly assembly = methodBase?.DeclaringType.Assembly;
             string fullyQualifiedName = CreateFullyQualifiedName(methodBase);
 
-            StackFrame stackFrame = new StackFrame
+            var stackFrame = new StackFrame
             {
                 Module = assembly?.GetName().Name,
                 Location = new Location()

--- a/src/Sarif/Core/Tool.cs
+++ b/src/Sarif/Core/Tool.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 dottedQuadFileVersion = ParseFileVersion(version.ToString());
             }
 
-            Tool tool = new Tool
+            var tool = new Tool
             {
                 Driver = new ToolComponent
                 {

--- a/src/Sarif/ExternalProcess.cs
+++ b/src/Sarif/ExternalProcess.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             acceptableReturnCodes = acceptableReturnCodes ?? new int[] { 0 };
 
-            ProcessStartInfo psi = new ProcessStartInfo();
+            var psi = new ProcessStartInfo();
 
             psi.FileName = exePath;
             psi.Arguments = arguments;
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             psi.StandardOutputEncoding = System.Text.Encoding.UTF8;
             psi.WindowStyle = ProcessWindowStyle.Hidden;
 
-            using (Process process = Process.Start(psi))
+            using (var process = Process.Start(psi))
             {
                 StdErr = new ConsoleStreamCapture();
                 StdOut = stdOut ?? new ConsoleStreamCapture();

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static Long ComputeFirstMod()
         {
-            Long firstMod = new Long(1, 0, false);
+            var firstMod = new Long(1, 0, false);
 
             for (int i = 0; i < 100; i++)
             {

--- a/src/Sarif/LineInfo.cs
+++ b/src/Sarif/LineInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <returns>true if the objects are considered equal, false if they are not.</returns>
         public override bool Equals(object obj)
         {
-            LineInfo? other = obj as LineInfo?;
+            var other = obj as LineInfo?;
             return other != null
                 && this.Equals(other.Value);
         }

--- a/src/Sarif/Map/JsonMapBuilder.cs
+++ b/src/Sarif/Map/JsonMapBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
             }
 
             // Parse file using JsonPositionedTextReader so map can get byte locations of elements
-            using (JsonPositionedTextReader reader = new JsonPositionedTextReader(streamProvider))
+            using (var reader = new JsonPositionedTextReader(streamProvider))
             {
                 if (!reader.Read()) { return null; }
                 return Build(reader, runSettings, startPosition: 0, out long _);
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
             }
 
             // For objects and arrays, capture the exact position, then build a node and look inside...
-            JsonMapNode node = new JsonMapNode();
+            var node = new JsonMapNode();
             node.Start = reader.TokenPosition;
             node.Count = 0;
 
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
                 if (every > 1)
                 {
                     int newCount = node.Count / every;
-                    List<long> newStarts = new List<long>(newCount);
+                    var newStarts = new List<long>(newCount);
 
                     for (int i = 0; i * every < node.Count; ++i)
                     {

--- a/src/Sarif/Map/JsonMapNode.cs
+++ b/src/Sarif/Map/JsonMapNode.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
                 // Make it a valid array prefix (it must start with '[', which will look like the root of the Json document
                 buffer[0] = (byte)'[';
 
-                using (JsonPositionedTextReader reader = new JsonPositionedTextReader(() => new MemoryStream(buffer)))
+                using (var reader = new JsonPositionedTextReader(() => new MemoryStream(buffer)))
                 {
                     // Find the desired array item index in the buffer
                     long relativePosition = reader.ReadToArrayIndex(index - startIndex);

--- a/src/Sarif/Map/LongArrayDeltaConverter.cs
+++ b/src/Sarif/Map/LongArrayDeltaConverter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
 
             reader.Read();
 
-            List<long> list = new List<long>();
+            var list = new List<long>();
             long current = 0;
 
             // Convert the array values from relative to absolute
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
                 return;
             }
 
-            List<long> list = (List<long>)value;
+            var list = (List<long>)value;
 
             writer.WriteStartArray();
 

--- a/src/Sarif/OffsetInfo.cs
+++ b/src/Sarif/OffsetInfo.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <returns>true if the objects are considered equal, false if they are not.</returns>
         public override bool Equals(object obj)
         {
-            OffsetInfo? other = obj as OffsetInfo?;
+            var other = obj as OffsetInfo?;
             return other != null
                 && this.Equals(other.Value);
         }

--- a/src/Sarif/Processors/Generic/GenericMappingAction.cs
+++ b/src/Sarif/Processors/Generic/GenericMappingAction.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
 
         public IEnumerable<T> Map(IEnumerable<T> collection)
         {
-            List<T> output = new List<T>();
+            var output = new List<T>();
             foreach (T value in collection)
             {
                 output.Add(Action.Invoke(value));

--- a/src/Sarif/PropertiesDictionary.cs
+++ b/src/Sarif/PropertiesDictionary.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public void SaveToXml(Stream stream)
         {
             var settings = new XmlWriterSettings { Indent = true };
-            using (XmlWriter writer = XmlWriter.Create(stream, settings))
+            using (var writer = XmlWriter.Create(stream, settings))
             {
                 this.SavePropertiesToXmlStream(writer, settings, null, SettingNameToDescriptionsMap);
             }
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 XmlResolver = null
             };
 
-            using (XmlReader reader = XmlReader.Create(stream, settings))
+            using (var reader = XmlReader.Create(stream, settings))
             {
                 if (reader.IsStartElement(PropertiesDictionaryExtensionMethods.PROPERTIES_ID))
                 {

--- a/src/Sarif/Query/BitArrayExtensions.cs
+++ b/src/Sarif/Query/BitArrayExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
         /// <returns>List of items from set which were included in BitArray</returns>
         public static List<T> MatchingSubset<T>(this BitArray matches, IList<T> set)
         {
-            List<T> subset = new List<T>();
+            var subset = new List<T>();
 
             for (int i = 0; i < set.Count; ++i)
             {

--- a/src/Sarif/Query/Evaluators/ExpressionEvaluators.cs
+++ b/src/Sarif/Query/Evaluators/ExpressionEvaluators.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query.Evaluators
 
         public void Evaluate(ICollection<T> list, BitArray matches)
         {
-            BitArray termMatches = new BitArray(list.Count);
+            var termMatches = new BitArray(list.Count);
 
             for (int i = 0; i < _terms.Count; ++i)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query.Evaluators
 
         public void Evaluate(ICollection<T> list, BitArray matches)
         {
-            BitArray termMatches = new BitArray(list.Count);
+            var termMatches = new BitArray(list.Count);
 
             foreach (IExpressionEvaluator<T> term in _terms)
             {

--- a/src/Sarif/Query/Evaluators/PropertyBagPropertyEvaluator.cs
+++ b/src/Sarif/Query/Evaluators/PropertyBagPropertyEvaluator.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections;
@@ -60,13 +60,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Query.Evaluators
         private IExpressionEvaluator<Result> CreateEvaluator(TermExpression term)
         {
             if (IsStringComparison(term))
+            {
                 return new StringEvaluator<Result>(GetProperty<string>, term, StringComparison.OrdinalIgnoreCase);
+            }
             else if (IsDateTimeComparison(term))
+            {
                 return new DateTimeEvaluator<Result>(GetProperty<DateTime>, term);
+            }
             else if (IsDoubleComparison(term))
+            {
                 return new DoubleEvaluator<Result>(GetProperty<double>, term);
+            }
             else
+            {
                 return new StringEvaluator<Result>(GetProperty<string>, term, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         private static readonly ReadOnlyCollection<CompareOperator> s_stringSpecificOperators =

--- a/src/Sarif/Query/ExpressionParser.cs
+++ b/src/Sarif/Query/ExpressionParser.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
 
             // Otherwise, build the string, doubling each character to escape
             int nextCopyFrom = 0;
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             result.Append('\'');
 
             for (int i = 0; i < value.Length; ++i)
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
 
         public static IExpression ParseExpression(string expression)
         {
-            StringSlice text = new StringSlice(expression);
+            var text = new StringSlice(expression);
 
             // Parse the expression
             IExpression result = ParseExpression(ref text);
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
             ConsumeWhitespace(ref text);
             if (text.Length == 0) { return new AllExpression(); }
 
-            List<IExpression> terms = new List<IExpression>
+            var terms = new List<IExpression>
             {
                 ParseAndExpression(ref text)
             };
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
 
         private static IExpression ParseAndExpression(ref StringSlice text)
         {
-            List<IExpression> terms = new List<IExpression>
+            var terms = new List<IExpression>
             {
                 ParseTerm(ref text)
             };

--- a/src/Sarif/Query/Expressions.cs
+++ b/src/Sarif/Query/Expressions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
 
         public override string ToString()
         {
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
 
             foreach (IExpression part in Terms)
             {

--- a/src/Sarif/Readers/DeferredDictionary.cs
+++ b/src/Sarif/Readers/DeferredDictionary.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         private void BuildPositions()
         {
             using (Stream stream = _streamProvider())
-            using (JsonPositionedTextReader reader = new JsonPositionedTextReader(() => stream))
+            using (var reader = new JsonPositionedTextReader(() => stream))
             {
                 stream.Seek(_start, SeekOrigin.Begin);
                 reader.Read();
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             {
                 _stream.Seek(keyPosition, SeekOrigin.Begin);
 
-                using (JsonInnerTextReader reader = new JsonInnerTextReader(new JsonObjectMemberStreamReader(_stream)))
+                using (var reader = new JsonInnerTextReader(new JsonObjectMemberStreamReader(_stream)))
                 {
                     reader.CloseInput = false;
 

--- a/src/Sarif/Readers/DeferredList.cs
+++ b/src/Sarif/Readers/DeferredList.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         private void BuildPositions()
         {
             using (Stream stream = _streamProvider())
-            using (JsonPositionedTextReader reader = new JsonPositionedTextReader(() => stream))
+            using (var reader = new JsonPositionedTextReader(() => stream))
             {
                 stream.Seek(_start, SeekOrigin.Begin);
                 reader.Read();
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
         private void BuildPositions(JsonPositionedTextReader reader, long currentOffset)
         {
-            List<long> positions = new List<long>();
+            var positions = new List<long>();
 
             while (true)
             {
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 _stream.Seek(position, SeekOrigin.Begin);
 
                 // Build a JsonTextReader
-                using (JsonInnerTextReader reader = new JsonInnerTextReader(new StreamReader(_stream)))
+                using (var reader = new JsonInnerTextReader(new StreamReader(_stream)))
                 {
                     reader.CloseInput = false;
                     reader.Read();

--- a/src/Sarif/Readers/SarifContractResolver.cs
+++ b/src/Sarif/Readers/SarifContractResolver.cs
@@ -19,29 +19,53 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             // this will only be called once and then cached
             if (objectType == typeof(Uri))
+            {
                 contract.Converter = UriConverter.Instance;
+            }
             else if (objectType == typeof(DateTime))
+            {
                 contract.Converter = DateTimeConverter.Instance;
+            }
             else if (objectType == typeof(Version))
+            {
                 contract.Converter = VersionConverter.Instance;
+            }
             else if (objectType == typeof(SarifVersion))
+            {
                 contract.Converter = SarifVersionConverter.Instance;
+            }
             else if (objectType == typeof(ThreadFlowLocationImportance))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(FailureLevel))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(ResultKind))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(BaselineState))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(SuppressionKind))
+            {
                 contract.Converter = FlagsEnumConverter.Instance;
+            }
             else if (objectType == typeof(ArtifactRoles))
+            {
                 contract.Converter = FlagsEnumConverter.Instance;
+            }
             else if (objectType == typeof(IDictionary<string, SerializedPropertyInfo>))
+            {
                 contract.Converter = PropertyBagConverter.Instance;
+            }
             else if (objectType == typeof(Dictionary<string, SerializedPropertyInfo>))
+            {
                 contract.Converter = PropertyBagConverter.Instance;
+            }
 
             return contract;
         }

--- a/src/Sarif/Readers/SerializedPropertyInfoConverter.cs
+++ b/src/Sarif/Readers/SerializedPropertyInfoConverter.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 bool wasString = reader.TokenType == JsonToken.String;
 
-                StringBuilder builder = new StringBuilder();
-                using (StringWriter w = new StringWriter(builder))
-                using (JsonTextWriter writer = new JsonTextWriter(w))
+                var builder = new StringBuilder();
+                using (var w = new StringWriter(builder))
+                using (var writer = new JsonTextWriter(w))
                 {
                     writer.WriteToken(reader);
                 }

--- a/src/Sarif/Readers/VersionConverter.cs
+++ b/src/Sarif/Readers/VersionConverter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            Version version = (Version)value;
+            var version = (Version)value;
 
             string versionString = version.ToString();
 

--- a/src/Sarif/RuleUtilities.cs
+++ b/src/Sarif/RuleUtilities.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             ruleMessageId = NormalizeRuleMessageId(ruleMessageId, context.Rule.Id);
 
-            Result result = new Result
+            var result = new Result
             {
                 RuleId = context.Rule.Id,
 

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -100,6 +100,7 @@
       <DependentUpon>SdkResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+  
 <!-- Disabling the automatic code generation. This code emit is generating
      style guideline breaks. It is also extremely stable at this point. 
      Moving forward, we could update JSchema to generate code that strictly

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -100,7 +100,12 @@
       <DependentUpon>SdkResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <Import Project="ToDotNet\ToDotNet.targets" />
+<!-- Disabling the automatic code generation. This code emit is generating
+     style guideline breaks. It is also extremely stable at this point. 
+     Moving forward, we could update JSchema to generate code that strictly
+     meets our style guidelines. We can also temporarily enable this targets
+     file again (and reapply style changes) if necessary.
+  <Import Project="ToDotNet\ToDotNet.targets" />  
+-->
 
 </Project>

--- a/src/Sarif/TypedPropertiesDictionaryConverter.cs
+++ b/src/Sarif/TypedPropertiesDictionaryConverter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return JsonConvert.DeserializeObject<Version>(reader.ReadAsString(), _versionConverter);
             }
 
-            JObject jo = JObject.Load(reader);
+            var jo = JObject.Load(reader);
             var result = new PropertiesDictionary();
 
             foreach (JProperty property in jo.Properties())

--- a/src/Sarif/UriHelper.cs
+++ b/src/Sarif/UriHelper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
             else if (Uri.TryCreate(path, UriKind.Relative, out uri))
             {
-                UriBuilder builder = new UriBuilder("http", "www.example.com", 80, path);
+                var builder = new UriBuilder("http", "www.example.com", 80, path);
                 validUri = builder.Uri.AbsolutePath;
 
                 // Since what we actually want is a relative path, strip the leading "/"

--- a/src/Sarif/VersionOne/Core/PropertyBagHolderVersionOne.cs
+++ b/src/Sarif/VersionOne/Core/PropertyBagHolderVersionOne.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Sarif.VersionOne
 
             // We need the concrete class because the IPropertyBagHolderVersionOne interface
             // doesn't expose the raw Properties array.
-            PropertyBagHolderVersionOne otherHolder = other as PropertyBagHolderVersionOne;
+            var otherHolder = other as PropertyBagHolderVersionOne;
             Debug.Assert(otherHolder != null);
 
             Properties = other.PropertyNames.Count > 0 ? new Dictionary<string, SerializedPropertyInfo>() : null;

--- a/src/Sarif/VersionOne/Readers/SarifContractResolverVersionOne.cs
+++ b/src/Sarif/VersionOne/Readers/SarifContractResolverVersionOne.cs
@@ -20,31 +20,57 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             // this will only be called once and then cached
             if (objectType == typeof(Uri))
+            {
                 contract.Converter = UriConverter.Instance;
+            }
             else if (objectType == typeof(DateTime))
+            {
                 contract.Converter = DateTimeConverter.Instance;
+            }
             else if (objectType == typeof(Version))
+            {
                 contract.Converter = VersionConverter.Instance;
+            }
             else if (objectType == typeof(SarifVersionVersionOne))
+            {
                 contract.Converter = SarifVersionConverter.Instance;
+            }
             else if (objectType == typeof(AnnotatedCodeLocationKindVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(AnnotatedCodeLocationImportanceVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(ResultLevelVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(RuleConfigurationVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(NotificationLevelVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(AlgorithmKindVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(BaselineStateVersionOne))
+            {
                 contract.Converter = EnumConverter.Instance;
+            }
             else if (objectType == typeof(SuppressionStatesVersionOne))
+            {
                 contract.Converter = FlagsEnumConverter.Instance;
+            }
             else if (objectType == typeof(IDictionary<string, SerializedPropertyInfo>))
+            {
                 contract.Converter = PropertyBagConverter.Instance;
+            }
 
             return contract;
         }

--- a/src/Sarif/Visitors/PartitioningVisitor.cs
+++ b/src/Sarif/Visitors/PartitioningVisitor.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     var partitionArtifactIndexRemappingDictionary = new Dictionary<int, int>();
                     artifactIndexRemappingDictionaries.Add(partitionArtifactIndexRemappingDictionary);
 
-                    List<int> allPartitionArtifactIndicesList = allPartitionArtifactIndices
+                    var allPartitionArtifactIndicesList = allPartitionArtifactIndices
                         .OrderBy(index => index)
                         .ToList();
 

--- a/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
+++ b/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                         _currentRun.ToolNotifications = new List<NotificationVersionOne>();
                     }
 
-                    List<NotificationVersionOne> notifications = v2Invocation.ToolExecutionNotifications.Select(CreateNotificationVersionOne).ToList();
+                    var notifications = v2Invocation.ToolExecutionNotifications.Select(CreateNotificationVersionOne).ToList();
                     _currentRun.ToolNotifications = _currentRun.ToolNotifications.Union(notifications).ToList();
                 }
             }

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                         _v1LogicalLocationKeyToDecoratedNameMap = visitor.LogicalLocationKeyToDecoratedNameMap;
 
                         run.LogicalLocations = new List<LogicalLocation>();
-                        HashSet<string> populatedKeys = new HashSet<string>();
+                        var populatedKeys = new HashSet<string>();
 
                         foreach (KeyValuePair<string, LogicalLocationVersionOne> pair in v1Run.LogicalLocations)
                         {

--- a/src/Sarif/Writers/MemoryStreamSarifLogger.cs
+++ b/src/Sarif/Writers/MemoryStreamSarifLogger.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             this.writer.BaseStream.Position = 0;
 
-            SarifLog log = SarifLog.Load(this.writer.BaseStream);
+            var log = SarifLog.Load(this.writer.BaseStream);
             return log;
         }
 

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (string.IsNullOrEmpty(prereleaseSarifLog)) { return null; }
 
-            JObject logObject = JObject.Parse(prereleaseSarifLog);
+            var logObject = JObject.Parse(prereleaseSarifLog);
 
             string version = (string)logObject["version"];
             if (version == SarifUtilities.V1_0_0)
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (run["redactionToken"] is JToken redactionToken)
             {
-                JArray redactionTokens = new JArray
+                var redactionTokens = new JArray
                 {
                     redactionToken
                 };
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private static void MoveToolLanguageToRun(JObject run)
         {
-            JObject tool = (JObject)run["tool"];
+            var tool = (JObject)run["tool"];
             if (tool["language"] is JToken language)
             {
                 tool.Remove("language");
@@ -1502,11 +1502,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             // 1. Retrieve run.tool object, which will serve as the basis of the
             //    new run.tool.driver object and zap sarifLoggerVersion from it.
-            JObject driver = (JObject)run["tool"];
+            var driver = (JObject)run["tool"];
             driver.Remove("sarifLoggerVersion");
 
             // 2. Create a new tool object, preserving only the language property
-            JObject tool = new JObject(new JProperty("language", driver["language"] ?? "en-US"));
+            var tool = new JObject(new JProperty("language", driver["language"] ?? "en-US"));
             driver.Remove("language");
 
             // https://github.com/oasis-tcs/sarif-spec/issues/319
@@ -1591,7 +1591,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private static JObject CreateMultiformatMessageStringFromPlaintext(string plaintext)
         {
-            JProperty textProperty = new JProperty("text", plaintext);
+            var textProperty = new JProperty("text", plaintext);
             return new JObject(textProperty);
         }
 
@@ -1604,7 +1604,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 return;
             }
 
-            JObject tool = (JObject)run["tool"];
+            var tool = (JObject)run["tool"];
 
             // 1. 'run.resources.messageStrings' moves to 'run.tool.globalMessageStrings'
             if (resources["messageStrings"] is JObject messageStrings)
@@ -1799,7 +1799,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                         {
                             // result.message SHALL be present constraint should be added to schema
                             // https://github.com/oasis-tcs/sarif-spec/issues/262
-                            JObject message = (JObject)result["message"];
+                            var message = (JObject)result["message"];
 
                             if (message == null)
                             {
@@ -1823,7 +1823,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     // 
                     // We will also explicitly apply the default tool.language value of "en-US".
 
-                    JObject tool = (JObject)run["tool"];
+                    var tool = (JObject)run["tool"];
                     modifiedLog |= RenameProperty(tool, previousName: "fileVersion", newName: "dottedQuadFileVersion");
                     PopulatePropertyIfAbsent(tool, "language", "en-US", ref modifiedLog);
 
@@ -1849,7 +1849,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (rules == null) { return null; }
 
-            Dictionary<JObject, int> jObjectToIndexMap = new Dictionary<JObject, int>();
+            var jObjectToIndexMap = new Dictionary<JObject, int>();
 
             foreach (JProperty ruleEntry in rules.Properties())
             {
@@ -1910,7 +1910,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (files == null) { return null; }
 
-            Dictionary<JObject, int> jObjectToIndexMap = new Dictionary<JObject, int>();
+            var jObjectToIndexMap = new Dictionary<JObject, int>();
 
             foreach (JProperty fileEntry in files.Properties())
             {
@@ -1975,7 +1975,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             var fileLocationKey = ArtifactLocation.CreateFromFilesDictionaryKey(key, parentKey);
 
-            JObject fileLocationObject = new JObject();
+            var fileLocationObject = new JObject();
             file["fileLocation"] = fileLocationObject;
             fileLocationObject["uri"] = fileLocationKey.Uri;
             fileLocationObject["uriBaseId"] = fileLocationKey.UriBaseId;
@@ -2002,7 +2002,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (logicalLocations == null) { return null; }
 
-            Dictionary<JObject, int> jObjectToIndexMap = new Dictionary<JObject, int>();
+            var jObjectToIndexMap = new Dictionary<JObject, int>();
             logicalLocationToIndexMap = new Dictionary<LogicalLocation, int>(LogicalLocation.ValueComparer);
 
             fullyQualifiedLogicalNameToIndexMap = new Dictionary<string, int>();
@@ -2297,7 +2297,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             bool modifiedRun = false;
 
-            JArray results = (JArray)run["results"];
+            var results = (JArray)run["results"];
             if (results == null) { return modifiedRun; }
 
             foreach (JObject result in results)
@@ -2332,12 +2332,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             foreach (JObject codeFlow in codeFlows)
             {
-                JArray threadFlows = (JArray)codeFlow["threadFlows"];
+                var threadFlows = (JArray)codeFlow["threadFlows"];
                 if (threadFlows == null) { continue; }
 
                 foreach (JObject threadFlow in threadFlows)
                 {
-                    JArray threadFlowLocations = (JArray)threadFlow["locations"];
+                    var threadFlowLocations = (JArray)threadFlow["locations"];
                     if (threadFlowLocations == null) { continue; }
 
                     foreach (JObject threadFlowLocation in threadFlowLocations)
@@ -2517,7 +2517,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             JToken hashes = file["hashes"];
             if (hashes == null || hashes.Type != JTokenType.Array) { return modifiedRun; }
 
-            JObject rewrittenHashes = new JObject();
+            var rewrittenHashes = new JObject();
 
             foreach (JObject hash in hashes)
             {

--- a/src/Sarif/Writers/SarifConsolidator.cs
+++ b/src/Sarif/Writers/SarifConsolidator.cs
@@ -157,8 +157,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (locations == null || locations.Count == 0) { return locations; }
 
-            HashSet<Location> uniqueLocations = new HashSet<Location>(Location.ValueComparer);
-            List<Location> newLocations = new List<Location>();
+            var uniqueLocations = new HashSet<Location>(Location.ValueComparer);
+            var newLocations = new List<Location>();
 
             foreach (Location location in locations)
             {
@@ -190,8 +190,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (logicalLocations == null || logicalLocations.Count == 0) { return logicalLocations; }
 
-            HashSet<LogicalLocation> uniqueLocations = new HashSet<LogicalLocation>(LogicalLocation.ValueComparer);
-            List<LogicalLocation> newLocations = new List<LogicalLocation>();
+            var uniqueLocations = new HashSet<LogicalLocation>(LogicalLocation.ValueComparer);
+            var newLocations = new List<LogicalLocation>();
 
             foreach (LogicalLocation logicalLocation in logicalLocations)
             {

--- a/src/Sarif/Writers/SarifOneZeroZeroLogger.cs
+++ b/src/Sarif/Writers/SarifOneZeroZeroLogger.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             var transformer = new SarifCurrentToVersionOneVisitor();
             transformer.VisitSarifLog(v2Log);
 
-            JsonSerializerSettings v1Settings = new JsonSerializerSettings()
+            var v1Settings = new JsonSerializerSettings()
             {
                 ContractResolver = SarifContractResolverVersionOne.Instance,
                 Formatting = PrettyPrint ? Formatting.Indented : Formatting.None

--- a/src/Test.EndToEnd.Baselining/BaseliningDetailEnricher.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningDetailEnricher.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -55,8 +54,8 @@ namespace Test.EndToEnd.Baselining
 
         public void Convert(Stream source, Stream target)
         {
-            using (StreamReader reader = new StreamReader(source))
-            using (StreamWriter writer = new StreamWriter(target))
+            using (var reader = new StreamReader(source))
+            using (var writer = new StreamWriter(target))
             {
                 Convert(reader, writer);
             }

--- a/src/Test.EndToEnd.Baselining/BaseliningDetailLogger.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningDetailLogger.cs
@@ -47,7 +47,7 @@ namespace Test.EndToEnd.Baselining
 
         public void Write(SarifLog newBaselineLog, SarifLog baselineLog, BaseliningSummary summary)
         {
-            Dictionary<Guid?, Result> baselineResultsByGuid = new Dictionary<Guid?, Result>();
+            var baselineResultsByGuid = new Dictionary<Guid?, Result>();
             foreach (Result result in baselineLog.EnumerateResults())
             {
                 baselineResultsByGuid[result.CorrelationGuid ?? result.Guid] = result;

--- a/src/Test.EndToEnd.Baselining/BaseliningSummary.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningSummary.cs
@@ -73,7 +73,7 @@ namespace Test.EndToEnd.Baselining
 
         public void Add(SarifLog newBaselineLog, SarifLog baselineLog, SarifLog currentLog)
         {
-            Dictionary<string, ResultCounts> newAndRemovedPerUri = new Dictionary<string, ResultCounts>();
+            var newAndRemovedPerUri = new Dictionary<string, ResultCounts>();
 
             foreach (Result result in newBaselineLog.EnumerateResults())
             {

--- a/src/Test.EndToEnd.Baselining/BaseliningTester.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningTester.cs
@@ -55,7 +55,7 @@ namespace Test.EndToEnd.Baselining
 
         public BaseliningSummary RunUnder(string folderPath, string reportingName)
         {
-            BaseliningSummary folderSummary = new BaseliningSummary(Path.GetFileName(folderPath));
+            var folderSummary = new BaseliningSummary(Path.GetFileName(folderPath));
 
             // Recurse on subfolders, if found
             foreach (string subfolder in Directory.EnumerateDirectories(folderPath, "*", SearchOption.TopDirectoryOnly))
@@ -77,12 +77,12 @@ namespace Test.EndToEnd.Baselining
         public BaseliningSummary RunSeries(string seriesPath, string reportingName, int debugLogIndex = -1, int debugResultIndex = -1)
         {
             string outputLogPath = Path.ChangeExtension(seriesPath.Replace($"\\{InputFolderName}\\", $"\\{OutputFolderName}\\"), ".log");
-            BaseliningSummary seriesSummary = new BaseliningSummary(Path.GetFileName(seriesPath));
+            var seriesSummary = new BaseliningSummary(Path.GetFileName(seriesPath));
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputLogPath));
 
             using (Stream outputStream = File.Create(outputLogPath))
-            using (BaseliningDetailLogger logger = new BaseliningDetailLogger(seriesPath, outputStream))
+            using (var logger = new BaseliningDetailLogger(seriesPath, outputStream))
             {
                 // Load the original baseline
                 SarifLog baseline = LoadBaseline(seriesPath);
@@ -100,11 +100,11 @@ namespace Test.EndToEnd.Baselining
 
                     if (debugLogIndex == current.LogIndex)
                     {
-                        List<Result> absentResults = newBaseline.EnumerateResults().Where((r) => r.BaselineState == BaselineState.Absent).ToList();
-                        List<Result> newResults = newBaseline.EnumerateResults().Where((r) => r.BaselineState == BaselineState.New).ToList();
+                        var absentResults = newBaseline.EnumerateResults().Where((r) => r.BaselineState == BaselineState.Absent).ToList();
+                        var newResults = newBaseline.EnumerateResults().Where((r) => r.BaselineState == BaselineState.New).ToList();
                     }
 
-                    BaseliningSummary fileSummary = new BaseliningSummary(Path.GetFileNameWithoutExtension(current.FilePath));
+                    var fileSummary = new BaseliningSummary(Path.GetFileNameWithoutExtension(current.FilePath));
                     fileSummary.Add(newBaseline, baseline, current.Log);
                     seriesSummary.AddCounts(fileSummary);
                     logger.Write(newBaseline, baseline, fileSummary);
@@ -138,7 +138,7 @@ namespace Test.EndToEnd.Baselining
         public void EnrichSeries(string seriesPath)
         {
             string outputLogPath = Path.ChangeExtension(seriesPath.Replace($"\\{InputFolderName}\\", $"\\{OutputFolderName}\\"), ".log");
-            BaseliningDetailEnricher enricher = new BaseliningDetailEnricher();
+            var enricher = new BaseliningDetailEnricher();
 
             // Load Baseline details
             SarifLog baseline = LoadBaseline(seriesPath);
@@ -196,7 +196,7 @@ namespace Test.EndToEnd.Baselining
         private IEnumerable<LogInSeries> LoadSeriesLogs(string seriesPath)
         {
             // Baseline each log in order
-            List<string> logs = new List<string>(Directory.EnumerateFiles(seriesPath, "*.sarif", SearchOption.TopDirectoryOnly).Where(filePath => !filePath.EndsWith(FirstBaselineFileName)).OrderBy(path => path));
+            var logs = new List<string>(Directory.EnumerateFiles(seriesPath, "*.sarif", SearchOption.TopDirectoryOnly).Where(filePath => !filePath.EndsWith(FirstBaselineFileName)).OrderBy(path => path));
             int logIndex = 1;
 
             foreach (string filePath in logs)
@@ -232,8 +232,8 @@ namespace Test.EndToEnd.Baselining
                 return false;
             }
 
-            ExtractedResult bExtractedResult = new ExtractedResult(bResult, bResult.Run);
-            ExtractedResult cExtractedResult = new ExtractedResult(cResult, cResult.Run);
+            var bExtractedResult = new ExtractedResult(bResult, bResult.Run);
+            var cExtractedResult = new ExtractedResult(cResult, cResult.Run);
 
             bool outcome = bExtractedResult.IsSufficientlySimilarTo(cExtractedResult);
             return outcome;
@@ -291,7 +291,7 @@ namespace Test.EndToEnd.Baselining
             // Mark all Results which are NOT in the new run as 'Unchanged'
             if (filteringMode == BaselineFilteringMode.ToIncludedArtifacts)
             {
-                HashSet<string> includedArtifacts = new HashSet<string>(currentLog.AllResultArtifactUris().Select(uri => uri.OriginalString));
+                var includedArtifacts = new HashSet<string>(currentLog.AllResultArtifactUris().Select(uri => uri.OriginalString));
 
                 foreach (Result result in outputLog.EnumerateResults())
                 {
@@ -332,7 +332,7 @@ namespace Test.EndToEnd.Baselining
         private static void SortForBaselining(Run run)
         {
             run.SetRunOnResults();
-            List<Result> results = (List<Result>)run.Results;
+            var results = (List<Result>)run.Results;
             results.Sort(DirectResultMatchingComparer.Instance);
         }
 

--- a/src/Test.EndToEnd.Baselining/Program.cs
+++ b/src/Test.EndToEnd.Baselining/Program.cs
@@ -85,7 +85,7 @@ namespace Test.EndToEnd.Baselining
         {
             try
             {
-                Program program = new Program();
+                var program = new Program();
 
                 return Parser.Default.ParseArguments<RunOptions, DebugOptions, RebuildDebugLogsOptions>(args).MapResult(
                     (RunOptions options) => Program.Run(options),
@@ -102,7 +102,7 @@ namespace Test.EndToEnd.Baselining
 
         private static int Run(RunOptions options)
         {
-            BaseliningTester tester = new BaseliningTester();
+            var tester = new BaseliningTester();
             BaseliningSummary overallSummary = tester.RunAll(options.TestRootPath);
 
             return 0;
@@ -110,7 +110,7 @@ namespace Test.EndToEnd.Baselining
 
         private static int Debug(DebugOptions options)
         {
-            BaseliningTester tester = new BaseliningTester();
+            var tester = new BaseliningTester();
             tester.RunSeries(Path.Combine(options.TestRootPath, BaseliningTester.InputFolderName, options.DebugSeriesPath), options.DebugSeriesPath, options.DebugLogIndex, options.DebugResultIndex);
 
             return 0;
@@ -118,7 +118,7 @@ namespace Test.EndToEnd.Baselining
 
         private static int CreateDebugLogs(RebuildDebugLogsOptions options)
         {
-            BaseliningTester tester = new BaseliningTester();
+            var tester = new BaseliningTester();
             tester.EnrichUnder(Path.Combine(options.TestRootPath, BaseliningTester.InputFolderName));
 
             return 0;

--- a/src/Test.FunctionalTests.Sarif/MultitoolCommandLineTests.cs
+++ b/src/Test.FunctionalTests.Sarif/MultitoolCommandLineTests.cs
@@ -25,13 +25,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     Directory.GetCurrentDirectory(),
                     @"..\..\Sarif.Multitool\netcoreapp3.1\Sarif.Multitool.exe"));
 
-            ProcessStartInfo startInfo = new ProcessStartInfo(multitoolPath, @"validate v2\ConverterTestData\ContrastSecurity\WebGoat.xml.sarif")
+            var startInfo = new ProcessStartInfo(multitoolPath, @"validate v2\ConverterTestData\ContrastSecurity\WebGoat.xml.sarif")
             {
                 WindowStyle = ProcessWindowStyle.Hidden,
                 CreateNoWindow = true
             };
 
-            using (Process process = Process.Start(startInfo))
+            using (var process = Process.Start(startInfo))
             {
                 process.WaitForExit();
 

--- a/src/Test.FunctionalTests.Sarif/MultitoolCommandLineTests.cs
+++ b/src/Test.FunctionalTests.Sarif/MultitoolCommandLineTests.cs
@@ -5,9 +5,11 @@ using System.Diagnostics;
 using System.IO;
 
 using FluentAssertions;
-using FluentAssertions.Execution;
 
+#if DEBUG
+using FluentAssertions.Execution;
 using Microsoft.CodeAnalysis.Sarif.Driver;
+#endif
 
 using Xunit;
 

--- a/src/Test.FunctionalTests.Sarif/PropertyBagConverterTests.cs
+++ b/src/Test.FunctionalTests.Sarif/PropertyBagConverterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             long longPropertyValue = (long)10 * int.MaxValue;
 
             string dateTimePropertyName = nameof(dateTimePropertyName);
-            DateTime dateTimePropertyValue = new DateTime(2019, 9, 27, 13, 52, 0);
+            var dateTimePropertyValue = new DateTime(2019, 9, 27, 13, 52, 0);
 
             var run = new Run
             {

--- a/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
+++ b/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void EnrichSarifLog(string actualFilePath)
         {
-            JsonSerializerSettings settings = new JsonSerializerSettings()
+            var settings = new JsonSerializerSettings()
             {
                 Formatting = Formatting.Indented,
             };

--- a/src/Test.FunctionalTests.Sarif/SarifLogEqualityComparerTests.cs
+++ b/src/Test.FunctionalTests.Sarif/SarifLogEqualityComparerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 
 using FluentAssertions;

--- a/src/Test.UnitTests.Sarif.Converters/BuiltinConverterFactoryTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/BuiltinConverterFactoryTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;

--- a/src/Test.UnitTests.Sarif.Converters/BuiltinConverterFactoryTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/BuiltinConverterFactoryTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void BuiltInConverterFactory_HasConverterForEveryBuiltInToolFormat()
         {
-            List<string> toolFormats = Utilities.GetToolFormats()
+            var toolFormats = Utilities.GetToolFormats()
                 .ToList();
 
             string factoryName = nameof(BuiltInConverterFactory);

--- a/src/Test.UnitTests.Sarif.Converters/ClangAnalyzerConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/ClangAnalyzerConverterTests.cs
@@ -15,21 +15,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void ClangAnalyzerConverter_Convert_NullInput()
         {
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(null, null, OptionallyEmittedData.None));
         }
 
         [Fact]
         public void ClangAnalyzerConverter_Convert_NullOutput()
         {
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(new MemoryStream(), null, OptionallyEmittedData.None));
         }
 
         [Fact]
         public void ClangAnalyzerConverter_Convert_NullLogTest()
         {
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(null, new ResultLogObjectWriter(), OptionallyEmittedData.None));
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<key>clang_version</key>\r\n<string>Ubuntu clang version 3.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)</string>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n<key>diagnostics</key>\r\n<array>\r\n<dict>\r\n<key>path</key>\r\n<array>\r\n<dict>\r\n<key>kind</key>\r\n<string>event</string>\r\n<key>location</key>\r\n<dict>\r\n<key>line</key>\r\n<integer>Bogus</integer>\r\n<key>col</key>\r\n<integer>5</integer>\r\n<key>file</key>\r\n<integer>0</integer>\r\n</dict>\r\n<key>ranges</key>\r\n<array>\r\n<array>\r\n<dict>\r\n<key>line</key>\r\n<integer>595</integer>\r\n<key>col</key>\r\n<integer>15</integer>\r\n<key>file</key>\r\n<integer>0</integer>\r\n</dict>\r\n<dict>\r\n<key>line</key>\r\n<integer>595</integer>\r\n<key>col</key>\r\n<integer>50</integer>\r\n<key>file</key>\r\n<integer>0</integer>\r\n</dict>\r\n</array>\r\n</array>\r\n<key>depth</key>\r\n<integer>0</integer>\r\n<key>extended_message</key>\r\n<string>Value stored to &apos;scanptr&apos; is never read</string>\r\n<key>message</key>\r\n<string>Value stored to &apos;scanptr&apos; is never read</string>\r\n</dict>\r\n</array>\r\n<key>description</key>\r\n<string>Value stored to &apos;scanptr&apos; is never read</string>\r\n<key>category</key>\r\n<string>Dead store</string>\r\n<key>type</key>\r\n<string>Dead assignment</string>\r\n<key>issue_context_kind</key>\r\n<string>function</string>\r\n<key>issue_context</key>\r\n<string>jpeg_simple_progression</string>\r\n<key>issue_hash</key>\r\n<string>57</string>\r\n<key>location</key>\r\n<dict>\r\n<key>line</key>\r\n<integer>Bogus</integer>\r\n<key>col</key>\r\n<integer>5</integer>\r\n<key>file</key>\r\n<integer>0</integer>\r\n</dict>\r\n<key>HTMLDiagnostics_files</key>\r\n<array>\r\n<string>report-ab0d45.html</string>\r\n</array>\r\n</dict>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
 
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<string>No Key Throw</string>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
 
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<array></array>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
 
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         public void ClangAnalyzerConverter_MissingNestedStringDictionaryKey()
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<key>clang_version</key>\r\n<string>Ubuntu clang version 3.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)</string>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n<key>diagnostics</key>\r\n<array>\r\n<dict>\r\n<string>\r\n</string>\r\n</dict>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         public void ClangAnalyzerConverter_MissingNestedArrayDictionaryKey()
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<key>clang_version</key>\r\n<string>Ubuntu clang version 3.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)</string>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n<key>diagnostics</key>\r\n<array>\r\n<dict>\r\n<array>\r\n</array>\r\n</dict>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         public void ClangAnalyzerConverter_MissingNestedDictionaryKey()
         {
             string clangAnalyzerLog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n<key>clang_version</key>\r\n<string>Ubuntu clang version 3.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)</string>\r\n<key>files</key>\r\n<array>\r\n<string>jcparam.c</string>\r\n</array>\r\n<key>diagnostics</key>\r\n<array>\r\n<dict>\r\n<dict>\r\n</dict>\r\n</dict>\r\n</array>\r\n</dict>\r\n</plist>\r\n";
-            ClangAnalyzerConverter converter = new ClangAnalyzerConverter();
+            var converter = new ClangAnalyzerConverter();
             Assert.Throws<InvalidDataException>(() => Utilities.GetConverterJson(converter, clangAnalyzerLog));
         }
     }

--- a/src/Test.UnitTests.Sarif.Converters/CppCheckConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/CppCheckConverterTests.cs
@@ -18,21 +18,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void CppCheckConverter_Convert_NullInput()
         {
-            CppCheckConverter converter = new CppCheckConverter();
+            var converter = new CppCheckConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(null, null, OptionallyEmittedData.None));
         }
 
         [Fact]
         public void CppCheckConverter_Convert_NullOutput()
         {
-            CppCheckConverter converter = new CppCheckConverter();
+            var converter = new CppCheckConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(new MemoryStream(), null, OptionallyEmittedData.None));
         }
 
         [Fact]
         public void CppCheckConverter_Convert_NullLogTest()
         {
-            CppCheckConverter converter = new CppCheckConverter();
+            var converter = new CppCheckConverter();
             Assert.Throws<ArgumentNullException>(() => converter.Convert(null, new ResultLogObjectWriter(), OptionallyEmittedData.None));
         }
 

--- a/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyFprConverter_GetFailureLevelFromRuleMetadata_MissingImpactProperty_ReturnsWarning()
         {
-            ReportingDescriptor rule = new ReportingDescriptor();
+            var rule = new ReportingDescriptor();
 
             FailureLevel level = FortifyFprConverter.GetFailureLevelFromRuleMetadata(rule);
 
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             foreach (KeyValuePair<string, FailureLevel> keyValuePair in expectedInputOutputs)
             {
-                ReportingDescriptor rule = new ReportingDescriptor();
+                var rule = new ReportingDescriptor();
                 rule.SetProperty<string>("Impact", keyValuePair.Key);
 
                 FailureLevel level = FortifyFprConverter.GetFailureLevelFromRuleMetadata(rule);

--- a/src/Test.UnitTests.Sarif.Converters/FortifyIssueTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyIssueTests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_IgnoresNonCweTypeExternalCategories()
         {
-            XElement xml = XElement.Parse(s_fullIssueXml);
+            var xml = XElement.Parse(s_fullIssueXml);
             xml.Element("ExternalCategory").Attribute("type").Value = "a_differnt_type";
             FortifyIssue result = Parse(xml);
             result.CweIds.Should().BeEmpty();
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_RequiresElementsInOrder()
         {
-            XElement xml = XElement.Parse(s_fullIssueXml);
+            var xml = XElement.Parse(s_fullIssueXml);
             // Move the primary node to the end
             XElement primary = xml.Element("Primary");
             primary.Remove();
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_RequiresCategory()
         {
-            XElement xml = XElement.Parse(s_minimalIssueXml);
+            var xml = XElement.Parse(s_minimalIssueXml);
             xml.Element("Category").Remove();
             Assert.Throws<XmlException>(() => Parse(xml));
         }
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_RequiresFolder()
         {
-            XElement xml = XElement.Parse(s_minimalIssueXml);
+            var xml = XElement.Parse(s_minimalIssueXml);
             xml.Element("Folder").Remove();
             Assert.Throws<XmlException>(() => Parse(xml));
         }
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_RequiresKingdom()
         {
-            XElement xml = XElement.Parse(s_minimalIssueXml);
+            var xml = XElement.Parse(s_minimalIssueXml);
             xml.Element("Kingdom").Remove();
             Assert.Throws<XmlException>(() => Parse(xml));
         }
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void FortifyIssue_Parse_RequiresPrimary()
         {
-            XElement xml = XElement.Parse(s_minimalIssueXml);
+            var xml = XElement.Parse(s_minimalIssueXml);
             xml.Element("Primary").Remove();
             Assert.Throws<XmlException>(() => Parse(xml));
         }

--- a/src/Test.UnitTests.Sarif.Converters/PylintConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/PylintConverterTests.cs
@@ -96,7 +96,7 @@ namespace Sarif.Converters.UnitTests
         public void PylintConverter_Convert_WhenInputIsValid_Passes()
         {
             byte[] data = Encoding.UTF8.GetBytes(InputJson);
-            MemoryStream stream = new MemoryStream(data);
+            var stream = new MemoryStream(data);
 
             var mockWriter = new Mock<IResultLogWriter>();
             mockWriter.Setup(writer => writer.Initialize(It.IsAny<Run>()));

--- a/src/Test.UnitTests.Sarif.Converters/TSLintConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/TSLintConverterTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private Result CreateTestResult()
         {
-            Result testResult = new Result()
+            var testResult = new Result()
             {
                 RuleId = "ruleName.test.value",
                 Message = new Message { Text = "failure.test.value" },
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Kind = ResultKind.Fail
             };
 
-            Region region = new Region()
+            var region = new Region()
             {
                 StartLine = 3,
                 StartColumn = 2,
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 CharOffset = 3,
                 CharLength = 10
             };
-            PhysicalLocation physLoc = new PhysicalLocation()
+            var physLoc = new PhysicalLocation()
             {
                 ArtifactLocation = new ArtifactLocation
                 {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 },
                 Region = region
             };
-            Location location = new Location()
+            var location = new Location()
             {
                 PhysicalLocation = physLoc
             };
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 location
             };
 
-            Replacement replacement = new Replacement()
+            var replacement = new Replacement()
             {
                 DeletedRegion = new Region
                 {
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         public void TSLintConverter_Convert_WhenInputIsValid_Passes()
         {
             byte[] data = Encoding.UTF8.GetBytes(InputJson);
-            MemoryStream stream = new MemoryStream(data);
+            var stream = new MemoryStream(data);
 
             var mockWriter = new Mock<IResultLogWriter>();
             mockWriter.Setup(writer => writer.Initialize(It.IsAny<Run>()));

--- a/src/Test.UnitTests.Sarif.Converters/TSLintLogReaderTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/TSLintLogReaderTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void TSLintLogReader_ReadLog_WhenInputIsNull_ThrowsArgumentNullException()
         {
-            TSLintLogReader logReader = new TSLintLogReader();
+            var logReader = new TSLintLogReader();
 
             Action action = () => logReader.ReadLog(default(Stream));
             action.Should().Throw<ArgumentNullException>();
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             ]";
 
-            TSLintLog expectedLog = new TSLintLog
+            var expectedLog = new TSLintLog
             {
                 new TSLintLogEntry
                 {
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             };
 
-            TSLintLogReader logReader = new TSLintLogReader();
+            var logReader = new TSLintLogReader();
 
             TSLintLog actualLog = logReader.ReadLog(Input);
 
@@ -155,10 +155,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             ]";
 
-            JToken expectedToken = JToken.Parse(ExpectedOutput);
+            var expectedToken = JToken.Parse(ExpectedOutput);
 
-            JToken inputToken = JToken.Parse(Input);
-            TSLintLogReader logReader = new TSLintLogReader();
+            var inputToken = JToken.Parse(Input);
+            var logReader = new TSLintLogReader();
             JToken actualToken = logReader.NormalizeLog(inputToken);
 
             JToken.DeepEquals(expectedToken, actualToken).Should().BeTrue();
@@ -222,10 +222,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 },
             ]";
 
-            JToken expectedToken = JToken.Parse(ExpectedOutput);
+            var expectedToken = JToken.Parse(ExpectedOutput);
 
-            JToken inputToken = JToken.Parse(Input);
-            TSLintLogReader logReader = new TSLintLogReader();
+            var inputToken = JToken.Parse(Input);
+            var logReader = new TSLintLogReader();
             JToken actualToken = logReader.NormalizeLog(inputToken);
 
             JToken.DeepEquals(expectedToken, actualToken).Should().BeTrue();

--- a/src/Test.UnitTests.Sarif.Converters/TextFormats/CsvReaderTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/TextFormats/CsvReaderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             int bufferSize = 64;
 
             // Empty file - verify no rows
-            using (CsvReader reader = new CsvReader(StreamFromString(""), bufferSize))
+            using (var reader = new CsvReader(StreamFromString(""), bufferSize))
             {
                 Assert.False(reader.NextRow());
 
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Single row file, no trailing newline
-            using (CsvReader reader = new CsvReader(StreamFromString("One,Two,Three"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString("One,Two,Three"), bufferSize))
             {
                 Assert.Equal(0, reader.RowCountRead);
                 Assert.True(reader.NextRow());
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Empty values
-            using (CsvReader reader = new CsvReader(StreamFromString(",Value,,"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString(",Value,,"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("|Value||", string.Join("|", reader.Current()));
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Newline variation and trailing newline
-            using (CsvReader reader = new CsvReader(StreamFromString("One\nTwo\r\nThree\r\n"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString("One\nTwo\r\nThree\r\n"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("One", string.Join("|", reader.Current()));
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // Row requiring a buffer resize and verify nothing is missed
             string oneHundredColumns = string.Join(",", Enumerable.Range(100, 100).Select(i => i.ToString()));
-            using (CsvReader reader = new CsvReader(StreamFromString(oneHundredColumns), bufferSize))
+            using (var reader = new CsvReader(StreamFromString(oneHundredColumns), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal(100, reader.Current().Count);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // Value exactly 2x buffer, requiring two buffer resizes to be read
             string valueRequiringBufferExpand = new string('0', 128);
-            using (CsvReader reader = new CsvReader(StreamFromString($"One,Two,Three\r\nSecond,Row\r\n{valueRequiringBufferExpand}"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString($"One,Two,Three\r\nSecond,Row\r\n{valueRequiringBufferExpand}"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("One|Two|Three", string.Join("|", reader.Current()));
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // '\r' exactly at buffer boundary, requiring refill to track the unread '\n' to ignore
-            using (CsvReader reader = new CsvReader(StreamFromString($"{new string('0', 63)}\r\nNextRow\r\n"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString($"{new string('0', 63)}\r\nNextRow\r\n"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal(new string('0', 63), string.Join("|", reader.Current()));
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Quoted value variations - quoted empty, quotes at start/end, quote in middle, unquoted after quoted, adjacent escaped quotes
-            using (CsvReader reader = new CsvReader(StreamFromString("\"\",\"\"\"Around\"\"\",\"With\"\"in\",None,\"Many\"\"\"\"\"\nNextRow"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString("\"\",\"\"\"Around\"\"\",\"With\"\"in\",None,\"Many\"\"\"\"\"\nNextRow"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("|\"Around\"|With\"in|None|Many\"\"", string.Join("|", reader.Current()));
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Exception for unescaped quote not at cell end
-            using (CsvReader reader = new CsvReader(StreamFromString("\"Unescaped\"Quote,"), bufferSize))
+            using (var reader = new CsvReader(StreamFromString("\"Unescaped\"Quote,"), bufferSize))
             {
                 Assert.Throws<IOException>(() => reader.NextRow());
             }
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private int ParseFile(string filePath)
         {
-            using (CsvReader reader = new CsvReader(filePath))
+            using (var reader = new CsvReader(filePath))
             {
                 while (reader.NextRow())
                 { }

--- a/src/Test.UnitTests.Sarif.Converters/TextFormats/TsvReaderTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/TextFormats/TsvReaderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             int bufferSize = 64;
 
             // Empty file - verify no rows
-            using (TsvReader reader = new TsvReader(StreamFromString(""), bufferSize))
+            using (var reader = new TsvReader(StreamFromString(""), bufferSize))
             {
                 Assert.False(reader.NextRow());
 
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Single row file, no trailing newline
-            using (TsvReader reader = new TsvReader(StreamFromString("One\tTwo\tThree"), bufferSize))
+            using (var reader = new TsvReader(StreamFromString("One\tTwo\tThree"), bufferSize))
             {
                 Assert.Equal(0, reader.RowCountRead);
                 Assert.True(reader.NextRow());
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Empty values
-            using (TsvReader reader = new TsvReader(StreamFromString("\tValue\t\t"), bufferSize))
+            using (var reader = new TsvReader(StreamFromString("\tValue\t\t"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("|Value||", string.Join("|", reader.Current()));
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // Newline variation and trailing newline
-            using (TsvReader reader = new TsvReader(StreamFromString("One\nTwo\r\nThree\r\n"), bufferSize))
+            using (var reader = new TsvReader(StreamFromString("One\nTwo\r\nThree\r\n"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("One", string.Join("|", reader.Current()));
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // Row requiring a buffer resize and verify nothing is missed
             string oneHundredColumns = string.Join("\t", Enumerable.Range(100, 100).Select(i => i.ToString()));
-            using (TsvReader reader = new TsvReader(StreamFromString(oneHundredColumns), bufferSize))
+            using (var reader = new TsvReader(StreamFromString(oneHundredColumns), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal(100, reader.Current().Count);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // Value exactly 2x buffer, requiring two buffer resizes to be read
             string valueRequiringBufferExpand = new string('0', 128);
-            using (TsvReader reader = new TsvReader(StreamFromString($"One\tTwo\tThree\r\nSecond\tRow\r\n{valueRequiringBufferExpand}"), bufferSize))
+            using (var reader = new TsvReader(StreamFromString($"One\tTwo\tThree\r\nSecond\tRow\r\n{valueRequiringBufferExpand}"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal("One|Two|Three", string.Join("|", reader.Current()));
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             // '\r' exactly at buffer boundary, requiring refill to track the unread '\n' to ignore
-            using (TsvReader reader = new TsvReader(StreamFromString($"{new string('0', 63)}\r\nNextRow\r\n"), bufferSize))
+            using (var reader = new TsvReader(StreamFromString($"{new string('0', 63)}\r\nNextRow\r\n"), bufferSize))
             {
                 Assert.True(reader.NextRow());
                 Assert.Equal(new string('0', 63), string.Join("|", reader.Current()));
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private int ParseFile(string filePath)
         {
-            using (TsvReader reader = new TsvReader(filePath))
+            using (var reader = new TsvReader(filePath))
             {
                 while (reader.NextRow())
                 { }

--- a/src/Test.UnitTests.Sarif.Converters/ToolFileConverterBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/ToolFileConverterBaseTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Kind = LogicalLocationKind.Package
             };
 
-            Location location3 = new Location
+            var location3 = new Location
             {
                 LogicalLocation = new LogicalLocation
                 {

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/CommonOptionsBaseTests.cs
@@ -18,7 +18,7 @@ namespace Test.UnitTests.Sarif.Driver.Sdk
             FilePersistenceOptions loggingOptions;
 
             // Any case in which PrettyPrint is not specified should default to PrettyPrint.
-            TestAnalyzeOptions analyzeOptions = new TestAnalyzeOptions()
+            var analyzeOptions = new TestAnalyzeOptions()
             {
                 Quiet = true,
             };

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/ExportConfigurationCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/ExportConfigurationCommandBaseTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public static PropertiesDictionary CreateDefaultConfiguration()
         {
-            PropertiesDictionary configuration = new PropertiesDictionary();
+            var configuration = new PropertiesDictionary();
             string path = Path.GetTempFileName() + ".xml";
 
             try

--- a/src/Test.UnitTests.Sarif.Multitool.Library/BaselineOptionTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/BaselineOptionTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             int returnCode = new ValidateCommand().Run(options);
             returnCode.Should().Be(0);
 
-            SarifLog sarifLog = SarifLog.Load(outputPath);
+            var sarifLog = SarifLog.Load(outputPath);
             sarifLog.Runs.Count.Should().Be(1);
             sarifLog.Runs[0].Results.Count.Should().Be(1);
 
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             int returnCode = new ValidateCommand().Run(options);
             returnCode.Should().Be(0);
 
-            SarifLog sarifLog = SarifLog.Load(baselineFilePath);
+            var sarifLog = SarifLog.Load(baselineFilePath);
             sarifLog.Runs.Count.Should().Be(1);
             sarifLog.Runs[0].Results.Count.Should().Be(1);
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/ConvertCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/ConvertCommandTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;
-using Microsoft.CodeAnalysis.Sarif.Writers;
 
 using Moq;
 
@@ -42,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             File.Exists(outputFilePath).Should().BeTrue();
 
             // Verify log loads, has correct Result count, and spot check a Result
-            SarifLog log = SarifLog.Load(outputFilePath);
+            var log = SarifLog.Load(outputFilePath);
             log.Runs[0].Results.Count.Should().Be(8);
             log.Runs[0].Results[7].Locations[0].PhysicalLocation.Region.StartLine.Should().Be(40);
             log.Runs[0].Results[7].Locations[0].PhysicalLocation.Region.StartColumn.Should().Be(43);

--- a/src/Test.UnitTests.Sarif.Multitool.Library/ExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/ExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Fact]
         public void Extensions_Validate_RefersToDriver()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
 
             foreach (ToolComponentReferenceTestCase item in s_toolComponentReferenceTestCases)
             {

--- a/src/Test.UnitTests.Sarif.Multitool.Library/GenericCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/GenericCommandTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private void CheckTypeForDuplicateArgumentNames(Type type)
         {
-            Dictionary<char, Argument> parameters = new Dictionary<char, Argument>();
+            var parameters = new Dictionary<char, Argument>();
 
             foreach (PropertyInfo property in type.GetProperties())
             {
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private Argument ParseOptionAttribute(CustomAttributeData attribute)
         {
-            Argument result = new Argument();
+            var result = new Argument();
 
             foreach (CustomAttributeTypedArgument argument in attribute.ConstructorArguments)
             {

--- a/src/Test.UnitTests.Sarif.Multitool.Library/OptionsInterpretterTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/OptionsInterpretterTests.cs
@@ -2,20 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 using FluentAssertions;
 
-using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Readers;
-using Microsoft.CodeAnalysis.Sarif.VersionOne;
-
 using Moq;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 using Xunit;
 
@@ -29,9 +20,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             var mockEnvironmentVariableGetter = new Mock<IEnvironmentVariableGetter>();
             //  Don't setup any responses so they always return null
 
-            OptionsInterpretter optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
+            var optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
 
-            List<ValidateOptions> beforeAndAfter = new List<ValidateOptions>(2);
+            var beforeAndAfter = new List<ValidateOptions>(2);
 
             for (int i = 0; i < beforeAndAfter.Capacity; i++)
             {
@@ -63,9 +54,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             //  Deliberately more delimeters than needed
             mockEnvironmentVariableGetter.Setup(x => x.GetEnvironmentVariable("SARIF_LEVEL_ADDITION")).Returns("Note");
 
-            OptionsInterpretter optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
+            var optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
 
-            ValidateOptions analyzeOptionsBase = new ValidateOptions
+            var analyzeOptionsBase = new ValidateOptions
             {
                 DataToInsert = new List<OptionallyEmittedData> { OptionallyEmittedData.Hashes, OptionallyEmittedData.EnvironmentVariables },
                 DataToRemove = new List<OptionallyEmittedData> { OptionallyEmittedData.VersionControlDetails },

--- a/src/Test.UnitTests.Sarif.Multitool.Library/PageCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/PageCommandTests.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
 
             // Run the normal Page command
-            PageCommand command = new PageCommand(fileSystem);
+            var command = new PageCommand(fileSystem);
             command.RunWithoutCatch(options);
 
             // Rewrite indented
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             string actualUnindentedPath = Path.ChangeExtension(sourceFilePath, ".Paged.Actual.Unformatted.sarif");
 
             // Page with the Command
-            PageCommand command = new PageCommand();
+            var command = new PageCommand();
             command.RunWithoutCatch(new PageOptions() { InputFilePath = sourceFilePath, OutputFilePath = actualUnindentedPath, Index = index, Count = count });
 
             // Indent the Paged output
@@ -255,8 +255,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private static void Indent(string sourceFilePath, string outputPath)
         {
-            using (JsonTextReader reader = new JsonTextReader(new StreamReader(sourceFilePath)))
-            using (JsonTextWriter writer = new JsonTextWriter(File.CreateText(outputPath)))
+            using (var reader = new JsonTextReader(new StreamReader(sourceFilePath)))
+            using (var writer = new JsonTextWriter(File.CreateText(outputPath)))
             {
                 writer.Formatting = Newtonsoft.Json.Formatting.Indented;
                 reader.Read();
@@ -266,8 +266,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private static void PageManual(string sourceFilePath, string outputPath, int index, int count)
         {
-            using (JsonTextReader reader = new JsonTextReader(new StreamReader(sourceFilePath)))
-            using (JsonTextWriter writer = new JsonTextWriter(File.CreateText(outputPath)))
+            using (var reader = new JsonTextReader(new StreamReader(sourceFilePath)))
+            using (var writer = new JsonTextWriter(File.CreateText(outputPath)))
             {
                 writer.Formatting = Newtonsoft.Json.Formatting.Indented;
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/RebaseUriCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/RebaseUriCommandTests.cs
@@ -7,9 +7,6 @@ using System.Text;
 
 using FluentAssertions;
 
-using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
-using Microsoft.Extensions.Options;
-
 using Moq;
 
 using Newtonsoft.Json;
@@ -55,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             string inputSarifLog = JsonConvert.SerializeObject(sarifLog);
 
             string logFilePath = Path.Combine(Directory.GetCurrentDirectory(), "mylog.sarif");
-            StringBuilder transformedContents = new StringBuilder();
+            var transformedContents = new StringBuilder();
 
             RebaseUriOptions options = CreateDefaultOptions();
 
@@ -127,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             string inputSarifLog = GetInputSarifTextFromResource(testFilePath);
 
             string logFilePath = Path.Combine(Directory.GetCurrentDirectory(), "mylog.sarif");
-            StringBuilder transformedContents = new StringBuilder();
+            var transformedContents = new StringBuilder();
 
             options.TargetFileSpecifiers = new string[] { logFilePath };
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/RewriteCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/RewriteCommandTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             string inputSarifLog = GetInputSarifTextFromResource(testFilePath);
 
             string logFilePath = Path.Combine(Directory.GetCurrentDirectory(), "mylog.sarif");
-            StringBuilder transformedContents = new StringBuilder();
+            var transformedContents = new StringBuilder();
 
             this.options.InputFilePath = logFilePath;
             this.options.OutputFilePath = null;
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private void PrereleaseSarifLogVersionDiffersFromCurrent(string prereleaseV2Text)
         {
-            JObject sarifLog = JObject.Parse(prereleaseV2Text);
+            var sarifLog = JObject.Parse(prereleaseV2Text);
 
             ((string)sarifLog["$schema"]).Should().NotBe(SarifUtilities.SarifSchemaUri);
             ((string)sarifLog["version"]).Should().NotBe(SarifUtilities.StableSarifVersion);

--- a/src/Test.UnitTests.Sarif.Multitool/QueryCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool/QueryCommandTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         {
             public TestFixture()
             {
-                TestAssetResourceExtractor extractor = new TestAssetResourceExtractor(typeof(QueryCommandTests));
+                var extractor = new TestAssetResourceExtractor(typeof(QueryCommandTests));
                 File.WriteAllText(fileWithPropertyBag, extractor.GetResourceText(fileWithPropertyBag));
             }
         }

--- a/src/Test.UnitTests.Sarif.Multitool/RewriteCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool/RewriteCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 using CommandLine;
 

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
@@ -69,10 +69,10 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             string expectedTemplate = "[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:Warning]: TestRuleId: Test Rule (in al...)";
             string expected = $":Warning]: TestRuleId: Test Rule (in al" + new string('a', maxLength - expectedTemplate.Length) + "...)";
 
-            Result result = new Result();
-            ArtifactLocation artifactLocation = new ArtifactLocation(new Uri("al" + new string('a', 1024), UriKind.Relative), string.Empty, 0, new Message(), new Dictionary<string, SerializedPropertyInfo>());
-            PhysicalLocation physicalLocation = new PhysicalLocation(new Address(), artifactLocation, new Region(), new Region(), new Dictionary<string, SerializedPropertyInfo>());
-            Location location = new Location(0, physicalLocation, null, null, null, null, null);
+            var result = new Result();
+            var artifactLocation = new ArtifactLocation(new Uri("al" + new string('a', 1024), UriKind.Relative), string.Empty, 0, new Message(), new Dictionary<string, SerializedPropertyInfo>());
+            var physicalLocation = new PhysicalLocation(new Address(), artifactLocation, new Region(), new Region(), new Dictionary<string, SerializedPropertyInfo>());
+            var location = new Location(0, physicalLocation, null, null, null, null, null);
             result.Locations = new List<Location>();
             result.Locations.Add(location);
             result.RuleId = ruleId;
@@ -89,9 +89,9 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         [Fact]
         public void SarifWorkItemExtensions_CreateWorkItemTitle_LongTitleFromLogicalLocation()
         {
-            Result result = new Result();
-            LogicalLocation logicaLocation = new LogicalLocation(null, 0, string.Empty, null, 0, null, null);
-            Location location = new Location(0, null, new[] { logicaLocation }, null, null, null, null);
+            var result = new Result();
+            var logicaLocation = new LogicalLocation(null, 0, string.Empty, null, 0, null, null);
+            var location = new Location(0, null, new[] { logicaLocation }, null, null, null, null);
             result.Locations = new List<Location>();
             result.Locations.Add(location);
             result.RuleId = "TestRuleId";
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         [Fact]
         public void SarifWorkItemExtensions_PhraseToolNames_ConstructPhraseCorrectly()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
 
             foreach (PhraseToolNamesTestCase testCase in s_phraseToolNamesTestCases)
             {

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemFilerTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemFilerTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
-using Microsoft.CodeAnalysis.Sarif.VersionOne;
 using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
 using Microsoft.CodeAnalysis.WorkItems;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
@@ -325,10 +324,10 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         [Fact]
         public void WorkItemFiler_FileWorkItems_RelativeSarifLogPath()
         {
-            Uri uri = new Uri("path/to/sarif/log.sarif", UriKind.Relative);
+            var uri = new Uri("path/to/sarif/log.sarif", UriKind.Relative);
             SarifWorkItemContext context = CreateAzureDevOpsTestContext();
 
-            SarifWorkItemFiler filer = new SarifWorkItemFiler(context.HostUri, context);
+            var filer = new SarifWorkItemFiler(context.HostUri, context);
             Assert.Throws<ArgumentException>(() => filer.FileWorkItems(uri));
         }
 
@@ -352,8 +351,8 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             string bugUriText = "https://example.com/" + Guid.NewGuid().ToString();
             string bugHtmlUriText = "https://example.com/" + Guid.NewGuid().ToString();
 
-            Uri bugUri = new Uri(bugUriText, UriKind.RelativeOrAbsolute);
-            Uri bugHtmlUri = new Uri(bugHtmlUriText, UriKind.RelativeOrAbsolute);
+            var bugUri = new Uri(bugUriText, UriKind.RelativeOrAbsolute);
+            var bugHtmlUri = new Uri(bugHtmlUriText, UriKind.RelativeOrAbsolute);
 
             workItem.Url = bugUriText;
             workItem.Links.AddLink("html", bugHtmlUriText);
@@ -513,7 +512,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         private static FilingClient CreateGitHubMocksAndFilingClient(string bugUriText, string bugHtmlUriText, SarifWorkItemFiler filer)
         {
             FilingClient filingClient;
-            Issue testGithubIssue = new Issue(bugUriText, bugHtmlUriText, bugUriText + "comments", bugUriText + "events",
+            var testGithubIssue = new Issue(bugUriText, bugHtmlUriText, bugUriText + "comments", bugUriText + "events",
                                               111111, ItemState.Open, "TestTitle", "TestBody", new User(), new User(), null, new User(), null, new Milestone(1), 0, new PullRequest(), null,
                                               new DateTimeOffset(DateTime.Now), null, 111111, null, false, null, null);
 

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemModelTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemModelTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 
 using FluentAssertions;
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ExactMatchers/FullFingerprintMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ExactMatchers/FullFingerprintMatcherTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
             resultA.Fingerprints = new Dictionary<string, string>() { { "FingerprintAlgorithm1", "FingerprintValue1" }, { "FingerprintAlgorithm2", "FingerprintValue2" } };
             resultB.Fingerprints = new Dictionary<string, string>() { { "FingerprintAlgorithm1", "FingerprintValue1" } };
 
-            ExtractedResult matchingResultA = new ExtractedResult(resultA, null);
-            ExtractedResult matchingResultB = new ExtractedResult(resultB, null);
+            var matchingResultA = new ExtractedResult(resultA, null);
+            var matchingResultB = new ExtractedResult(resultB, null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { matchingResultA }, new ExtractedResult[] { matchingResultB });
 
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
             resultA.Fingerprints = new Dictionary<string, string>() { { "FingerprintAlgorithm1", "FingerprintValue1" }, { "FingerprintAlgorithm2", "FingerprintValue2" } };
             resultB.Fingerprints = new Dictionary<string, string>() { { "FingerprintAlgorithm1", "FingerprintValue3" }, { "FingerprintAlgorithm2", "FingerprintValue4" } };
 
-            ExtractedResult matchingResultA = new ExtractedResult(resultA, null);
-            ExtractedResult matchingResultB = new ExtractedResult(resultB, null);
+            var matchingResultA = new ExtractedResult(resultA, null);
+            var matchingResultB = new ExtractedResult(resultB, null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { matchingResultA }, new ExtractedResult[] { matchingResultB });
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ExactMatchers/IdenticalResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ExactMatchers/IdenticalResultMatcherTests.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_MatchesIdenticalResults_Single()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
-            ExtractedResult resultB = new ExtractedResult(resultA.Result.DeepClone(), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultB = new ExtractedResult(resultA.Result.DeepClone(), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultA }, new ExtractedResult[] { resultB });
 
@@ -31,10 +31,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_MatchesIdenticalResults_Multiple()
         {
-            ExtractedResult resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
-            ExtractedResult resultBA = new ExtractedResult(resultAA.Result.DeepClone(), null);
-            ExtractedResult resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
-            ExtractedResult resultBB = new ExtractedResult(resultAB.Result.DeepClone(), null);
+            var resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultBA = new ExtractedResult(resultAA.Result.DeepClone(), null);
+            var resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
+            var resultBB = new ExtractedResult(resultAB.Result.DeepClone(), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultAA, resultAB }, new ExtractedResult[] { resultBA, resultBB });
 
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_DoesNotMatchDifferentResults_Single()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultA }, new ExtractedResult[] { resultB });
 
@@ -57,10 +57,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_DoesNotMatchDifferentResults_Multiple()
         {
-            ExtractedResult resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context1"), null);
-            ExtractedResult resultBA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
-            ExtractedResult resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context3"), null);
-            ExtractedResult resultBB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context4"), null);
+            var resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context1"), null);
+            var resultBA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
+            var resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context3"), null);
+            var resultBB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context4"), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultAA, resultAB }, new ExtractedResult[] { resultBA, resultBB });
 
@@ -70,13 +70,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_MatchesResults_DifferingOnIdOrStatus_Single()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
 
             Result changedResultA = resultA.Result.DeepClone();
             changedResultA.CorrelationGuid = Guid.NewGuid();
             changedResultA.BaselineState = BaselineState.Unchanged;
 
-            ExtractedResult resultB = new ExtractedResult(changedResultA, null);
+            var resultB = new ExtractedResult(changedResultA, null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultA }, new ExtractedResult[] { resultB });
 
@@ -88,20 +88,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_MatchesResults_DifferingOnIdOrStatus_Multiple()
         {
-            ExtractedResult resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
 
             Result changedResultA = resultAA.Result.DeepClone();
             changedResultA.CorrelationGuid = Guid.NewGuid();
             changedResultA.BaselineState = BaselineState.Unchanged;
 
-            ExtractedResult resultBA = new ExtractedResult(changedResultA, null);
-            ExtractedResult resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
+            var resultBA = new ExtractedResult(changedResultA, null);
+            var resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
 
             Result changedResultB = resultAB.Result.DeepClone();
             changedResultA.CorrelationGuid = Guid.NewGuid();
             changedResultA.BaselineState = BaselineState.New;
 
-            ExtractedResult resultBB = new ExtractedResult(changedResultB, null);
+            var resultBB = new ExtractedResult(changedResultB, null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultAA, resultAB }, new ExtractedResult[] { resultBA, resultBB });
 
@@ -113,22 +113,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.ExactMatchers
         [Fact]
         public void IdenticalResultMatcher_MatchesResults_DifferingOnResultMatchingProperties_Multiple()
         {
-            ExtractedResult resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
+            var resultAA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context"), null);
 
             Result changedResultA = resultAA.Result.DeepClone();
             changedResultA.CorrelationGuid = Guid.NewGuid();
             changedResultA.BaselineState = BaselineState.Unchanged;
             changedResultA.SetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, new Dictionary<string, string> { { "property", "value" } });
 
-            ExtractedResult resultBA = new ExtractedResult(changedResultA, null);
-            ExtractedResult resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
+            var resultBA = new ExtractedResult(changedResultA, null);
+            var resultAB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test", "file://test2", "test context2"), null);
 
             Result changedResultB = resultAB.Result.DeepClone();
             changedResultA.CorrelationGuid = Guid.NewGuid();
             changedResultA.BaselineState = BaselineState.New;
 
             changedResultB.SetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, new Dictionary<string, string> { { "property1", "value1" } });
-            ExtractedResult resultBB = new ExtractedResult(changedResultB, null);
+            var resultBB = new ExtractedResult(changedResultB, null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new ExtractedResult[] { resultAA, resultAB }, new ExtractedResult[] { resultBA, resultBB });
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/HeuristicMatchers/ContextRegionResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/HeuristicMatchers/ContextRegionResultMatcherTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void ContextRegionHeuristicMatcher_NoRegion_DoesNotMatchResults()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, null), null);
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, null), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, null), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, null), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new List<ExtractedResult>() { resultA }, new List<ExtractedResult>() { resultB });
 
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void ContextRegionHeuristicMatcher_DifferentRegion_DoesNotMatchResults()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, "test one"), null);
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, "test two"), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, "test one"), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, "test two"), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new List<ExtractedResult>() { resultA }, new List<ExtractedResult>() { resultB });
 
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void ContextRegionHeuristicMatcher_SameRegion_MatchesResults()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, "region contents"), null);
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, "region contents"), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null, "region contents"), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null, "region contents"), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new List<ExtractedResult>() { resultA }, new List<ExtractedResult>() { resultB });
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/HeuristicMatchers/PartialFingerprintResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/HeuristicMatchers/PartialFingerprintResultMatcherTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void PartialFingerprintResultMatcher_WithoutPartialFingerprints_DoesNotMatch()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
 
             IEnumerable<MatchedResults> matchedResults = matcher.Match(new List<ExtractedResult>() { resultA }, new List<ExtractedResult>() { resultB });
 
@@ -27,11 +27,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void PartialFingerprintResultMatcher_DifferentPartialFingerprints_DoesNotMatch()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
 
             resultA.Result.PartialFingerprints = new Dictionary<string, string>() { { "Fingerprint1", "Value1" } };
 
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
 
             resultA.Result.PartialFingerprints = new Dictionary<string, string>() { { "Fingerprint1", "Value2" } };
 
@@ -43,11 +43,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching.HeuristicMatchers
         [Fact]
         public void PartialFingerprintResultMatcher_SamePartialFingerprints_Matches()
         {
-            ExtractedResult resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
+            var resultA = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test1", "file://test2", null), null);
 
             resultA.Result.PartialFingerprints = new Dictionary<string, string>() { { "Fingerprint1", "Value1" } };
 
-            ExtractedResult resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
+            var resultB = new ExtractedResult(ResultMatchingTestHelpers.CreateMatchingResult("file://test3", "file://test4", null), null);
 
             resultA.Result.PartialFingerprints = new Dictionary<string, string>() { { "Fingerprint1", "Value1" } };
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ResultMatchingBaselinerTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ResultMatchingBaselinerTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             baselineLog.Runs[0].Tool.Driver.Name = "Test1";
             currentLog.Runs[0].Tool.Driver.Name = "Test2";
 
-            var exception = Record.Exception(() => baseliner.Match(new SarifLog[] { baselineLog }, new SarifLog[] { currentLog }).First());
+            Exception exception = Record.Exception(() => baseliner.Match(new SarifLog[] { baselineLog }, new SarifLog[] { currentLog }).First());
             Assert.Null(exception);
         }
 

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ResultMatchingTestHelpers.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/ResultMatchingTestHelpers.cs
@@ -5,11 +5,11 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 {
-    static class ResultMatchingTestHelpers
+    internal static class ResultMatchingTestHelpers
     {
         public static Result CreateMatchingResult(string target, string location, string regionContent, string contextRegionContent = null)
         {
-            Result result = new Result()
+            var result = new Result()
             {
                 RuleId = "TEST001",
                 Level = FailureLevel.Error,

--- a/src/Test.UnitTests.Sarif/Baseline/ResultMatching/SarifLogResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/ResultMatching/SarifLogResultMatcherTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
             SarifLog baselineLog = RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, 1);
-            SarifLog currentLog = new SarifLog();
+            var currentLog = new SarifLog();
             currentLog.Runs = new Run[] { new Run() };
             baselineLog.Runs[0].AutomationDetails = new RunAutomationDetails { Guid = Guid.NewGuid() };
 
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         [Fact]
         public void SarifLogResultMatcher_MultipleLogsDuplicateData_WorksAsExpected()
         {
-            SarifLog current1 = new SarifLog()
+            var current1 = new SarifLog()
             {
                 Runs = new Run[]
                 {

--- a/src/Test.UnitTests.Sarif/Baseline2/ExtractedResultTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/ExtractedResultTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void WhatComparer_MatchesCategory()
         {
-            Run run = new Run()
+            var run = new Run()
             {
                 Tool = new Tool()
                 {

--- a/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline2
                 ExtractedResult currentExtracted = testCase.CurrentResult != null
                     ? new ExtractedResult(testCase.CurrentResult, testCase.CurrentRun)
                     : null;
-                MatchedResults matchedResults = new MatchedResults(previousExtracted, currentExtracted);
+                var matchedResults = new MatchedResults(previousExtracted, currentExtracted);
 
                 Result result = matchedResults.CalculateBasedlinedResult(DictionaryMergeBehavior.InitializeFromMostRecent /* arbitrary */);
 

--- a/src/Test.UnitTests.Sarif/Baseline2/OverallBaseliningTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/OverallBaseliningTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using FluentAssertions;

--- a/src/Test.UnitTests.Sarif/Baseline2/TrustMapTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/TrustMapTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         public void TrustMap_Basics()
         {
             // Create a TrustMap for both of the Runs being compared
-            TrustMap beforeMap = new TrustMap();
-            TrustMap afterMap = new TrustMap();
+            var beforeMap = new TrustMap();
+            var afterMap = new TrustMap();
 
             // All properties are unknown to start
             beforeMap.Trust(Set, NameGreat).Should().Be(TrustMap.DefaultTrust);

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -393,7 +393,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
 
         private void SetResultRuleIndexOnly(Run run)
         {
-            Dictionary<string, int> ruleIndexByRuleId = new Dictionary<string, int>();
+            var ruleIndexByRuleId = new Dictionary<string, int>();
 
             for (int i = 0; i < run.Tool.Driver.Rules.Count; ++i)
             {
@@ -415,9 +415,9 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void ResultMatchingBaseliner_WhenThereIsOnlyOneCurrentRun_CopiesSelectedRunData()
         {
-            DateTime firstDetectionTime = new DateTime(2019, 10, 7, 12, 13, 14);
+            var firstDetectionTime = new DateTime(2019, 10, 7, 12, 13, 14);
 
-            Run originalRun = new Run
+            var originalRun = new Run
             {
                 Tool = new Tool
                 {

--- a/src/Test.UnitTests.Sarif/Baseline2/WhatComparerTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/WhatComparerTests.cs
@@ -19,11 +19,11 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void WhatComparer_Basics()
         {
-            Run run = new Run();
-            Result left = new Result { RuleId = "Rule1", Message = new Message() { Text = "One" }, Run = run };
-            Result right = new Result { RuleId = "Rule1", Message = new Message() { Text = "Two" }, Run = run };
-            ExtractedResult eLeft = new ExtractedResult(left, run);
-            ExtractedResult eRight = new ExtractedResult(right, run);
+            var run = new Run();
+            var left = new Result { RuleId = "Rule1", Message = new Message() { Text = "One" }, Run = run };
+            var right = new Result { RuleId = "Rule1", Message = new Message() { Text = "Two" }, Run = run };
+            var eLeft = new ExtractedResult(left, run);
+            var eRight = new ExtractedResult(right, run);
 
             // GUIDs
             // =====
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             WhatComparer.MatchesWhat(eLeft, eRight).Should().BeTrue();
 
             // Verify snippets must also match.
-            Location location = new Location
+            var location = new Location
             {
                 PhysicalLocation = new PhysicalLocation
                 {

--- a/src/Test.UnitTests.Sarif/Baseline2/WhereComparerTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/WhereComparerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             // Reminder: CompareTo less than zero means left sorts before right.
             5.CompareTo(10).Should().BeLessThan(0);
 
-            Region left = new Region(SampleRegion);
+            var left = new Region(SampleRegion);
             Region right;
 
             // Equal
@@ -109,15 +109,15 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void WhereComparer_ArtifactLocation()
         {
-            Run run = new Run();
+            var run = new Run();
             run.Artifacts = new List<Artifact>();
 
             run.Artifacts.Add(new Artifact() { Location = new ArtifactLocation() });
             run.Artifacts.Add(new Artifact() { Location = ArtifactLocationUri1 });
             run.Artifacts.Add(new Artifact() { Location = ArtifactLocationUri2 });
 
-            ArtifactLocation left = new ArtifactLocation(ArtifactLocationUri1);
-            ArtifactLocation right = new ArtifactLocation(ArtifactLocationUri2);
+            var left = new ArtifactLocation(ArtifactLocationUri1);
+            var right = new ArtifactLocation(ArtifactLocationUri2);
 
             // Equal; run not needed if no index provided.
             WhereComparer.CompareTo(left, null, left, null).Should().Be(0);
@@ -147,12 +147,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void WhereComparer_PhysicalLocation()
         {
-            PhysicalLocation left = new PhysicalLocation
+            var left = new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation() { Uri = Uri1 }
             };
 
-            PhysicalLocation right = new PhysicalLocation
+            var right = new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation { Uri = Uri2 }
             };
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             WhereComparer.CompareTo(left, null, right, null).Should().BeLessThan(0);
 
             left.Region = SampleRegion;
-            PhysicalLocation leftLater = new PhysicalLocation(left) { Region = new Region(SampleRegion) { StartLine = SampleRegion.StartLine + 1 } };
+            var leftLater = new PhysicalLocation(left) { Region = new Region(SampleRegion) { StartLine = SampleRegion.StartLine + 1 } };
 
             // Sort by Region if Uris match
             WhereComparer.CompareTo(left, null, leftLater, null).Should().BeLessThan(0);
@@ -188,14 +188,14 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void WhereComparer_ListOfLogicalLocation()
         {
-            List<LogicalLocation> empty = new List<LogicalLocation>();
+            var empty = new List<LogicalLocation>();
 
-            List<LogicalLocation> left = new List<LogicalLocation>
+            var left = new List<LogicalLocation>
             {
                 LogicalLocation1
             };
 
-            List<LogicalLocation> right = new List<LogicalLocation>
+            var right = new List<LogicalLocation>
             {
                 LogicalLocation1,
                 LogicalLocation2
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             WhereComparer.CompareTo(left, null, right, null).Should().BeLessThan(0);
 
             // Later location wins over longer list
-            List<LogicalLocation> three = new List<LogicalLocation> { LogicalLocation2 };
+            var three = new List<LogicalLocation> { LogicalLocation2 };
             WhereComparer.CompareTo(right, null, three, null).Should().BeLessThan(0);
         }
     }

--- a/src/Test.UnitTests.Sarif/CacheTests.cs
+++ b/src/Test.UnitTests.Sarif/CacheTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         public void CacheBasics()
         {
             int buildCount = 0;
-            Cache<int, int> cache = new Cache<int, int>(
+            var cache = new Cache<int, int>(
                 (key) => { buildCount++; return 10 * key; },
                 capacity: 2);
 

--- a/src/Test.UnitTests.Sarif/Comparers/ComparersTests.cs
+++ b/src/Test.UnitTests.Sarif/Comparers/ComparersTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Test.UnitTests.Sarif/Core/ArtifactLocationTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ArtifactLocationTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 Uri = new Uri(SourceFile, UriKind.Relative)
             };
 
-            Location location = artifactLocation.ToLocation(lineNumber: 12, column: 9, length: 14, offset: 140);
+            var location = artifactLocation.ToLocation(lineNumber: 12, column: 9, length: 14, offset: 140);
 
             PhysicalLocation physicalLocation = location.PhysicalLocation;
             physicalLocation.ArtifactLocation.Uri.OriginalString.Should().Be(SourceFile);

--- a/src/Test.UnitTests.Sarif/Core/ArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ArtifactTests.cs
@@ -33,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         {
             string filePath = Path.GetTempFileName();
             string fileContents = Guid.NewGuid().ToString();
-            Uri uri = new Uri(filePath);
+            var uri = new Uri(filePath);
 
             try
             {
                 File.WriteAllText(filePath, fileContents);
-                Artifact fileData = Artifact.Create(uri, OptionallyEmittedData.Hashes);
+                var fileData = Artifact.Create(uri, OptionallyEmittedData.Hashes);
                 fileData.Location.Should().Be(null);
                 HashData hashes = HashUtilities.ComputeHashes(filePath);
                 fileData.Contents.Should().BeNull();
@@ -82,12 +82,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         {
             string filePath = Path.GetTempFileName() + fileExtension;
             string fileContents = Guid.NewGuid().ToString();
-            Uri uri = new Uri(filePath);
+            var uri = new Uri(filePath);
 
             try
             {
                 File.WriteAllText(filePath, fileContents);
-                Artifact fileData = Artifact.Create(uri, dataToInsert);
+                var fileData = Artifact.Create(uri, dataToInsert);
                 fileData.Location.Should().BeNull();
 
                 if (dataToInsert.HasFlag(OptionallyEmittedData.Hashes))
@@ -134,12 +134,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             string textValue = "अचम्भा";
             byte[] fileContents = encoding.GetBytes(textValue);
 
-            Uri uri = new Uri(filePath);
+            var uri = new Uri(filePath);
 
             try
             {
                 File.WriteAllBytes(filePath, fileContents);
-                Artifact fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles, encoding: encoding);
+                var fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles, encoding: encoding);
                 fileData.Location.Should().Be(null);
                 fileData.Hashes.Should().BeNull();
 
@@ -158,8 +158,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             // If a file does not exist, and we request file contents
             // persistence, the logger will not raise an exception
             string filePath = Path.GetTempFileName();
-            Uri uri = new Uri(filePath);
-            Artifact fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles);
+            var uri = new Uri(filePath);
+            var fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles);
             fileData.Location.Should().Be(null);
             fileData.Hashes.Should().BeNull();
             fileData.Contents.Should().BeNull();
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         public void Artifact_FileIsLocked()
         {
             string filePath = Path.GetTempFileName();
-            Uri uri = new Uri(filePath);
+            var uri = new Uri(filePath);
 
             try
             {
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 // This raises an IOException, which is swallowed by FileData.Create
                 using (FileStream exclusiveAccessReader = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
                 {
-                    Artifact fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles);
+                    var fileData = Artifact.Create(uri, OptionallyEmittedData.TextFiles);
                     fileData.Location.Should().Be(null);
                     fileData.Hashes.Should().BeNull();
                     fileData.Contents.Should().BeNull();
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void Artifact_SerializeSingleFileRole()
         {
-            Artifact fileData = Artifact.Create(new Uri("file:///example.cs"), OptionallyEmittedData.None);
+            var fileData = Artifact.Create(new Uri("file:///example.cs"), OptionallyEmittedData.None);
             fileData.Roles = ArtifactRoles.AnalysisTarget;
 
             string result = JsonConvert.SerializeObject(fileData);
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void Artifact_SerializeMultipleFileRoles()
         {
-            Artifact fileData = Artifact.Create(new Uri("file:///example.cs"), OptionallyEmittedData.None);
+            var fileData = Artifact.Create(new Uri("file:///example.cs"), OptionallyEmittedData.None);
             fileData.Roles = ArtifactRoles.ResponseFile | ArtifactRoles.ResultFile;
 
             string actual = JsonConvert.SerializeObject(fileData);
@@ -226,14 +226,14 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void Artifact_DeserializeSingleFileRole()
         {
-            Artifact actual = JsonConvert.DeserializeObject("{\"roles\":[\"analysisTarget\"]}", typeof(Artifact)) as Artifact;
+            var actual = JsonConvert.DeserializeObject("{\"roles\":[\"analysisTarget\"]}", typeof(Artifact)) as Artifact;
             actual.Roles.Should().Be(ArtifactRoles.AnalysisTarget);
         }
 
         [Fact]
         public void Artifact_DeserializeMultipleFileRoles()
         {
-            Artifact actual = JsonConvert.DeserializeObject("{\"roles\":[\"responseFile\",\"resultFile\"]}", typeof(Artifact)) as Artifact;
+            var actual = JsonConvert.DeserializeObject("{\"roles\":[\"responseFile\",\"resultFile\"]}", typeof(Artifact)) as Artifact;
             actual.Roles.Should().Be(ArtifactRoles.ResponseFile | ArtifactRoles.ResultFile);
         }
 
@@ -241,11 +241,11 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         {
             string extension = isTextFile ? ".cs" : ".dll";
             string filePath = Path.GetFullPath(Guid.NewGuid().ToString()) + extension;
-            Uri uri = new Uri(filePath);
+            var uri = new Uri(filePath);
 
             IFileSystem fileSystem = SetUnauthorizedAccessExceptionMock();
 
-            Artifact fileData = Artifact.Create(
+            var fileData = Artifact.Create(
                 uri,
                 OptionallyEmittedData.TextFiles,
                 encoding: null,

--- a/src/Test.UnitTests.Sarif/Core/LocationTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/LocationTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Numerics;
 
 using FluentAssertions;

--- a/src/Test.UnitTests.Sarif/Core/PropertyBagHolderTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/PropertyBagHolderTests.cs
@@ -297,8 +297,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 
     internal static class ExtensionsForPropertyBagHolderTests
     {
-        const string PropertyName = "prop";
-        const string Input = "{\"properties\":{\"" + PropertyName + "\":12}}";
+        private const string PropertyName = "prop";
+        private const string Input = "{\"properties\":{\"" + PropertyName + "\":12}}";
 
         internal static void ShouldSerializeAs<T>(this T value, string serializedValue)
         {

--- a/src/Test.UnitTests.Sarif/Core/ReportingDescriptorTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ReportingDescriptorTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void ShouldSerializeShortDescription_CorrectlyHandlesNullAndEmptyValues()
         {
-            ReportingDescriptor reportingDescriptor = new ReportingDescriptor()
+            var reportingDescriptor = new ReportingDescriptor()
             {
                 ShortDescription = null,
                 FullDescription = null
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void ShouldSerializeShortDescription_FalseForIdenticalStrings()
         {
-            ReportingDescriptor reportingDescriptor = new ReportingDescriptor()
+            var reportingDescriptor = new ReportingDescriptor()
             {
                 ShortDescription = new MultiformatMessageString() { Text = "EasyFalse1" },
                 FullDescription = new MultiformatMessageString() { Text = "EasyFalse1" }

--- a/src/Test.UnitTests.Sarif/Core/RunTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/RunTests.cs
@@ -496,8 +496,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         public void Run_ShouldSerializeAutomationDetails_WhenAnyPropertyIsValid()
         {
             const string id = "automation-id";
-            Guid guid = Guid.Parse("8b02f0b8-6df5-40b2-9e93-5404e56676e2");
-            Guid correlationGuid = Guid.Parse("3d468dd8-3c62-45ed-b86a-a4fe9da93dd9");
+            var guid = Guid.Parse("8b02f0b8-6df5-40b2-9e93-5404e56676e2");
+            var correlationGuid = Guid.Parse("3d468dd8-3c62-45ed-b86a-a4fe9da93dd9");
 
             var sarifLog = new SarifLog
             {
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 
         private ToolComponent CreateToolComponent(string name, int rulesCount, FailureLevel failureLevel)
         {
-            ToolComponent toolComponent = new ToolComponent();
+            var toolComponent = new ToolComponent();
             toolComponent.Name = name;
             toolComponent.Rules = new ReportingDescriptor[rulesCount];
             for (int i = 0; i < rulesCount; i++)

--- a/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SerializedPropertyInfoTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void SerializedPropertyInfo_ComparerTests()
         {
-            Guid testGuid = Guid.NewGuid();
+            var testGuid = Guid.NewGuid();
             DateTime now = DateTime.UtcNow;
 
             var testCases = new[]

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         public void Stack_CreateFromStackTrace()
         {
             var dotNetStack = new StackTrace();
-            Stack stack = new Stack(dotNetStack);
+            var stack = new Stack(dotNetStack);
 
             // The .NET StackTrace.ToString() override must preserve a trailing NewLine
             // for compatibility reasons. We do not retain this behavior in ToString()

--- a/src/Test.UnitTests.Sarif/Core/ToolTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ToolTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Core
         [Fact]
         public void Tool_ParseFileVersion_ExtractsDottedQuadFileVersion()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
 
             foreach (DottedQuadFileVersionTestCase testCase in s_dottedQuadFileVersionTestCases)
             {

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -26,7 +26,7 @@ Accept-Language: en, mi
 
 ";
 
-            WebRequest webRequest = WebRequest.Parse(RequestString);
+            var webRequest = WebRequest.Parse(RequestString);
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
@@ -54,7 +54,7 @@ This is the body.
 Line 2.
 ";
 
-            WebRequest webRequest = WebRequest.Parse(RequestString);
+            var webRequest = WebRequest.Parse(RequestString);
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
@@ -78,7 +78,7 @@ User-Agent: my-agent
 
 ";
 
-            WebRequest webRequest = WebRequest.Parse(RequestString);
+            var webRequest = WebRequest.Parse(RequestString);
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt?verbose=true&debug=false");
@@ -104,7 +104,7 @@ User-Agent: my-agent
 
 ";
 
-            WebRequest webRequest = WebRequest.Parse(RequestString);
+            var webRequest = WebRequest.Parse(RequestString);
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt?this-query-is-a-parameter-without-value");

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -31,7 +31,7 @@ Content-Type: text/plain
 Hello World!My payload includes a trailing NewLine.
 ";
 
-            WebResponse webResponse = WebResponse.Parse(ResponseString);
+            var webResponse = WebResponse.Parse(ResponseString);
 
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");
@@ -60,7 +60,7 @@ Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
 
 ";
 
-            WebResponse webResponse = WebResponse.Parse(ResponseString);
+            var webResponse = WebResponse.Parse(ResponseString);
 
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");

--- a/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
+++ b/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
@@ -399,9 +399,9 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
             var run = new Run();
             var fileRegionsCache = new FileRegionsCache();
 
-            Uri uri = new Uri(@"c:\temp\DoesNotExist\" + Guid.NewGuid().ToString() + ".cpp");
+            var uri = new Uri(@"c:\temp\DoesNotExist\" + Guid.NewGuid().ToString() + ".cpp");
 
-            Region region = new Region() { CharOffset = 17 };
+            var region = new Region() { CharOffset = 17 };
 
             // Region should not be touched in any way if the file it references is missing
             fileRegionsCache.PopulateTextRegionProperties(region, uri, populateSnippet: false).ValueEquals(region).Should().BeTrue();
@@ -412,15 +412,15 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         public void FileRegionsCache_PopulatesUsingProvidedText()
         {
             var fileRegionsCache = new FileRegionsCache();
-            Uri uri = new Uri(@"c:\temp\DoesNotExist\" + Guid.NewGuid().ToString() + ".cpp");
+            var uri = new Uri(@"c:\temp\DoesNotExist\" + Guid.NewGuid().ToString() + ".cpp");
             string fileText = "12345\n56790\n";
             int charOffset = 6;
             int charLength = 1;
 
             // Region should grab the second line of text in 'fileText'.
-            Region region = new Region() { CharOffset = charOffset, CharLength = charLength };
+            var region = new Region() { CharOffset = charOffset, CharLength = charLength };
 
-            Region expected = new Region()
+            var expected = new Region()
             {
                 CharOffset = charOffset,
                 CharLength = charLength,
@@ -591,7 +591,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
             Exception exception = Record.Exception(() =>
             {
                 var fileRegionsCache = new FileRegionsCache();
-                List<Task> taskList = new List<Task>();
+                var taskList = new List<Task>();
 
                 for (int i = 0; i < 1_000; i++)
                 {
@@ -606,7 +606,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
 
         private static void ExecuteTests(string fileText, ReadOnlyCollection<TestCaseData> testCases)
         {
-            Uri uri = new Uri(@"c:\temp\myFile.cpp");
+            var uri = new Uri(@"c:\temp\myFile.cpp");
 
             var run = new Run();
             IFileSystem mockFileSystem = MockFactory.MakeMockFileSystem(uri.LocalPath, fileText);
@@ -653,19 +653,19 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         [Fact(Skip = "Flaky test. Results vary depending on environment.")]
         public void FileRegionsCache_ProperlyCaches()
         {
-            Uri uri = new Uri(@"C:\Code\Program.cs");
+            var uri = new Uri(@"C:\Code\Program.cs");
 
-            StringBuilder fileContents = new StringBuilder();
+            var fileContents = new StringBuilder();
             for (int i = 0; i < 1000; ++i)
             {
                 fileContents.AppendLine("0123456789");
             }
 
-            Run run = new Run();
+            var run = new Run();
             IFileSystem mockFileSystem = MockFactory.MakeMockFileSystem(uri.LocalPath, fileContents.ToString());
-            FileRegionsCache fileRegionsCache = new FileRegionsCache(fileSystem: mockFileSystem);
+            var fileRegionsCache = new FileRegionsCache(fileSystem: mockFileSystem);
 
-            Region region = new Region()
+            var region = new Region()
             {
                 StartLine = 2,
                 StartColumn = 1,
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
                 EndColumn = 10,
             };
 
-            Stopwatch w = Stopwatch.StartNew();
+            var w = Stopwatch.StartNew();
 
             for (int i = 0; i < 1000; ++i)
             {
@@ -691,7 +691,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         [Fact]
         public void FileRegionsCache_PopulatesNullRegion()
         {
-            Uri uri = new Uri(@"c:\temp\myFile.cpp");
+            var uri = new Uri(@"c:\temp\myFile.cpp");
 
             var run = new Run();
             IFileSystem mockFileSystem = MockFactory.MakeMockFileSystem(uri.LocalPath, SPEC_EXAMPLE);
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         [Fact]
         public void FileRegionsCache_IncreasingToLeftAndRight()
         {
-            Uri uri = new Uri(@"c:\temp\myFile.cpp");
+            var uri = new Uri(@"c:\temp\myFile.cpp");
             string fileContent = $"{new string('a', 200)}{new string('b', 800)}";
 
             var region = new Region

--- a/src/Test.UnitTests.Sarif/JsonTests.cs
+++ b/src/Test.UnitTests.Sarif/JsonTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         protected static string GetJson(Action<ResultLogJsonWriter> testContent)
         {
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             using (var str = new StringWriter(result))
             using (var json = new JsonTextWriter(str) { Formatting = Formatting.Indented, DateTimeZoneHandling = DateTimeZoneHandling.Utc })
             using (var uut = new ResultLogJsonWriter(json))

--- a/src/Test.UnitTests.Sarif/Map/LongArrayDeltaConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Map/LongArrayDeltaConverterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
 
         private static void RoundTrip(long[] values)
         {
-            Container before = new Container();
+            var before = new Container();
             if (values != null)
             {
                 before.Values = new List<long>(values);
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
 
             string serialized = JsonConvert.SerializeObject(before);
 
-            Container after = (Container)JsonConvert.DeserializeObject(serialized, typeof(Container));
+            var after = (Container)JsonConvert.DeserializeObject(serialized, typeof(Container));
             Assert.Equal(values, after.Values);
         }
     }

--- a/src/Test.UnitTests.Sarif/OrderSensitiveValueComparisonListTests.cs
+++ b/src/Test.UnitTests.Sarif/OrderSensitiveValueComparisonListTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
             var fileChangeTwo = new ArtifactChange();
 
             var fileChangeThree = new ArtifactChange();
-            Guid differentiatingProperty = Guid.NewGuid();
+            var differentiatingProperty = Guid.NewGuid();
             fileChangeThree.SetProperty(DIFFERENTIATING_PROPERTY_NAME, differentiatingProperty);
 
             var list = new OrderSensitiveValueComparisonList<ArtifactChange>(equalityComparer);

--- a/src/Test.UnitTests.Sarif/Processors/GenericTests/GenericProcessorTests.cs
+++ b/src/Test.UnitTests.Sarif/Processors/GenericTests/GenericProcessorTests.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
     {
         private List<int> GenerateRandomIntList()
         {
-            Random r = new Random();
+            var r = new Random();
             int size = r.Next(1, 100);
-            List<int> list = new List<int>(size);
+            var list = new List<int>(size);
             for (int i = 0; i < size; i++)
             {
                 list.Add(r.Next());
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         {
             List<int> list = GenerateRandomIntList();
 
-            TestMappingProcessor testMapper = new TestMappingProcessor();
+            var testMapper = new TestMappingProcessor();
 
             IEnumerable<int> mappedList = testMapper.Map(list.AsEnumerable());
 
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         {
             List<int> list = GenerateRandomIntList();
 
-            TestFoldProcessor testFold = new TestFoldProcessor();
+            var testFold = new TestFoldProcessor();
 
             int result = testFold.Fold(list.AsEnumerable());
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         {
             List<int> list = GenerateRandomIntList();
 
-            GenericActionPipeline<int> actionPipeline = new GenericActionPipeline<int>(new List<IActionWrapper<int>> { new TestMappingProcessor(), new TestFoldProcessor(), new TestMappingProcessor() });
+            var actionPipeline = new GenericActionPipeline<int>(new List<IActionWrapper<int>> { new TestMappingProcessor(), new TestFoldProcessor(), new TestMappingProcessor() });
 
             IEnumerable<int> result = actionPipeline.Act(list);
 

--- a/src/Test.UnitTests.Sarif/Processors/GenericTests/TestFoldProcessor.cs
+++ b/src/Test.UnitTests.Sarif/Processors/GenericTests/TestFoldProcessor.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Sarif.Processors
 {
-    class TestFoldProcessor : GenericFoldAction<int>
+    internal class TestFoldProcessor : GenericFoldAction<int>
     {
         public static Func<int, int, int> internalFunction = (acc, value) => { return acc + value; };
 

--- a/src/Test.UnitTests.Sarif/Processors/Log/LogPipelineSerializationTests.cs
+++ b/src/Test.UnitTests.Sarif/Processors/Log/LogPipelineSerializationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         [Fact]
         public void SerializeDeserializePipeline_WorksAsExpected()
         {
-            SarifLogPipeline preserialized = new SarifLogPipeline(
+            var preserialized = new SarifLogPipeline(
                 new List<SarifLogActionTuple>()
                  { new SarifLogActionTuple(){Action=SarifLogAction.RebaseUri, Parameters=new string[] {"SrcRoot", @"C:\src\"} },
                    new SarifLogActionTuple(){Action=SarifLogAction.Merge, Parameters=new string[0]}

--- a/src/Test.UnitTests.Sarif/Processors/Log/MergeStageTests.cs
+++ b/src/Test.UnitTests.Sarif/Processors/Log/MergeStageTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
             output = outputHelper;
         }
 
-        readonly GenericFoldAction<SarifLog> Merge = (GenericFoldAction<SarifLog>)SarifLogProcessorFactory.GetActionStage(SarifLogAction.Merge);
+        private readonly GenericFoldAction<SarifLog> Merge = (GenericFoldAction<SarifLog>)SarifLogProcessorFactory.GetActionStage(SarifLogAction.Merge);
 
         [Theory]
         [InlineData(0)]
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
 
-            List<SarifLog> logs = new List<SarifLog>();
+            var logs = new List<SarifLog>();
             for (int i = 0; i < fileCount; i++)
             {
                 logs.Add(RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, random.Next(5)));

--- a/src/Test.UnitTests.Sarif/Processors/Log/RebaseUriStageTests.cs
+++ b/src/Test.UnitTests.Sarif/Processors/Log/RebaseUriStageTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors
         public void RewriteUri_RewritesAllFiles(int fileCount)
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
-            List<SarifLog> logs = new List<SarifLog>();
+            var logs = new List<SarifLog>();
             for (int i = 0; i < fileCount; i++)
             {
                 logs.Add(RandomSarifLogGenerator.GenerateSarifLogWithRuns(random, random.Next(10)));

--- a/src/Test.UnitTests.Sarif/Processors/Log/SarifLogExtensionTests.cs
+++ b/src/Test.UnitTests.Sarif/Processors/Log/SarifLogExtensionTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
         public void TestMerge_WorksAsExpected()
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
-            List<SarifLog> logs = new List<SarifLog>();
-            List<SarifLog> secondLogSet = new List<SarifLog>();
+            var logs = new List<SarifLog>();
+            var secondLogSet = new List<SarifLog>();
             int count = random.Next(10) + 1;
             for (int i = 0; i < count; i++)
             {
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
         public void RebaseUri_WorksAsExpected()
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
-            List<SarifLog> logs = new List<SarifLog>();
+            var logs = new List<SarifLog>();
 
             int count = random.Next(10) + 1;
             for (int i = 0; i < count; i++)
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
         public void RebaseUri_WorksAsExpectedWithRebaseRelativeUris()
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
-            List<SarifLog> logs = new List<SarifLog>();
+            var logs = new List<SarifLog>();
 
             int count = random.Next(10) + 1;
             for (int i = 0; i < count; i++)

--- a/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
+++ b/src/Test.UnitTests.Sarif/PropertiesDictionaryTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             Exception exception = Record.Exception(() =>
             {
-                List<Task> taskList = new List<Task>();
+                var taskList = new List<Task>();
 
                 for (int i = 0; i < 1000; i++)
                 {

--- a/src/Test.UnitTests.Sarif/Query/EvaluatorTests.cs
+++ b/src/Test.UnitTests.Sarif/Query/EvaluatorTests.cs
@@ -50,10 +50,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
         [Fact]
         public void ComplexEvaluator_Basics()
         {
-            List<SampleItem> set = new List<SampleItem>();
+            var set = new List<SampleItem>();
             for (int i = 0; i < 100; ++i)
             {
-                SampleItem item = new SampleItem();
+                var item = new SampleItem();
                 item.ID = i;
                 item.State = (State)(i % 4);
                 item.Uri = i.ToString();
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
             IExpressionEvaluator<T> evaluator = expression.ToEvaluator<T>(converter);
 
             // Ask for matches from the array
-            BitArray matches = new BitArray(values.Count);
+            var matches = new BitArray(values.Count);
             evaluator.Evaluate(values, matches);
 
             // Verify the match count is correct

--- a/src/Test.UnitTests.Sarif/Query/StringSliceTests.cs
+++ b/src/Test.UnitTests.Sarif/Query/StringSliceTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Query
             Assert.Equal(-1, empty.CompareTo(":"));
 
             // AppendTo shouldn't do anything
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             empty.AppendTo(result);
             Assert.Equal(0, result.Length);
 
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Query
             Assert.Equal(3, slice.Length);
             Assert.Equal(0, slice.CompareTo("the"));
 
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             slice.AppendTo(result);
             Assert.Equal(3, result.Length);
             Assert.Equal("the", result.ToString());

--- a/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/DeferredCollectionsTests.cs
@@ -66,12 +66,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         private static void CompareReadNormalToReadDeferredWithStreams(string filePath)
         {
             LogModelSampleBuilder.EnsureSamplesBuilt();
-            JsonSerializer serializer = new JsonSerializer();
+            var serializer = new JsonSerializer();
 
             Log expected;
             Log actual;
             // Read normally (JsonSerializer -> JsonTextReader -> StreamReader)
-            using (JsonTextReader reader = new JsonTextReader(new StreamReader(filePath)))
+            using (var reader = new JsonTextReader(new StreamReader(filePath)))
             {
                 expected = serializer.Deserialize<Log>(reader);
                 Assert.IsType<Dictionary<string, CodeContext>>(expected.CodeContexts);
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             serializer.ContractResolver = new LogModelDeferredContractResolver();
             Stream contents = File.OpenRead(filePath);
 
-            using (JsonPositionedTextReader reader = JsonPositionedTextReader.FromStream(contents))
+            using (var reader = JsonPositionedTextReader.FromStream(contents))
             {
                 actual = serializer.Deserialize<Log>(reader);
                 Assert.IsType<DeferredDictionary<CodeContext>>(actual.CodeContexts);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             AssertEqual(expected, actual);
 
             // DeferredList Code Coverage - CopyTo()
-            LogMessage[] messages = new LogMessage[actual.Messages.Count + 1];
+            var messages = new LogMessage[actual.Messages.Count + 1];
             actual.Messages.CopyTo(messages, 1);
             if (actual.Messages.Count > 0) { Assert.Equal<LogMessage>(actual.Messages[0], messages[1]); }
 
@@ -125,12 +125,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             }
 
             // CopyTo
-            KeyValuePair<string, CodeContext>[] contexts = new KeyValuePair<string, CodeContext>[actual.CodeContexts.Count + 1];
+            var contexts = new KeyValuePair<string, CodeContext>[actual.CodeContexts.Count + 1];
             actual.CodeContexts.CopyTo(contexts, 1);
             if (actual.CodeContexts.Count > 0) { Assert.Equal(actual.CodeContexts.First(), contexts[1]); }
 
             // Enumeration
-            Dictionary<string, CodeContext> contextsCopy = new Dictionary<string, CodeContext>();
+            var contextsCopy = new Dictionary<string, CodeContext>();
             foreach (KeyValuePair<string, CodeContext> pair in actual.CodeContexts)
             {
                 contextsCopy[pair.Key] = pair.Value;

--- a/src/Test.UnitTests.Sarif/Readers/LineMappingStreamReaderTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/LineMappingStreamReaderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             // Read it all and find all newline indices
             byte[] content = File.ReadAllBytes(path);
-            List<long> newlines = new List<long>();
+            var newlines = new List<long>();
             newlines.Add(-1);
             newlines.Add(-1);
 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             char[] buffer = new char[1024];
             int nextLine = 1;
             long bytesRead = 0;
-            using (LineMappingStreamReader reader = new LineMappingStreamReader(File.OpenRead(path)))
+            using (var reader = new LineMappingStreamReader(File.OpenRead(path)))
             {
                 while (true)
                 {
@@ -71,14 +71,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         {
             LogModelSampleBuilder.EnsureSamplesBuilt();
             string filePath = LogModelSampleBuilder.SampleLogPath;
-            JsonSerializer serializer = new JsonSerializer();
+            var serializer = new JsonSerializer();
 
             // Open a stream to read objects individually
             using (Stream seekingStream = File.OpenRead(filePath))
             {
                 // Read the Json with a LineMappingStreamReader
-                using (LineMappingStreamReader streamReader = new LineMappingStreamReader(File.OpenRead(filePath)))
-                using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+                using (var streamReader = new LineMappingStreamReader(File.OpenRead(filePath)))
+                using (var jsonReader = new JsonTextReader(streamReader))
                 {
                     // Get into the top object
                     jsonReader.Read();
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                             long position = streamReader.LineAndCharToOffset(jsonReader.LineNumber, jsonReader.LinePosition);
 
                             // Create an object from the original stream
-                            JObject expected = (JObject)serializer.Deserialize(jsonReader);
+                            var expected = (JObject)serializer.Deserialize(jsonReader);
 
                             // Compare to one we get by seeking to the calculated byte offset
                             JObject actual = ReadAtPosition(serializer, seekingStream, position);
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         private static JObject ReadAtPosition(JsonSerializer serializer, Stream stream, long position)
         {
             stream.Seek(position, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(new StreamReader(stream)))
+            using (var jsonReader = new JsonTextReader(new StreamReader(stream)))
             {
                 jsonReader.CloseInput = false;
                 return (JObject)serializer.Deserialize(jsonReader);
@@ -121,8 +121,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             File.WriteAllBytes(sampleFilePath, s_extractor.GetResourceBytes("elfie-arriba-utf8-bom.sarif"));
 
             // Read the Json with a LineMappingStreamReader
-            using (LineMappingStreamReader streamReader = new LineMappingStreamReader(File.OpenRead(sampleFilePath)))
-            using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+            using (var streamReader = new LineMappingStreamReader(File.OpenRead(sampleFilePath)))
+            using (var jsonReader = new JsonTextReader(streamReader))
             {
                 // Get into the top object
                 jsonReader.Read();

--- a/src/Test.UnitTests.Sarif/Readers/NonDisposingDelegatingStreamTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/NonDisposingDelegatingStreamTests.cs
@@ -8,8 +8,6 @@ using System.Text;
 
 using FluentAssertions;
 
-using Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Readers;
-
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Readers

--- a/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             PerformRoundTrip();
 
-            Guid expectedGuid = new Guid("{12345678-90ab-cdef-1234-567890abcdef}");
+            var expectedGuid = new Guid("{12345678-90ab-cdef-1234-567890abcdef}");
 
             _inputObject.GetProperty<Guid>("g").Should().Be(expectedGuid);
             _roundTrippedObject.GetProperty<Guid>("g").Should().Be(expectedGuid);
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             PerformRoundTrip();
 
-            Guid expectedGuid = new Guid("{12345678-90ab-cdef-1234-567890abcdef}");
+            var expectedGuid = new Guid("{12345678-90ab-cdef-1234-567890abcdef}");
 
             _inputObject.GetProperty<Guid>("g").Should().Be(expectedGuid);
             _roundTrippedObject.GetProperty<Guid>("g").Should().Be(expectedGuid);

--- a/src/Test.UnitTests.Sarif/Readers/SampleModel/LogModel.cs
+++ b/src/Test.UnitTests.Sarif/Readers/SampleModel/LogModel.cs
@@ -35,8 +35,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
         public override bool Equals(object obj)
         {
-            LogMessage other = obj as LogMessage;
-            if (other == null) return false;
+            var other = obj as LogMessage;
+            if (other == null)
+            {
+                return false;
+            }
 
             return this.Level == other.Level
                 && this.WhenUtc == other.WhenUtc
@@ -70,8 +73,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
         public override bool Equals(object obj)
         {
-            CodeContext other = obj as CodeContext;
-            if (other == null) return false;
+            var other = obj as CodeContext;
+            if (other == null)
+            {
+                return false;
+            }
 
             return this.ParentContextID == other.ParentContextID
                 && this.Name == other.Name
@@ -160,12 +166,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
         public static Log Build(Random r, DateTime whenUtc, int messageCount)
         {
-            Log log = new Log();
+            var log = new Log();
             log.ID = Guid.NewGuid();
             log.StartTimeUtc = whenUtc;
             log.ApplicationContext = "CodeCrawler.exe";
 
-            Dictionary<string, CodeContext> contexts = new Dictionary<string, CodeContext>();
+            var contexts = new Dictionary<string, CodeContext>();
             contexts["app"] = new CodeContext() { Name = "CodeCrawler.exe", Type = CodeContextType.Binary };
             contexts["scan"] = new CodeContext() { Name = "CodeCrawler.Scanners", Type = CodeContextType.Namespace, ParentContextID = "app" };
             contexts["file"] = new CodeContext() { Name = "FileScanner", Type = CodeContextType.Class, ParentContextID = "scan" };
@@ -173,14 +179,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
             contexts["load"] = new CodeContext() { Name = "LoadRules()", Type = CodeContextType.Method, ParentContextID = "run" };
             log.CodeContexts = contexts;
 
-            List<string> codeContextKeys = new List<string>(contexts.Keys);
+            var codeContextKeys = new List<string>(contexts.Keys);
 
             log.Messages = new List<LogMessage>();
             for (int i = 0; i < messageCount; ++i)
             {
                 whenUtc = whenUtc.AddMilliseconds(r.Next(10));
 
-                LogMessage m = new LogMessage()
+                var m = new LogMessage()
                 {
                     Level = (Level)r.Next(5),
                     WhenUtc = whenUtc,
@@ -199,13 +205,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
             lock (_locker)
             {
                 Log log = null;
-                JsonSerializer serializer = new JsonSerializer();
+                var serializer = new JsonSerializer();
 
                 if (!File.Exists(SampleLogPath))
                 {
-                    if (log == null) log = Build();
+                    if (log == null)
+                    {
+                        log = Build();
+                    }
 
-                    using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleLogPath))))
+                    using (var writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleLogPath))))
                     {
                         serializer.Formatting = Formatting.Indented;
                         serializer.Serialize(writer, log);
@@ -214,9 +223,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
                 if (!File.Exists(SampleOneLinePath))
                 {
-                    if (log == null) log = Build();
+                    if (log == null)
+                    {
+                        log = Build();
+                    }
 
-                    using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleOneLinePath))))
+                    using (var writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleOneLinePath))))
                     {
                         serializer.Formatting = Formatting.None;
                         serializer.Serialize(writer, log);
@@ -225,7 +237,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
                 if (!File.Exists(SampleNoCodeContextsPath))
                 {
-                    if (log == null) log = Build();
+                    if (log == null)
+                    {
+                        log = Build();
+                    }
 
                     log.CodeContexts.Clear();
                     foreach (LogMessage m in log.Messages)
@@ -233,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
                         m.CodeContextID = null;
                     }
 
-                    using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleNoCodeContextsPath))))
+                    using (var writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleNoCodeContextsPath))))
                     {
                         serializer.Formatting = Formatting.None;
                         serializer.Serialize(writer, log);
@@ -242,12 +257,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
                 if (!File.Exists(SampleEmptyPath))
                 {
-                    if (log == null) log = Build();
+                    if (log == null)
+                    {
+                        log = Build();
+                    }
 
                     log.CodeContexts.Clear();
                     log.Messages.Clear();
 
-                    using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleEmptyPath))))
+                    using (var writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleEmptyPath))))
                     {
                         serializer.Formatting = Formatting.Indented;
                         serializer.Serialize(writer, log);

--- a/src/Test.UnitTests.Sarif/RuntimeConditionsTests.cs
+++ b/src/Test.UnitTests.Sarif/RuntimeConditionsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 using FluentAssertions;
 using FluentAssertions.Execution;
 

--- a/src/Test.UnitTests.Sarif/SarifUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/SarifUtilitiesTests.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 
-using Castle.DynamicProxy.Generators;
-
 using FluentAssertions;
 
 using Xunit;

--- a/src/Test.UnitTests.Sarif/UriConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/UriConverterTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
             // Framework Bug: Uris with certain escaped unreserved characters are doubled by Uri.TryCreate
             // https://github.com/dotnet/runtime/issues/36288
 
-            StringBuilder errors = new StringBuilder();
+            var errors = new StringBuilder();
 
             SarifUriRoundTrip("http://github.com/Microsoft/sarif-sdk", errors);
             SarifUriRoundTrip("src/Program.cs", errors);
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         private void SarifUriRoundTrip(string value, StringBuilder errors)
         {
             // Put in a class with a Uri using the Sarif 'UriConverter'
-            SingleUri sample = new SingleUri();
+            var sample = new SingleUri();
             sample.Uri = new Uri(value, UriKind.RelativeOrAbsolute);
 
             // Serialize and Deserialize
@@ -155,9 +155,9 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         {
             // .NET can return the string used to construct.
             // This seems like the safest way to roundtrip reliably
-            Uri original = new Uri(value, UriKind.RelativeOrAbsolute);
+            var original = new Uri(value, UriKind.RelativeOrAbsolute);
             string serialized = original.OriginalString;
-            Uri result = new Uri(serialized, UriKind.RelativeOrAbsolute);
+            var result = new Uri(serialized, UriKind.RelativeOrAbsolute);
 
             if (!result.Equals(original)) { errors.AppendLine(value); }
         }

--- a/src/Test.UnitTests.Sarif/Visitors/MakeUriAbsoluteVisitorTest.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/MakeUriAbsoluteVisitorTest.cs
@@ -43,10 +43,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             };
 
             // Initializes visitor with run in order to retrieve uri base id mappings
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
             visitor.VisitRun(run);
 
-            PhysicalLocation location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = "%TEST%", Uri = new Uri("src/file.cs", UriKind.Relative) } };
+            var location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = "%TEST%", Uri = new Uri("src/file.cs", UriKind.Relative) } };
 
             PhysicalLocation newLocation = visitor.VisitPhysicalLocation(location);
             newLocation.ArtifactLocation.UriBaseId.Should().BeNull();
@@ -65,10 +65,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             };
 
             // Initializes visitor with run in order to retrieve uri base id mappings
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
             visitor.VisitRun(run);
 
-            PhysicalLocation location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = "%TEST2%", Uri = new Uri("src/file.cs", UriKind.Relative) } };
+            var location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = "%TEST2%", Uri = new Uri("src/file.cs", UriKind.Relative) } };
 
             PhysicalLocation newLocation = visitor.VisitPhysicalLocation(location);
             newLocation.ArtifactLocation.UriBaseId.Should().NotBeNull();
@@ -87,10 +87,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             };
 
             // Initializes visitor with run in order to retrieve uri base id mappings
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
             visitor.VisitRun(run);
 
-            PhysicalLocation location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = null, Uri = new Uri("src/file.cs", UriKind.Relative) } };
+            var location = new PhysicalLocation() { ArtifactLocation = new ArtifactLocation { UriBaseId = null, Uri = new Uri("src/file.cs", UriKind.Relative) } };
 
             PhysicalLocation newLocation = visitor.VisitPhysicalLocation(location);
             newLocation.ArtifactLocation.UriBaseId.Should().BeNull();
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 ["%TEST2%"] = new ArtifactLocation { Uri = new Uri(@"D:\bld\out\") }
             });
 
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
 
             Run newRun = visitor.VisitRun(run);
 
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void MakeUriAbsoluteVisitor_VisitRun_DoesNotSetAbsoluteUriIfNotApplicable()
         {
-            Dictionary<string, ArtifactLocation> uriMapping = new Dictionary<string, ArtifactLocation>()
+            var uriMapping = new Dictionary<string, ArtifactLocation>()
             {
                 ["%TEST3%"] = new ArtifactLocation { Uri = new Uri(@"C:\srcroot\") },
                 ["%TEST4%"] = new ArtifactLocation { Uri = new Uri(@"D:\bld\out\") }
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             Run expectedRun = GenerateRunForTest(uriMapping);
             Run actualRun = expectedRun.DeepClone();
 
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
             Run newRun = visitor.VisitRun(actualRun);
 
             expectedRun.ValueEquals(actualRun).Should().BeTrue();
@@ -153,9 +153,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 ["%TEST1%"] = new ArtifactLocation { Uri = new Uri(@"C:\src\abc\") },
                 ["%TEST2%"] = new ArtifactLocation { Uri = new Uri(@"D:\bld\123\") }
             });
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
+            var visitor = new MakeUrisAbsoluteVisitor();
 
-            SarifLog log = new SarifLog() { Runs = new Run[] { runA, runB } };
+            var log = new SarifLog() { Runs = new Run[] { runA, runB } };
             SarifLog newLog = visitor.VisitSarifLog(log);
 
             // Validate
@@ -184,8 +184,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void MakeUriAbsoluteVisitor_CombineUriValidatesArgumentsProperly()
         {
-            Uri absoluteUri = new Uri("https://absolute.example.com", UriKind.Absolute);
-            Uri relativeUri = new Uri("relative/someResource", UriKind.Relative);
+            var absoluteUri = new Uri("https://absolute.example.com", UriKind.Absolute);
+            var relativeUri = new Uri("relative/someResource", UriKind.Relative);
 
             // First, ensure that our test data succeeds when used properly
             MakeUrisAbsoluteVisitor.CombineUris(

--- a/src/Test.UnitTests.Sarif/Visitors/PerRunPerRuleSplittingVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/PerRunPerRuleSplittingVisitorTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
             SarifLog sarifLog = GetTestSarifLog();
 
-            HashSet<string> ruleIds = new HashSet<string>();
+            var ruleIds = new HashSet<string>();
 
             for (int i = 0; i < sarifLog.Runs[0].Results.Count; i++)
             {

--- a/src/Test.UnitTests.Sarif/Visitors/RebaseUriVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/RebaseUriVisitorTests.cs
@@ -31,16 +31,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [InlineData("SRCROOT", @"C:\blddir\out\test.dll", @"C:\blddir\src\", null)]
         public void RebaseUriVisitor_VisitPhysicalLocation_RebasesUri_WhenAppropriate(string rootName, string locationUriStr, string baseUriStr, string expectedDifference)
         {
-            Uri locationUri = new Uri(locationUriStr);
-            Uri baseUri = new Uri(baseUriStr);
-            PhysicalLocation location = new PhysicalLocation
+            var locationUri = new Uri(locationUriStr);
+            var baseUri = new Uri(baseUriStr);
+            var location = new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation
                 {
                     Uri = locationUri
                 }
             };
-            RebaseUriVisitor visitor = new RebaseUriVisitor(rootName, baseUri);
+            var visitor = new RebaseUriVisitor(rootName, baseUri);
             PhysicalLocation newLocation = visitor.VisitPhysicalLocation(location);
 
             if (!string.IsNullOrEmpty(expectedDifference))
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void RebaseUriVisitor_VisitPhysicalLocation_DoesNotRebaseAlreadyRebasedUri()
         {
-            PhysicalLocation location = new PhysicalLocation
+            var location = new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation
                 {
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     UriBaseId = "BLDROOT"
                 }
             };
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\src\"));
+            var rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\src\"));
 
             rebaseUriVisitor.VisitPhysicalLocation(location).Should().BeEquivalentTo(location, because: "we should not rebase a URI multiple times.");
         }
@@ -74,14 +74,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void RebaseUriVisitor_VisitPhysicalLocation_DoesNothingIfIndexReferenceToRunArtifacts()
         {
-            PhysicalLocation location = new PhysicalLocation
+            var location = new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation
                 {
                     Index = 23
                 }
             };
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\src\"));
+            var rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\src\"));
 
             rebaseUriVisitor.VisitPhysicalLocation(location).Should().BeEquivalentTo(location, because: "artifact location does not need to be rebased.");
         }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             Run oldRun = RandomSarifLogGenerator.GenerateRandomRun(random);
 
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\src\root"));
+            var rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\src\root"));
 
             Run newRun = rebaseUriVisitor.VisitRun(oldRun);
 
@@ -107,15 +107,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         public void RebaseUriVisitor_VisitRun_UpdatesBaseUriDictionaryWhenPresent()
         {
             const string srcRoot = "SRCROOT";
-            Uri srcRootUri = new Uri(@"C:\src\root");
+            var srcRootUri = new Uri(@"C:\src\root");
 
             const string bldRoot = "BLDROOT";
-            Uri bldRootUri = new Uri(@"C:\bld\root");
+            var bldRootUri = new Uri(@"C:\bld\root");
 
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
 
             Run oldRun = RandomSarifLogGenerator.GenerateRandomRun(random);
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor(srcRoot, srcRootUri);
+            var rebaseUriVisitor = new RebaseUriVisitor(srcRoot, srcRootUri);
 
             var oldDictionary = new Dictionary<string, ArtifactLocation>() { { bldRoot, new ArtifactLocation { Uri = bldRootUri } } };
             oldRun.OriginalUriBaseIds = oldDictionary;
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             Run oldRun = RandomSarifLogGenerator.GenerateRandomRun(random);
 
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\src\"));
+            var rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\src\"));
 
             Run newRun = rebaseUriVisitor.VisitRun(oldRun);
 
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             Run oldRun = RandomSarifLogGenerator.GenerateRandomRun(random);
 
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\"));
+            var rebaseUriVisitor = new RebaseUriVisitor("SRCROOT", new Uri(@"C:\bld\"));
 
             Run newRun = rebaseUriVisitor.VisitRun(oldRun);
 
@@ -166,12 +166,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void RebaseUriVisitor_VisitFileData_PatchesParentUri()
         {
-            Uri rootfileUri = new Uri("file://C:/src/root/blah.zip");
-            Uri childFileUri = new Uri("/stuff.doc", UriKind.RelativeOrAbsolute);
+            var rootfileUri = new Uri("file://C:/src/root/blah.zip");
+            var childFileUri = new Uri("/stuff.doc", UriKind.RelativeOrAbsolute);
 
-            Artifact rootFileData = new Artifact() { Location = new ArtifactLocation { Uri = rootfileUri }, ParentIndex = -1 };
-            Artifact childFileData = new Artifact() { Location = new ArtifactLocation { Uri = childFileUri }, ParentIndex = 0 };
-            Run run = new Run
+            var rootFileData = new Artifact() { Location = new ArtifactLocation { Uri = rootfileUri }, ParentIndex = -1 };
+            var childFileData = new Artifact() { Location = new ArtifactLocation { Uri = childFileUri }, ParentIndex = 0 };
+            var run = new Run
             {
                 Artifacts = new List<Artifact>
                 {
@@ -183,8 +183,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             };
 
             string srcroot = "SRCROOT";
-            Uri rootUriBaseId = new Uri(@"C:\src\root\");
-            RebaseUriVisitor rebaseUriVisitor = new RebaseUriVisitor(srcroot, rootUriBaseId);
+            var rootUriBaseId = new Uri(@"C:\src\root\");
+            var rebaseUriVisitor = new RebaseUriVisitor(srcroot, rootUriBaseId);
 
             run = rebaseUriVisitor.VisitRun(run);
 

--- a/src/Test.UnitTests.Sarif/Visitors/RemoveOptionalDataVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/RemoveOptionalDataVisitorTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
             SarifLog log = _sampleLog.DeepClone();
 
-            RemoveOptionalDataVisitor v = new RemoveOptionalDataVisitor(OptionallyEmittedData.None);
+            var v = new RemoveOptionalDataVisitor(OptionallyEmittedData.None);
             v.Visit(log);
             log.Runs[0].Results[0].Guid.Should().NotBeNull();
 

--- a/src/Test.UnitTests.Sarif/Visitors/RunMergingVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/RunMergingVisitorTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using FluentAssertions;
 
@@ -484,7 +483,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 }
             };
 
-            RunMergingVisitor currentVisitor = new RunMergingVisitor();
+            var currentVisitor = new RunMergingVisitor();
             currentVisitor.Visit(baselineRun);
 
             currentVisitor.CurrentRun = currentRun;

--- a/src/Test.UnitTests.Sarif/Visitors/SortingVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/SortingVisitorTests.cs
@@ -11,7 +11,6 @@ using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Visitors;
-using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
 
 using Newtonsoft.Json;
 

--- a/src/Test.UnitTests.Sarif/Writers/BaseLoggerTestConcrete.cs
+++ b/src/Test.UnitTests.Sarif/Writers/BaseLoggerTestConcrete.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 

--- a/src/Test.UnitTests.Sarif/Writers/CachingLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/CachingLoggerTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 }
             };
 
-            TestAnalyzeOptions testAnalyzeOptions = new TestAnalyzeOptions();
+            var testAnalyzeOptions = new TestAnalyzeOptions();
 
             var logger = new CachingLogger(testAnalyzeOptions.FailureLevels, testAnalyzeOptions.ResultKinds);
             logger.LogConfigurationNotification(notification);
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             Result result01 = GenerateResult();
             ReportingDescriptor rule01 = GenerateRule();
 
-            TestAnalyzeOptions testAnalyzeOptions = new TestAnalyzeOptions();
+            var testAnalyzeOptions = new TestAnalyzeOptions();
 
             var logger = new CachingLogger(testAnalyzeOptions.FailureLevels, testAnalyzeOptions.ResultKinds);
 
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             Result result01 = GenerateResult();
             ReportingDescriptor rule01 = GenerateRule();
 
-            TestAnalyzeOptions testAnalyzeOptions = new TestAnalyzeOptions();
+            var testAnalyzeOptions = new TestAnalyzeOptions();
 
             var logger = new CachingLogger(testAnalyzeOptions.FailureLevels, testAnalyzeOptions.ResultKinds);
 
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             string message = Guid.NewGuid().ToString();
             string uriText = Guid.NewGuid().ToString();
 
-            Uri uri = new Uri(uriText, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(uriText, UriKind.RelativeOrAbsolute);
 
             return new Result
             {

--- a/src/Test.UnitTests.Sarif/Writers/SarifConsolidatorTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifConsolidatorTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_Nulls()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // Null objects handled gracefully (so callers can pass properties which may or may not be set)
             consolidator.Trim((Region)null);
@@ -90,11 +90,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_Region()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // If line information, offsets removed. If EndLine == StartLine, EndLine removed
-            Region r = new Region(SampleRegion);
-            Region rExpected = new Region(SampleRegionTrimmed);
+            var r = new Region(SampleRegion);
+            var rExpected = new Region(SampleRegionTrimmed);
 
             consolidator.Trim(r);
             Assert.True(Region.ValueComparer.Equals(SampleRegionTrimmed, r));
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Assert.Equal(1024, r.ByteOffset);
             Assert.True(Region.ValueComparer.Equals(rExpected, r));
 
-            Region everythingRegion = new Region() { StartLine = 10, StartColumn = 12, EndLine = 13, EndColumn = 15, ByteOffset = 100, ByteLength = 10, CharOffset = 100, CharLength = 10 };
+            var everythingRegion = new Region() { StartLine = 10, StartColumn = 12, EndLine = 13, EndColumn = 15, ByteOffset = 100, ByteLength = 10, CharOffset = 100, CharLength = 10 };
 
             // Trim to ByteOffset only
             r = new Region(everythingRegion);
@@ -146,11 +146,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_ArtifactLocation()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // If Index set, remove Uri and UriBaseId 
-            ArtifactLocation a = new ArtifactLocation(SampleArtifactLocation);
-            ArtifactLocation aExpected = new ArtifactLocation(SampleArtifactLocationTrimmed);
+            var a = new ArtifactLocation(SampleArtifactLocation);
+            var aExpected = new ArtifactLocation(SampleArtifactLocationTrimmed);
 
             consolidator.Trim(a);
             Assert.Null(a.Uri);
@@ -168,11 +168,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_Location()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // Id removed, inner components trimmed
-            Location loc = new Location(SampleLocation);
-            Location locExpected = new Location(SampleLocationTrimmed);
+            var loc = new Location(SampleLocation);
+            var locExpected = new Location(SampleLocationTrimmed);
 
             consolidator.Trim(loc);
             Assert.True(Location.ValueComparer.Equals(locExpected, loc));
@@ -181,10 +181,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_Locations()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // Duplicate locations removed, inner Locations trimmed
-            List<Location> locations = new List<Location>()
+            var locations = new List<Location>()
             {
                 new Location(SampleLocation),
                 new Location(SampleLocation)
@@ -199,10 +199,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_LogicalLocations()
         {
-            SarifConsolidator consolidator = new SarifConsolidator(new Run());
+            var consolidator = new SarifConsolidator(new Run());
 
             // Duplicate locations removed, inner Locations trimmed
-            List<LogicalLocation> locations = new List<LogicalLocation>()
+            var locations = new List<LogicalLocation>()
             {
                 new LogicalLocation(SampleLogicalLocation),
                 new LogicalLocation(SampleLogicalLocation)
@@ -216,10 +216,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_ThreadFlow()
         {
-            ThreadFlowLocation tfl = new ThreadFlowLocation() { ExecutionOrder = 3, Module = "Loader" };
+            var tfl = new ThreadFlowLocation() { ExecutionOrder = 3, Module = "Loader" };
 
             // Pre-add a ThreadFlowLocation to the Run, to ensure it is considered for re-use
-            Run run = new Run()
+            var run = new Run()
             {
                 ThreadFlowLocations = new List<ThreadFlowLocation>()
                 {
@@ -227,10 +227,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
             };
 
-            SarifConsolidator consolidator = new SarifConsolidator(run);
+            var consolidator = new SarifConsolidator(run);
 
             // ThreadFlow: Unique Locations added to run; only indices on ThreadFlow
-            ThreadFlow flow = new ThreadFlow()
+            var flow = new ThreadFlow()
             {
                 Locations = new List<ThreadFlowLocation>()
                 {
@@ -253,10 +253,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         [Fact]
         public void SarifConsolidator_Result()
         {
-            Run run = new Run();
-            SarifConsolidator consolidator = new SarifConsolidator(run);
+            var run = new Run();
+            var consolidator = new SarifConsolidator(run);
 
-            Result result = new Result()
+            var result = new Result()
             {
                 Message = new Message() { Text = new string('Z', 500) },
                 Locations = new List<Location>()
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 WebResponse = new WebResponse()
             };
 
-            Result expected = new Result(result)
+            var expected = new Result(result)
             {
                 Locations = new List<Location>()
                 {

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -50,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             string expectedText = s_extractor.GetResourceText("SimpleExample.sarif");
 
-            MemoryStream memoryStream = new MemoryStream();
+            var memoryStream = new MemoryStream();
             var streamWriter = new StreamWriter(memoryStream);
 
             using (var logger = new SarifLogger(streamWriter,
@@ -256,10 +255,10 @@ namespace Microsoft.CodeAnalysis.Sarif
             var versionControlUri = new Uri("https://www.github.com/contoso/contoso");
             var versionControlDetails = new VersionControlDetails() { RepositoryUri = versionControlUri, AsOfTimeUtc = DateTime.UtcNow };
             string originalUriBaseIdKey = "testBase";
-            Uri originalUriBaseIdValue = new Uri("https://sourceserver.contoso.com");
+            var originalUriBaseIdValue = new Uri("https://sourceserver.contoso.com");
             var originalUriBaseIds = new Dictionary<string, ArtifactLocation>() { { originalUriBaseIdKey, new ArtifactLocation { Uri = originalUriBaseIdValue } } };
             string defaultEncoding = "UTF7";
-            List<string> redactionTokens = new List<string> { "[MY_REDACTION_TOKEN]" };
+            var redactionTokens = new List<string> { "[MY_REDACTION_TOKEN]" };
 
             var sb = new StringBuilder();
 
@@ -877,7 +876,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private void LogSimpleResult(SarifLogger sarifLogger)
         {
-            ReportingDescriptor rule = new ReportingDescriptor { Id = "RuleId" };
+            var rule = new ReportingDescriptor { Id = "RuleId" };
             sarifLogger.Log(rule, CreateSimpleResult(rule), null);
         }
 
@@ -1158,7 +1157,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static SarifLog CreateSarifLog(List<Result> allKindLevelCombinations, ReportingDescriptor rule, FailureLevelSet desiredFailureLevels, ResultKindSet desiredResultKinds)
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
 
             using (var stringWriter = new StringWriter(stringBuilder))
             {

--- a/src/Test.UnitTests.WorkItems/FilingClientFactoryTests.cs
+++ b/src/Test.UnitTests.WorkItems/FilingClientFactoryTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.WorkItems
         [Fact]
         public void CreateFilingTarget_ThrowsIfUriPatternIsNotRecognized()
         {
-            Uri hostUri = new Uri("https://www.example.com/myOrg/myProject");
+            var hostUri = new Uri("https://www.example.com/myOrg/myProject");
 
             Action action = () => FilingClientFactory.Create(hostUri);
 
@@ -33,7 +33,7 @@ namespace Microsoft.WorkItems
         [Fact]
         public void CreateFilingTarget_ThrowsIfUriIncludesAdditionalPathSegments()
         {
-            Uri hostUri = new Uri("https://github.com/myOrg/myProject/issues");
+            var hostUri = new Uri("https://github.com/myOrg/myProject/issues");
 
             Action action = () => FilingClientFactory.Create(hostUri);
 
@@ -43,7 +43,7 @@ namespace Microsoft.WorkItems
         [Fact]
         public void CreateFilingTarget_CreatesGitHubFilingTarget()
         {
-            Uri hostUri = new Uri("https://github.com/myOrg/myProject");
+            var hostUri = new Uri("https://github.com/myOrg/myProject");
 
             FilingClient filingTarget = FilingClientFactory.Create(hostUri);
 
@@ -55,7 +55,7 @@ namespace Microsoft.WorkItems
         [Fact]
         public void CreateFilingTarget_CreatesAzureDevOpsFilingTarget()
         {
-            Uri hostUri = new Uri("https://dev.azure.com/myOrg/myProject");
+            var hostUri = new Uri("https://dev.azure.com/myOrg/myProject");
 
             FilingClient filingTarget = FilingClientFactory.Create(hostUri);
 
@@ -67,7 +67,7 @@ namespace Microsoft.WorkItems
         [Fact]
         public void CreateFilingTarget_CreatesLegacyAzureDevOpsFilingTarget()
         {
-            Uri hostUri = new Uri("https://myorg.visualstudio.com/myProject");
+            var hostUri = new Uri("https://myorg.visualstudio.com/myProject");
 
             FilingClient filingTarget = FilingClientFactory.Create(hostUri);
 

--- a/src/Test.UnitTests.WorkItems/Logging/ApplicationInsightsTelemetryInitializerTests.cs
+++ b/src/Test.UnitTests.WorkItems/Logging/ApplicationInsightsTelemetryInitializerTests.cs
@@ -6,7 +6,6 @@ using System;
 using FluentAssertions;
 
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.TeamFoundation;
 
 using Xunit;
 
@@ -17,7 +16,7 @@ namespace Microsoft.WorkItems.Logging
         [Fact]
         public void CreateFilingTarget_ThrowsIfTelemetryIsNull()
         {
-            ApplicationInsightsTelemetryInitializer initializer = new ApplicationInsightsTelemetryInitializer();
+            var initializer = new ApplicationInsightsTelemetryInitializer();
 
             Action action = () => initializer.Initialize(null);
             action.Should().Throw<ArgumentNullException>();
@@ -26,8 +25,8 @@ namespace Microsoft.WorkItems.Logging
         [Fact]
         public void CreateFilingTarget_OperationIdIsSet()
         {
-            TraceTelemetry telemetry = new TraceTelemetry();
-            ApplicationInsightsTelemetryInitializer initializer = new ApplicationInsightsTelemetryInitializer();
+            var telemetry = new TraceTelemetry();
+            var initializer = new ApplicationInsightsTelemetryInitializer();
 
             telemetry.Context.Operation.Id.Should().BeNull();
 
@@ -37,7 +36,7 @@ namespace Microsoft.WorkItems.Logging
             Guid.TryParse(telemetry.Context.Operation.Id, out Guid temp).Should().BeTrue();
 
             // A second telemetry item should be assigned the same operation_Id
-            TraceTelemetry telemetry2 = new TraceTelemetry();
+            var telemetry2 = new TraceTelemetry();
             initializer.Initialize(telemetry2);
             telemetry.Context.Operation.Id.Should().Be(telemetry2.Context.Operation.Id);
         }
@@ -46,8 +45,8 @@ namespace Microsoft.WorkItems.Logging
         public void CreateFilingTarget_OperationIdIsDifferent()
         {
             // After initialization, the operation_Id should be set to a GUID.
-            TraceTelemetry telemetry = new TraceTelemetry();
-            ApplicationInsightsTelemetryInitializer initializer = new ApplicationInsightsTelemetryInitializer();
+            var telemetry = new TraceTelemetry();
+            var initializer = new ApplicationInsightsTelemetryInitializer();
 
             telemetry.Context.Operation.Id.Should().BeNull();
             initializer.Initialize(telemetry);
@@ -55,8 +54,8 @@ namespace Microsoft.WorkItems.Logging
             Guid.TryParse(telemetry.Context.Operation.Id, out Guid temp).Should().BeTrue();
 
             // A second telemetry item using a different Initializer should be assigned a different operation_Id
-            TraceTelemetry telemetry2 = new TraceTelemetry();
-            ApplicationInsightsTelemetryInitializer initializer2 = new ApplicationInsightsTelemetryInitializer();
+            var telemetry2 = new TraceTelemetry();
+            var initializer2 = new ApplicationInsightsTelemetryInitializer();
 
             telemetry2.Context.Operation.Id.Should().BeNull();
             initializer2.Initialize(telemetry2);
@@ -69,8 +68,8 @@ namespace Microsoft.WorkItems.Logging
         [Fact]
         public void CreateFilingTarget_OperationIdShouldNotBeOverwritten()
         {
-            TraceTelemetry telemetry = new TraceTelemetry();
-            ApplicationInsightsTelemetryInitializer initializer = new ApplicationInsightsTelemetryInitializer();
+            var telemetry = new TraceTelemetry();
+            var initializer = new ApplicationInsightsTelemetryInitializer();
 
             const string operationId = "abcd";
             telemetry.Context.Operation.Id = operationId;

--- a/src/Test.UnitTests.WorkItems/Logging/MetricsLogValuesTests.cs
+++ b/src/Test.UnitTests.WorkItems/Logging/MetricsLogValuesTests.cs
@@ -7,9 +7,7 @@ using System.Linq;
 
 using FluentAssertions;
 
-using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Logging;
-using Microsoft.TeamFoundation;
 
 using Xunit;
 
@@ -21,7 +19,7 @@ namespace Microsoft.WorkItems.Logging
         public void MetricsLogValues_ThrowsIfNullOrEmptyDictionary()
         {
             string message = "message";
-            EventId eventId = new EventId(1);
+            var eventId = new EventId(1);
 
             Action action = () => new MetricsLogValues(message, eventId, null);
             action.Should().Throw<ArgumentOutOfRangeException>();
@@ -34,12 +32,12 @@ namespace Microsoft.WorkItems.Logging
         public void MetricsLogValues_ToStringPreference()
         {
             string message = "Original";
-            EventId eventId = new EventId(1);
-            Dictionary<string, object> customDimensions = new Dictionary<string, object>();
+            var eventId = new EventId(1);
+            var customDimensions = new Dictionary<string, object>();
             customDimensions.Add("EventId", eventId.Id);
 
             // Prefer original message if it's provided
-            MetricsLogValues values = new MetricsLogValues(message, eventId, customDimensions);
+            var values = new MetricsLogValues(message, eventId, customDimensions);
             values.ToString().Should().Be(message);
 
             // Next prefer the eventId if it's provided
@@ -52,13 +50,13 @@ namespace Microsoft.WorkItems.Logging
         public void MetricsLogValues_ContainsAllCustomDimensions()
         {
             string message = "Original";
-            EventId eventId = new EventId(1);
-            Dictionary<string, object> customDimensions = new Dictionary<string, object>();
+            var eventId = new EventId(1);
+            var customDimensions = new Dictionary<string, object>();
             customDimensions.Add("One", 1);
             customDimensions.Add("Two", 2);
             customDimensions.Add("Three", 3);
 
-            MetricsLogValues values = new MetricsLogValues(message, eventId, customDimensions);
+            var values = new MetricsLogValues(message, eventId, customDimensions);
 
             values.Count.Should().Be(customDimensions.Count);
 
@@ -72,14 +70,14 @@ namespace Microsoft.WorkItems.Logging
         public void MetricsLogValues_NullOrEmptyAllCustomDimensions()
         {
             string message = "Original";
-            EventId eventId = new EventId(1);
-            Dictionary<string, object> customDimensions = new Dictionary<string, object>();
+            var eventId = new EventId(1);
+            var customDimensions = new Dictionary<string, object>();
             customDimensions.Add("Empty", "");
             customDimensions.Add("Null1", null);
             customDimensions.Add("Null2", null);
             customDimensions.Add("HasValue", 3);
 
-            MetricsLogValues values = new MetricsLogValues(message, eventId, customDimensions);
+            var values = new MetricsLogValues(message, eventId, customDimensions);
 
             values.Count.Should().Be(customDimensions.Count);
 

--- a/src/Test.Utilities.Sarif/RandomSarifLogGenerator.cs
+++ b/src/Test.Utilities.Sarif/RandomSarifLogGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             // Slightly roundabout.  We want to randomly test this, but we also want to be able to repeat this if the test fails.
             int randomSeed = seed ?? (new Random()).Next();
 
-            Random random = new Random(randomSeed);
+            var random = new Random(randomSeed);
 
             output.WriteLine($"TestName: {testName} has seed {randomSeed}");
 
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static SarifLog GenerateSarifLogWithRuns(Random randomGen, int runCount, int? resultCount = null, RandomDataFields dataFields = RandomDataFields.None)
         {
-            SarifLog log = new SarifLog();
+            var log = new SarifLog();
 
             if (runCount > 0)
             {
@@ -48,8 +48,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static Run GenerateRandomRun(Random random, int? resultCount = null, RandomDataFields dataFields = RandomDataFields.None)
         {
-            List<string> ruleIds = new List<string>() { "TEST001", "TEST002", "TEST003", "TEST004", "TEST005" };
-            List<Uri> filePaths = GenerateFakeFiles(GeneratorBaseUri, random.Next(20) + 1).Select(a => new Uri(a)).ToList();
+            var ruleIds = new List<string>() { "TEST001", "TEST002", "TEST003", "TEST004", "TEST005" };
+            var filePaths = GenerateFakeFiles(GeneratorBaseUri, random.Next(20) + 1).Select(a => new Uri(a)).ToList();
             int results = resultCount == null ? random.Next(100) : (int)resultCount;
 
             return new Run()
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             Run run = GenerateRandomRun(random, resultCount);
             IList<Result> resultList = run.Results;
-            List<Result> uniqueResults = new List<Result>();
+            var uniqueResults = new List<Result>();
             foreach (Result result in resultList)
             {
                 if (!uniqueResults.Contains(result, comparer))
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static IEnumerable<string> GenerateFakeFiles(string baseAddress, int count)
         {
-            List<string> results = new List<string>();
+            var results = new List<string>();
 
             for (int i = 0; i < count; i++)
             {
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static IList<Result> GenerateFakeResults(Random random, List<string> ruleIds, List<Uri> filePaths, int resultCount, RandomDataFields dataFields = RandomDataFields.None)
         {
-            List<Result> results = new List<Result>();
+            var results = new List<Result>();
             for (int i = 0; i < resultCount; i++)
             {
                 int fileIndex = random.Next(filePaths.Count);

--- a/src/Test.Utilities.Sarif/TestAssetResourceExtractor.cs
+++ b/src/Test.Utilities.Sarif/TestAssetResourceExtractor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             ValidateStream(resourcePath, fallbackResourcePath, stream);
 
-            using StreamReader reader = new StreamReader(stream);
+            using var reader = new StreamReader(stream);
             return reader.ReadToEnd();
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private byte[] GetBytesFromStream(Stream stream)
         {
-            using MemoryStream memoryStream = new MemoryStream();
+            using var memoryStream = new MemoryStream();
             stream.CopyTo(memoryStream);
             return memoryStream.ToArray();
         }

--- a/src/WorkItems/Logging/AssemblyExtensions.cs
+++ b/src/WorkItems/Logging/AssemblyExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.WorkItems.Logging
             customDimensions ??= new Dictionary<string, object>();
 
             AssemblyName assemblyName = assembly.GetName();
-            FileInfo assemblyFileInfo = new FileInfo(assembly.Location);
-            Dictionary<string, object> assemblyMetrics = new Dictionary<string, object>(customDimensions);
+            var assemblyFileInfo = new FileInfo(assembly.Location);
+            var assemblyMetrics = new Dictionary<string, object>(customDimensions);
             assemblyMetrics.Add("Name", assemblyName.Name);
             assemblyMetrics.Add("Version", assemblyName.Version);
             assemblyMetrics.Add("CreationTime", assemblyFileInfo.CreationTime.ToUniversalTime().ToString());

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -13,6 +13,7 @@
     <Description>Classes for filing work items in either GitHub or AzureDevOps.</Description>
     <AssemblyName>WorkItems</AssemblyName>
     <RootNamespace>Microsoft.WorkItems</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />

--- a/src/build.props
+++ b/src/build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <GenerateDocumentationFile Condition="'$(IsTestProject)' == 'false'">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Label="AssemblyAttributes">


### PR DESCRIPTION
No behavioral changes, hence no release notes.

This change also disables automated SARIF object model generation: this code is stable and the autogenerator emit doesn't conform currently to our style guidelines. To enforce them we therefore need to check in and update a stable copy.

Finally, we now enforce strict adherence to the guidelines by elevating problems to errors via CLI build.
