### PR TITLE
Test utility file diffing enforcement of required result fingerprints

### DIFF
--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -233,6 +233,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             var filesWithErrors = new List<string>();
             var filesResultNotMatch = new List<string>();
+            var filesMissingFingerprints = new List<string>();
 
             // Reify the list of keys because we're going to modify the dictionary in place.
             var keys = expectedSarifTextDictionary.Keys.ToList();
@@ -269,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         {
                             if (actual.Runs[0].Results.Any(r => r.Fingerprints.ContainsKey(expectedFingerprintKey) == false))
                             {
-                                filesWithErrors.Add(key);
+                                filesMissingFingerprints.Add(key);
                                 break;
                             }
                         }
@@ -328,6 +329,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             var sb = new StringBuilder();
+
+            if (filesMissingFingerprints.Count > 0)
+            {
+                sb.AppendLine(Environment.NewLine)
+                  .AppendLine("one or more files contain results missing required fingerprints: ")
+                  .AppendLine(string.Join(Environment.NewLine, filesMissingFingerprints.Select(s => $" - {s}")));
+            }
 
             if (filesWithErrors.Count > 0)
             {

--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -263,16 +263,22 @@ namespace Microsoft.CodeAnalysis.Sarif
                                                      out SarifLog actual);
 
                     if (expectedResultFingerprintKeys != null &&
-                        actual != null &&
-                        actual.Runs[0].Results != null)
+                        actual?.Runs?[0]?.Results != null)
                     {
+                        List<string> missingFingerprints = null;
+
                         foreach (string expectedFingerprintKey in expectedResultFingerprintKeys)
                         {
                             if (actual.Runs[0].Results.Any(r => r.Fingerprints.ContainsKey(expectedFingerprintKey) == false))
                             {
-                                filesMissingFingerprints.Add(key);
-                                break;
+                                missingFingerprints ??= new List<string>();
+                                missingFingerprints.Add(expectedFingerprintKey);
                             }
+                        }
+
+                        if (missingFingerprints?.Count > 0)
+                        {
+                            filesMissingFingerprints.Add($"'{key}' analysis result is missing required fingerprints: {string.Join(", ", missingFingerprints)}");
                         }
                     }
 


### PR DESCRIPTION
Technical description:
Adding an optional capability to enforce a required result fingerprint set during file diffing test runs.

Change justification / impact:
No change to existing tests by default. This optional utility improvement will allow tool authors and consumers of the sarif-sdk to author file diffing tests that in addition to existing additional enforcement of output quality such as no tool notifications could ensure and fail tests on requiring a set of fingerprints exist for every result produced.