### PR TITLE
devops: add linux and mac coverage to PR validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   #########################################################################
   build-and-test:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-13]
+    runs-on: ${{matrix.os}}
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -19,14 +22,16 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: |
+          3.1.x
+          6.0.x
 
     - name: Show dotnet info
       run: dotnet --info
 
     - name: Build and Test
       # NoFormat because there is a separate format check action below
-      run: ./BuildAndTest.cmd -NoFormat
+      run: pwsh ./scripts/BuildAndTest.ps1 -NoFormat
 
   #########################################################################
   build-multitool-for-npm:

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -82,6 +82,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
+$OnWindows = $Env:OS -eq 'Windows_NT'
 $NonWindowsOptions = @{}
 
 $ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
@@ -106,6 +107,9 @@ function Invoke-DotNetBuild($solutionFileRelativePath) {
 function Publish-Application($project, $framework) {
     Write-Information "Publishing $project for $framework ..."
     dotnet publish $SourceRoot\$project\$project.csproj --no-build --configuration $Configuration --framework $framework
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Publish failed."
+    }
 }
 
 # Create a directory populated with the binaries that need to be signed.
@@ -216,13 +220,13 @@ if (-not $?) {
 
 if (-not $NoBuild) {
     Invoke-DotNetBuild $SolutionFile
-    if ($ENV:OS) {
+    if ($OnWindows) {
         Invoke-DotNetBuild $sampleSolutionFile
     }
 }
 
 if (-not $NoTest) {
-    if (-not $ENV:OS) {
+    if (-not $OnWindows) {
         $NonWindowsOptions = @{ "-filter" = "WindowsOnly!=true" }
     }
     & dotnet test $SourceRoot\$SolutionFile --no-build --configuration $Configuration @NonWindowsOptions
@@ -231,7 +235,7 @@ if (-not $NoTest) {
     }
 }
 
-if (-not $NoPublish) {
+if (-not $NoPublish -and $OnWindows) {  # Can't publish on non-windows due to not building net4x assets
     foreach ($project in $Projects.Applications) {
         foreach ($framework in $Frameworks.Application) {
             Publish-Application $project $framework
@@ -243,9 +247,9 @@ if (-not $NoSigningDirectory) {
     New-SigningDirectory
 }
 
-if (-not $NoPackage) {
+if (-not $NoPackage -and $OnWindows) { # Can't package on non-windows due to not building net4x assets
     & dotnet pack $SourceRoot\$SolutionFile --no-build --configuration $Configuration
-    if ($ENV:OS -and $LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "Package failed."
     }
 }


### PR DESCRIPTION
* Add macos-13 and ubuntu-latest to build-and-test matrix
  * macos-13 not macos-latest because build currently fails on arm64
  * Filed #2835
* Make code that checks if the build is running on windows clearer
* Make dotnet publish step check exit code
* Stop running dotnet publish and dotnet pack on non-windows where they failed with scary messages but confusingly allowed CI to pass since exit code was not checked
