### PR TITLE
Fix FileNotFoundException when a file name or directory path contains URL-encoded characters

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -6,6 +6,7 @@
 * DEP: Update `Azure.Identity` reference from 1.10.2 to 1.11.0 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-29992](https://github.com/advisories/GHSA-wvxc-855f-jvrv).
 * BUG: Resolve process hangs when a file path is provided with a wildcard, but without a `-r` (recurse) flag during the multi-threaded analysis file enumeration phase.
 * BUG: Fix error `ERR997.NoValidAnalysisTargets` when scanning symbolic link files.
+* BUG: Fix `ERR999.UnhandledEngineException: System.IO.FileNotFoundException: Could not find file` when a file name or directory path contains URL-encoded characters.
 
 ## **v4.5.4 [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.5.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.5.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.5.4)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.5.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.5.4)
 * BUG: Fix incorrect base class in rule ADO2012.

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 globalContext.CancellationToken.ThrowIfCancellationRequested();
 
-                string filePath = artifact.Uri.OriginalString;
+                string filePath = artifact.Uri.GetFilePath();
 
                 if (globalContext.CompiledGlobalFileDenyRegex?.Match(filePath).Success == true)
                 {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 globalContext.CancellationToken.ThrowIfCancellationRequested();
 
-                string filePath = artifact.Uri.LocalPath;
+                string filePath = artifact.Uri.OriginalString;
 
                 if (globalContext.CompiledGlobalFileDenyRegex?.Match(filePath).Success == true)
                 {

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 globalContext.CancellationToken.ThrowIfCancellationRequested();
 
-                string filePath = artifact.Uri.GetFilePath();
+                string filePath = artifact.Uri.LocalPath;
 
                 if (globalContext.CompiledGlobalFileDenyRegex?.Match(filePath).Success == true)
                 {

--- a/src/Sarif/EnumeratedArtifact.cs
+++ b/src/Sarif/EnumeratedArtifact.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 // This is our client-side, disk-based file retrieval case.
-                this.Stream = FileSystem.FileOpenRead(Uri.LocalPath);
+                this.Stream = FileSystem.FileOpenRead(Uri.OriginalString);
             }
 
             RetrieveDataFromStream();
@@ -164,9 +164,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 else if (Uri != null && Uri.IsAbsoluteUri && Uri.IsFile)
                 {
-                    this.sizeInBytes = FileSystem.IsSymbolicLink(Uri.LocalPath)
-                        ? (long)FileSystem.FileStreamLength(Uri.LocalPath)
-                        : (long)FileSystem.FileInfoLength(Uri.LocalPath);
+                    this.sizeInBytes = FileSystem.IsSymbolicLink(Uri.OriginalString)
+                        ? (long)FileSystem.FileStreamLength(Uri.OriginalString)
+                        : (long)FileSystem.FileInfoLength(Uri.OriginalString);
                 }
                 else if (this.Contents != null)
                 {


### PR DESCRIPTION
* BUG: Fix `ERR999.UnhandledEngineException: System.IO.FileNotFoundException: Could not find file` when a file name or directory path contains URL-encoded characters.

We use `Uri` class. When the path contains URL-encoded character, it will automatically decode, and the only reliable property is the  `OriginalString`: 

![image](https://github.com/user-attachments/assets/425b17a8-5900-4328-9a2f-5b16ef805c32)

Note that file name can contain `%2D` and it can contain `-` as well.

This fix the disk read related to use `OriginalString`.

Note that we have many other places that use other than `OriginalString`: `LocalPath`, `AbsoluteUri` etc.



