### PR TITLE
[DEP] Update `Microsoft.Data.SqlClient` from 2.1.7 to 5.2.2

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -7,7 +7,7 @@
 * DEP: Update `Azure.Core` from 1.35.0 to 1.41.1 to satisfy minimum requirement of `Azure.Identity` 1.12.1 (that has no known vulnerabilities).
 * DEP: Update `System.Text.Encodings.Web` from 5.0.1 to 6.0.0 (required by transitive closure of dependency requirements from other updates).
 * DEP: Update all `Newtonsoft.Json` references from 12.0.3 to 13.0.3 to resolve [CVE-2024-21907](https://nvd.nist.gov/vuln/detail/CVE-2024-21907).
-* DEP: Update `Microsoft.Data.SqlClient` from 2.1.7 to 5.2.2 so its dependencies `Microsoft.IdentityModel.JsonWebTokens` and `System.IdentityModel.Tokens.Jwt` upgrade to non-vulnerable version 6.35.0.
+* DEP: Update `Microsoft.Data.SqlClient` from 2.1.7 to 5.2.2 so its dependencies `Microsoft.IdentityModel.JsonWebTokens` and `System.IdentityModel.Tokens.Jwt` upgrade to non-vulnerable version 6.35.0 (https://github.com/dotnet/aspnetcore/security/advisories/GHSA-59j7-ghrg-fj52).
 * BUG: Resolve process hangs when a file path is provided with a wildcard, but without a `-r` (recurse) flag during the multi-threaded analysis file enumeration phase.
 * BUG: Fix error `ERR997.NoValidAnalysisTargets` when scanning symbolic link files.
 * BUG: Fix `ERR999.UnhandledEngineException: System.IO.FileNotFoundException: Could not find file` when a file name or directory path contains URL-encoded characters.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -5,6 +5,7 @@
 * DEP: Remove dependency on `Microsoft.Azure.Kusto.Data`.
 * DEP: Update `Azure.Identity` reference from 1.10.2 to 1.12.1 in `WorkItems` and `Sarif.Multitool.Library` to resolve [CVE-2024-29992](https://github.com/advisories/GHSA-wvxc-855f-jvrv) and other CVEs.
 * DEP: Update `Azure.Core` from 1.35.0 to 1.41.0 to satisfy minimum requirement of `Azure.Identity` 1.12.1 that also has no vulnerabilities.
+* DEP: Update `Microsoft.Data.SqlClient` from 2.1.7 to 5.2.2 so its dependencies `Microsoft.IdentityModel.JsonWebTokens` and `System.IdentityModel.Tokens.Jwt` upgrade to non-vulnerable version 6.35.0.
 * BUG: Resolve process hangs when a file path is provided with a wildcard, but without a `-r` (recurse) flag during the multi-threaded analysis file enumeration phase.
 * BUG: Fix error `ERR997.NoValidAnalysisTargets` when scanning symbolic link files.
 * BUG: Fix `ERR999.UnhandledEngineException: System.IO.FileNotFoundException: Could not find file` when a file name or directory path contains URL-encoded characters.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="CsvHelper" Version="15.0.5" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.7" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
@@ -35,7 +35,7 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.console" Version="2.4.2" />


### PR DESCRIPTION
# Description
`Microsoft.Data.SqlClient` 2.1.7 has references to vulnerable `Microsoft.IdentityModel.JsonWebTokens` 6.8.0 and `System.IdentityModel.Tokens.Jwt` 6.8.0 as identified by [CVE-2024-21319: .NET Denial of Service Vulnerability](https://github.com/dotnet/aspnetcore/security/advisories/GHSA-59j7-ghrg-fj52).

The fix updates `Microsoft.Data.SqlClient` to 5.2.2 to avoid the vulnerable dependencies.