### PR TITLE
[Tests] Make tests work for all autocrlf settings (on Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,9 @@
 ###############################################################################
 src/Sarif/Taxonomies/SampleCode.cs eol=lf
 
+# Pinned: this resource is embedded and hashed; line-ending drift would change the hash.
+src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/InsertOptionalDataVisitor.txt text eol=crlf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/src/Test.UnitTests.Sarif.Converters/AndroidStudioConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/AndroidStudioConverterTests.cs
@@ -123,9 +123,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var uut = new AndroidStudioProblem(builder);
             Result result = new AndroidStudioConverter().ConvertProblemToSarifResult(uut);
-            Assert.Equal(@"hungry EVIL zombies
-Possible resolution: comment
-Possible resolution: delete", result.Message.Text);
+            Assert.Equal(
+                $"hungry EVIL zombies{Environment.NewLine}Possible resolution: comment{Environment.NewLine}Possible resolution: delete",
+                result.Message.Text);
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Converters/FortifyUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyUtilitiesTests.cs
@@ -14,12 +14,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters.UnitTests
         {
             string content = @"<Content><Paragraph><b>General relativity</b> is the <pre>geometric theory of gravitation</pre> published by <i>Albert Einstein</i> in 1915 and the current description of <IfDef var=""ConditionalDescriptions""><ConditionalText attr=""value"">gravitation in modern physics</ConditionalText></IfDef>.<AltParagraph>General relativity generalizes special relativity and <Replace key=""Scientist.lastName""/>'s law of universal gravitation, providing a unified description of gravity as a geometric property of space and time, or spacetime. In particular, the curvature of spacetime is directly related to the energy and momentum of whatever matter and radiation are present.</AltParagraph>The relation is specified by the <code>Einstein field equations</code>, a system of <code>partial differential equations</code>.";
             content += $"{Environment.NewLine}And here's a garbage\n{Environment.NewLine} \n  \n\ndouble line break!</Paragraph></Content>";
-            string expected = @"**General relativity** is the `geometric theory of gravitation` published by _Albert Einstein_ in 1915 and the current description of gravitation in modern physics.
-General relativity generalizes special relativity and {Scientist.lastName}'s law of universal gravitation, providing a unified description of gravity as a geometric property of space and time, or spacetime. In particular, the curvature of spacetime is directly related to the energy and momentum of whatever matter and radiation are present.
-The relation is specified by the `Einstein field equations`, a system of `partial differential equations`.
-And here's a garbage
-
-double line break!";
+            string expected = string.Join(Environment.NewLine,
+                "**General relativity** is the `geometric theory of gravitation` published by _Albert Einstein_ in 1915 and the current description of gravitation in modern physics.",
+                "General relativity generalizes special relativity and {Scientist.lastName}'s law of universal gravitation, providing a unified description of gravity as a geometric property of space and time, or spacetime. In particular, the curvature of spacetime is directly related to the energy and momentum of whatever matter and radiation are present.",
+                "The relation is specified by the `Einstein field equations`, a system of `partial differential equations`.",
+                "And here's a garbage",
+                "",
+                "double line break!");
             string actual = FortifyUtilities.ParseFormattedContentText(content);
             Assert.Equal(expected, actual);
         }

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -115,13 +115,14 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void Stack_CreateFromStackTraceWithRelativeSourceFileLocation()
         {
-            string stackTraceTemplate = @"   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
-   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
-   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
-   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
-   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
-   at System.IO.File.Create(String path, Int32 bufferSize)
-   at Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core.StackTests.Stack_CreateFromExceptionWithInnerException()";
+            string stackTraceTemplate = string.Join(Environment.NewLine,
+                "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
+                "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)",
+                "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)",
+                "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)",
+                "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)",
+                "   at System.IO.File.Create(String path, Int32 bufferSize)",
+                "   at Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core.StackTests.Stack_CreateFromExceptionWithInnerException()");
 
             int relativePathLineNumber = 60;
             string relativeFilePath = "/_/src/Test.UnitTests.Sarif/Core/StackTests.cs";

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -44,15 +44,15 @@ Accept-Language: en, mi
         public void WebRequest_Parse_ExtractsBody()
         {
             // Example from RFC 7230.
-            const string RequestString =
-@"GET /hello.txt HTTP/1.1
-User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
-Host: www.example.com
-Accept-Language: en, mi
-
-This is the body.
-Line 2.
-";
+            string RequestString = string.Join(Environment.NewLine,
+                "GET /hello.txt HTTP/1.1",
+                "User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3",
+                "Host: www.example.com",
+                "Accept-Language: en, mi",
+                "",
+                "This is the body.",
+                "Line 2.",
+                "");
 
             var webRequest = WebRequest.Parse(RequestString);
 

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -17,19 +17,19 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         public void WebResponse_Parse_CreatesExpectedWebResponseObject()
         {
             // Example from RFC 7230.
-            const string ResponseString =
-@"HTTP/1.1 200 OK
-Date: Mon, 27 Jul 2009 12:28:53 GMT
-Server: Apache
-Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
-ETag: ""34aa387-d-1568eb00""
-Accept-Ranges: bytes
-Content-Length: 51
-Vary: Accept-Encoding
-Content-Type: text/plain
-
-Hello World!My payload includes a trailing NewLine.
-";
+            string ResponseString = string.Join(Environment.NewLine,
+                "HTTP/1.1 200 OK",
+                "Date: Mon, 27 Jul 2009 12:28:53 GMT",
+                "Server: Apache",
+                "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT",
+                "ETag: \"34aa387-d-1568eb00\"",
+                "Accept-Ranges: bytes",
+                "Content-Length: 51",
+                "Vary: Accept-Encoding",
+                "Content-Type: text/plain",
+                "",
+                "Hello World!My payload includes a trailing NewLine.",
+                "");
 
             var webResponse = WebResponse.Parse(ResponseString);
 

--- a/src/Test.Utilities.Sarif/TestAssetResourceExtractor.cs
+++ b/src/Test.Utilities.Sarif/TestAssetResourceExtractor.cs
@@ -68,7 +68,12 @@ namespace Microsoft.CodeAnalysis.Sarif
             ValidateStream(resourcePath, fallbackResourcePath, stream);
 
             using var reader = new StreamReader(stream);
-            return reader.ReadToEnd();
+            string text = reader.ReadToEnd();
+
+            // Canonicalize line endings to Environment.NewLine so resource text
+            // compares equal to tool output regardless of how the file was
+            // checked out (autocrlf) or which OS is running the tests.
+            return text.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
         }
 
         public byte[] GetResourceBytes(string resourcePath)


### PR DESCRIPTION
Test input files, baseline files, and multiline strings get their line endings changed based on git's core.autocrlf config setting, while the text generated by the Sarif tools generally has line endings set using Environment.NewLine.

Included in this PR is fixes for all of the tests that failed when run in a checkout set up with core.autocrlf=input on a Windows machine.