### PR TITLE
chore: use central package versions

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,45 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Azure.Core" Version="1.41.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.12.1" />
+    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="CsvHelper" Version="15.0.5" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.7" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.20.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
+    <PackageVersion Include="Microsoft.Json.Pointer" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Json.Schema" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageVersion Include="System.Composition" Version="5.0.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="YamlDotNet" Version="11.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -42,27 +42,27 @@
       <ItemGroup>
         <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 
              We mitigate risk by limiting nesting depth. -->
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" NoWarn="NU1903" />
+        <PackageReference Include="Newtonsoft.Json" VersionOverride="9.0.1" NoWarn="NU1903" />
 
-        <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+        <PackageReference Include="System.IO.FileSystem.Primitives" />
+        <PackageReference Include="System.Text.Encoding.Extensions" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
         <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 
              We mitigate risk by limiting nesting depth. -->
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" NoWarn="NU1903" />
+        <PackageReference Include="Newtonsoft.Json" VersionOverride="9.0.1" NoWarn="NU1903" />
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="YamlDotNet" Version="11.2.0" />
+    <PackageReference Include="CsvHelper" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -38,15 +38,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.9" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing"  />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="System.Diagnostics.Debug" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" />
+    <PackageReference Include="System.Text.Encoding.Extensions" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -15,18 +15,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Core" Version="1.41.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
-    <PackageReference Include="Microsoft.Json.Pointer" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Json.Pointer" />
+    <PackageReference Include="Microsoft.Json.Schema" />
+    <PackageReference Include="Microsoft.Json.Schema.Validation" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.Threading.Channels" />
 
     <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 
          We mitigate risk by limiting nesting depth. -->
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" NoWarn="NU1903" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="12.0.3" NoWarn="NU1903" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.WorkItems/Sarif.WorkItems.csproj
+++ b/src/Sarif.WorkItems/Sarif.WorkItems.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK.  
          We mitigate risk by limiting nesting depth. -->
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" NoWarn="NU1903" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="12.0.3" NoWarn="NU1903" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -33,14 +33,14 @@
   <Choose>
     <When Condition="$(TargetFramework) == 'netstandard2.0'">
       <ItemGroup>
-        <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK.  
+        <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 
              We mitigate risk by limiting nesting depth. -->
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" NoWarn="NU1903" />
+        <PackageReference Include="Newtonsoft.Json" VersionOverride="9.0.1" NoWarn="NU1903" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="6.0.8" NoWarn="NU1903" />
+        <PackageReference Include="Newtonsoft.Json" VersionOverride="6.0.8" NoWarn="NU1903" />
         <Reference Include="System.Web" />
         <Reference Include="System.Net.Http" />
       </ItemGroup>
@@ -48,14 +48,14 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" Condition="$(OS) == 'Windows_NT'" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister"  Condition="$(OS) == 'Windows_NT'" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent"  />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Diagnostics.Debug" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" />
+    <PackageReference Include="System.Text.Encoding.CodePages" />
+    <PackageReference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
 
   <ItemGroup Label="Packaging">

--- a/src/Test.EndToEnd.Baselining/Test.EndToEnd.Baselining.csproj
+++ b/src/Test.EndToEnd.Baselining/Test.EndToEnd.Baselining.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="CommandLineParser" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
+++ b/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
@@ -47,19 +47,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
+++ b/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
@@ -54,19 +54,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -30,19 +30,13 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.5.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Test.UnitTests.Sarif.Multitool.Library.csproj
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Test.UnitTests.Sarif.Multitool.Library.csproj
@@ -58,20 +58,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
+++ b/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
@@ -24,17 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
+++ b/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
@@ -25,19 +25,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -164,22 +164,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Json.Schema"  />
+    <PackageReference Include="Microsoft.Json.Schema.Validation"  />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrviateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
+++ b/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
@@ -16,19 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test.Utilities.Sarif/Test.Utilities.Sarif.csproj
+++ b/src/Test.Utilities.Sarif/Test.Utilities.Sarif.csproj
@@ -9,11 +9,11 @@
          to demonstrate we can bind to it and run successfuly.
          * We have to ship pre-patch versions of NewtonSoft for 
          VisualStudio SDK, and mitigate risk by limiting nesting depth. -->
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" NoWarn="NU1903" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="12.0.3" NoWarn="NU1903" />
 
-    <PackageReference Include="System.Composition" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -25,24 +25,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Core" Version="1.41.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"  />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights"  />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Json.Schema" />
+    <PackageReference Include="Microsoft.Json.Schema.Validation" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="System.Text.Encodings.Web" />
 
     <!-- We have to ship pre-patch versions of NewtonSoft for VisualStudio SDK. 
          We mitigate risk by limiting nesting depth. -->
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" NoWarn="NU1903" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="12.0.3" NoWarn="NU1903" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The only actual package version changes are in test projects:
- FluentAssertions: Unify to 6.12.0
- xunit: Unify to 2.4.2
- xunit.runner.console: Unify to 2.4.2
- xunit.runner.visualstudio: Unify to 2.4.5

NOTE: The xunit versions are slightly downgraded for Test.UnitTests.Sarif.Driver since upgrading xunit across the solution leads to issues:
- New xunit analyzer errors 
- Dropped support for netcoreapp3.1
- Filed #2834
- Filed #2836