### PR TITLE
Correctly setting working directory in OrderedFileSpecifierTests

### DIFF
--- a/src/Test.UnitTests.Sarif.Driver/FileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/FileSpecifierTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
     }
 
+    [Collection("TestsUsingCurrentDirectory")]
     public class FileSpecifierTests : IClassFixture<FileSpecifierTestsFixture>
     {
         private readonly FileSpecifierTestsFixture _fixture;

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public OrderedFileSpecifierTestsFixture()
         {
             RootDirectoryRelativePath = Guid.NewGuid().ToString();
-            RootDirectory = Path.Combine(GetThisTestAssemblyFilePath(), RootDirectoryRelativePath);
+            RootDirectory = Path.Combine(Path.GetTempPath(), RootDirectoryRelativePath);
 
             Directory.CreateDirectory(RootDirectory);
 
@@ -40,12 +40,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     File.WriteAllText(file, "12345");
                 }
             }
-        }
-
-        internal string GetThisTestAssemblyFilePath()
-        {
-            string filePath = typeof(MultithreadedAnalyzeCommandBaseTests).Assembly.Location;
-            return Path.GetDirectoryName(filePath);
         }
 
         public string RootDirectory { get; set; }
@@ -131,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 {
                     // Set current directory to the parent of _fixture.RootDirectory, that is, the assembly directory
                     // to avoid non-deterministic resolution of relative paths when the current working directory changes.
-                    Environment.CurrentDirectory = _fixture.GetThisTestAssemblyFilePath();
+                    Environment.CurrentDirectory = Path.GetTempPath();
 
                     var specifier = new OrderedFileSpecifier(testCase.Item1, recurse: true);
                     int artifactCount = specifier.Artifacts.Count();

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         /// </summary>
         public OrderedFileSpecifierTestsFixture()
         {
-            string tempPath = Path.GetTempPath();
+            TempPath = Path.GetTempPath();
             RootDirectoryRelativePath = Guid.NewGuid().ToString();
-            RootDirectory = Path.Combine(tempPath, RootDirectoryRelativePath);
+            RootDirectory = Path.Combine(TempPath, RootDirectoryRelativePath);
 
             Directory.CreateDirectory(RootDirectory);
 
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public string RootDirectory { get; set; }
 
         public string RootDirectoryRelativePath { get; set; }
+
+        public string TempPath {  get; set; }
 
         public void Dispose()
         {
@@ -127,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 {
                     // Set current directory to the parent of _fixture.RootDirectory, that is, the assembly directory
                     // to avoid non-deterministic resolution of relative paths when the current working directory changes.
-                    Environment.CurrentDirectory = Path.GetTempPath();
+                    Environment.CurrentDirectory = _fixture.TempPath;
 
                     var specifier = new OrderedFileSpecifier(testCase.Item1, recurse: true);
                     int artifactCount = specifier.Artifacts.Count();

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -23,8 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         /// </summary>
         public OrderedFileSpecifierTestsFixture()
         {
+            string tempPath = Path.GetTempPath();
             RootDirectoryRelativePath = Guid.NewGuid().ToString();
-            RootDirectory = Path.Combine(Path.GetTempPath(), RootDirectoryRelativePath);
+            RootDirectory = Path.Combine(tempPath, RootDirectoryRelativePath);
 
             Directory.CreateDirectory(RootDirectory);
 
@@ -55,6 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
     }
 
+    [Collection("TestsUsingCurrentDirectory")]
     public class OrderedFileSpecifierTests : IClassFixture<OrderedFileSpecifierTestsFixture>
     {
         private readonly OrderedFileSpecifierTestsFixture _fixture;

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public string RootDirectoryRelativePath { get; set; }
 
-        public string TempPath {  get; set; }
+        public string TempPath { get; set; }
 
         public void Dispose()
         {


### PR DESCRIPTION
The unit test in OrderedFileSpecifier fails when it is a submodule in the SPMI repo (Failing test pipeline: https://dev.azure.com/mseng/1ES/_build/results?buildId=29658428&view=ms.vss-test-web.build-test-results-tab&runId=168189729&resultId=100040&paneView=debug)

The error indicates that when the test code attempts to set the current working directory using,
`Environment.CurrentDirectory = _fixture.GetThisTestAssemblyFilePath();`
the directory returned by GetThisTestAssemblyFilePath() doesn't actually exist at that moment. This can happen if:
- The path is in a temporary folder: The test assembly might be running from a temporary directory that has been cleaned up or isn't guaranteed to exist at runtime.
- The directory was deleted: If any part of the test fixture's lifecycle (or the test runner) cleans up temporary directories before this line executes, setting the current directory will fail.

To fix this, this PR chooses a different base directory that is known to persist throughout the test execution by using Path.GetTempPath();

Since we are now using the temp path, both test files `OrderedFileSpecifierTests` and `FileSpecifiertests` rely on modifying the current working directory and accessing temporary directories, and they interfere with each other when run concurrently.

To resolve this, we also add the test collection attribute `[Collection("TestsUsingCurrentDirectory")]` to ensure that these tests run sequentially, reducing nondeterministic failures and resource conflicts.
