### PR TITLE
Enabling CodeQL workflows and updating codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @michaelcfanning @suvamM @shaopeng-gh @scottoneil-ms @rwoll @yongyan-gh @LingZhou-gh @EasyRhinoMSFT @cfaucon @nguerrera
+* @michaelcfanning @scottoneil-ms @cfaucon @nguerrera

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,12 +12,16 @@
 name: "CodeQL"
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-js-analysis.yml
+++ b/.github/workflows/codeql-js-analysis.yml
@@ -2,17 +2,15 @@ name: "CodeQL JS"
 
 on:
   push:
-    branches: "**"
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * 0'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
This PR updates the CodeQL workflows to run in two cases:
- after every merge (main)
- every day at midnight

It also updates the code owners by keeping only the current team members.