### PR TITLE
Make the build compatible with .NET 9 SDK

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -95,7 +95,7 @@ function Invoke-DotNetBuild($solutionFileRelativePath) {
     Write-Information "Building $solutionFileRelativePath..."
 
     $solutionFilePath = Join-Path $SourceRoot $solutionFileRelativePath
-    & dotnet build $solutionFilePath --configuration $Configuration --verbosity $BuildVerbosity --no-incremental -bl -p:WarningsAsErrors="MSB3277" /p:EnforceCodeStyleInBuild=true
+    & dotnet build $solutionFilePath --configuration $Configuration --verbosity $BuildVerbosity --no-incremental -bl /p:EnforceCodeStyleInBuild=true
     
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "Build of $solutionFilePath failed."

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -38,7 +38,7 @@ $npmBuildFolder = "$BuildRoot\Publish\npm"
 if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
     foreach ($runtime in "win-x64", "linux-x64", "osx-x64") {
-        dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.1 -r $runtime
+        dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.1 -r $runtime --self-contained
     }
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."

--- a/src/Directory.Solution.props
+++ b/src/Directory.Solution.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="build.warnings_as_errors.props" />
+</Project>

--- a/src/build.props
+++ b/src/build.props
@@ -2,7 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <AnalysisMode>Default</AnalysisMode>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -18,10 +21,6 @@
 
     <!-- The stable version of the SARIF specification. -->
     <StableSarifVersion>2.1.0</StableSarifVersion>
-
-    <AnalysisLevel>latest</AnalysisLevel>
-    <LangVersion>latest</LangVersion>
-
     </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -40,10 +39,6 @@
     <PackageOutputPath>$(MsBuildThisFileDirectory)..\bld\Publish\Nuget\$(Configuration)\</PackageOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-    <!-- These can change externally, breaking our build. -->
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors> 
     <HighEntropyVA>true</HighEntropyVA>
     <!-- The line causes the assemblies in a project's referenced NuGet packages to be
          copied to the output directory. If we omit it from a test project, the tests
@@ -118,9 +113,5 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <EnableNETAnalyzers>True</EnableNETAnalyzers>
-    <AnalysisMode>Default</AnalysisMode>
-    <AnalysisLevel>latest</AnalysisLevel>
-  </PropertyGroup>
+  <Import Project="./build.warnings_as_errors.props" />
 </Project>

--- a/src/build.warnings_as_errors.props
+++ b/src/build.warnings_as_errors.props
@@ -1,0 +1,27 @@
+﻿<Project>
+  <!-- 
+    NOTE: We only turn on warnings-as-errors in Release because it hurts
+    iteration time in the IDE to error out while the code is still
+    work-in-progress.
+   -->
+  <PropertyGroup Label="WarningsAsErrors" Condition="'$(Configuration)' == 'Release'">
+    <!-- Treat compiler warnings as errors. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Treat all build warnings as errors -->
+    <MSBuildTreatWarningsAsErrors>$(TreatWarningsAsErrors)</MSBuildTreatWarningsAsErrors> 
+
+    <!--
+      NU190X are security vulnerability warnings and can trigger without code
+      changes. Don't let them break the build.
+     -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <MSBuildWarningsNotAsErrors>$(WarningsNotAsErrors)</MSBuildWarningsNotAsErrors>
+
+    <!--
+      We are not yet clean on new analysis introduced with .NET 9 SDK so lower
+      the analysis level when treating warnings as errors in Release.
+    -->
+    <AnalysisLevel>8</AnalysisLevel>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
* Move all warning-as-error handling to build props
* Disable warning-as-error in Debug builds
* Lower AnalysisLevel to .NET 8 wave when treating warnings as errors in Release
* Pass --self-contained explicitly to dotnet publish with runtime identifier for forward compat