### PR TITLE
Add filtering of symbolic links to (Ordered)FileSpecifier

### DIFF
--- a/src/Sarif.Driver/FileSpecifier.cs
+++ b/src/Sarif.Driver/FileSpecifier.cs
@@ -100,7 +100,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     {
                         foreach (string subdir in FileSystem.DirectoryGetDirectories(dir))
                         {
-                            AddFilesFromDirectory(subdir, filter);
+                            // Skip subdirectories that are symbolic links to prevent infinite loops
+                            // and avoid unintentionally following symbolic links during recursion
+                            if (!FileSystem.IsSymbolicLink(subdir))
+                            {
+                                AddFilesFromDirectory(subdir, filter);
+                            }
                         }
                     }
                     catch (UnauthorizedAccessException)

--- a/src/Sarif.Driver/OrderedFileSpecifier.cs
+++ b/src/Sarif.Driver/OrderedFileSpecifier.cs
@@ -195,7 +195,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     return;
                 }
 
-                EnqueueAllFilesUnderDirectory(childDirectory, fileChannelWriter, fileFilter, sortedDiskItemsBuffer);
+                // Skip subdirectories that are symbolic links to prevent infinite loops
+                // and avoid unintentionally following symbolic links during recursion
+                if (!FileSystem.IsSymbolicLink(childDirectory))
+                {
+                    EnqueueAllFilesUnderDirectory(childDirectory, fileChannelWriter, fileFilter, sortedDiskItemsBuffer);
+                }
             }
         }
 

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -417,8 +417,26 @@ namespace Microsoft.CodeAnalysis.Sarif
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.fileattributes
             // While symbolic links will have the ReparsePoint flag set, not all reparse points represent symbolic links.
             // This is a basic implementation.
-            var fileInfo = new FileInfo(path);
-            return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var fileInfo = new FileInfo(path);
+                    return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+                }
+                else if (Directory.Exists(path))
+                {
+                    var directoryInfo = new DirectoryInfo(path);
+                    return (directoryInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+                }
+
+                return false;
+            }
+            catch
+            {
+                // In case of any exception (permissions, etc.), assume it's not a symbolic link
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -404,39 +404,31 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         /// <summary>
-        /// Uses <see cref="FileInfo"/> to determine whether a file is a symbolic link.
+        /// Uses <see cref="FileInfo"/> or <see cref="DirectoryInfo"/> to determine whether a file or directory is a symbolic link.
         /// </summary>
         /// <param name="path">
-        /// The fully qualified name or relative path of the file.
+        /// The fully qualified name or relative path of the file or directory.
         /// </param>
         /// <returns>
-        /// A boolean value indicating whether the file is a symbolic link.
+        /// A boolean value indicating whether the file or directory is a symbolic link.
         /// </returns>
         public bool IsSymbolicLink(string path)
         {
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.fileattributes
             // While symbolic links will have the ReparsePoint flag set, not all reparse points represent symbolic links.
             // This is a basic implementation.
-            try
+            if (FileExists(path))
             {
-                if (File.Exists(path))
-                {
-                    var fileInfo = new FileInfo(path);
-                    return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
-                }
-                else if (Directory.Exists(path))
-                {
-                    var directoryInfo = new DirectoryInfo(path);
-                    return (directoryInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
-                }
+                var fileInfo = new FileInfo(path);
+                return (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
+            else if (DirectoryExists(path))
+            {
+                var directoryInfo = new DirectoryInfo(path);
+                return (directoryInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
 
-                return false;
-            }
-            catch
-            {
-                // In case of any exception (permissions, etc.), assume it's not a symbolic link
-                return false;
-            }
+            return false;
         }
 
         /// <summary>

--- a/src/Test.UnitTests.Sarif.Driver/FileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/FileSpecifierTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var mockFileSystem = new Mock<IFileSystem>();
 
-            string baseDir = @"C:\test";
+            string baseDir = Path.Combine(Path.GetTempPath(), "test");
             string targetDir = Path.Combine(baseDir, "target");
             string symlinkDir = Path.Combine(baseDir, "symlink");
             string targetFile = Path.Combine(targetDir, "test.txt");

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -223,11 +223,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 var artifacts = specifier.Artifacts.ToList();
 
                 artifacts.Count.Should().Be(2);
-                
+
                 var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
                 filePaths.Should().Contain(targetFile1);
                 filePaths.Should().Contain(targetFile2);
-                
                 filePaths.Should().NotContain(path => path.Contains("realSymlink"));
                 filePaths.Should().AllSatisfy(path => path.Should().Contain("realTarget"));
             }
@@ -262,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 var artifacts = specifier.Artifacts.ToList();
 
                 artifacts.Count.Should().Be(2);
-                
+
                 var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
                 filePaths.Should().Contain(targetFile);
                 filePaths.Should().Contain(symlinkFile);
@@ -309,11 +308,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 var artifacts = specifier.Artifacts.ToList();
 
                 artifacts.Count.Should().Be(2);
-                
+
                 var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
                 filePaths.Should().Contain(testFile1);
                 filePaths.Should().Contain(testFile2);
-                
+
                 filePaths.Should().NotContain(path => path.Contains("linkToParent"));
                 filePaths.Should().NotContain(path => path.Contains("linkToSibling"));
             }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var mockFileSystem = new Mock<IFileSystem>();
 
-            string baseDir = @"C:\test";
+            string baseDir = Path.Combine(Path.GetTempPath(), "test");
             string targetDir = Path.Combine(baseDir, "target");
             string symlinkDir = Path.Combine(baseDir, "symlink");
             string targetFile = Path.Combine(targetDir, "test.txt");
@@ -195,7 +195,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
-        [Trait(TestTraits.WindowsOnly, "true")]
         public void OrderedFileSpecifier_SkipsRealSymbolicLinkDirectoriesDuringRecursion()
         {
             string tempFolder = Path.GetTempPath();
@@ -239,7 +238,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
-        [Trait(TestTraits.WindowsOnly, "true")]
         public void OrderedFileSpecifier_HandlesSymbolicLinkFiles()
         {
             string tempFolder = Path.GetTempPath();

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -10,6 +10,8 @@ using System.Text;
 
 using FluentAssertions;
 
+using Moq;
+
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver
@@ -154,6 +156,222 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
 
             sb.Length.Should().Be(0, because: "all artifacts should be enumerated but the following cases failed." + Environment.NewLine + sb.ToString());
+        }
+
+        [Fact]
+        public void OrderedFileSpecifier_SkipsSymbolicLinkDirectoriesDuringRecursion()
+        {
+            var mockFileSystem = new Mock<IFileSystem>();
+
+            string baseDir = @"C:\test";
+            string targetDir = Path.Combine(baseDir, "target");
+            string symlinkDir = Path.Combine(baseDir, "symlink");
+            string targetFile = Path.Combine(targetDir, "test.txt");
+
+            mockFileSystem.Setup(fs => fs.DirectoryExists(baseDir)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(targetDir)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(symlinkDir)).Returns(true);
+
+            mockFileSystem.Setup(fs => fs.DirectoryEnumerateDirectories(baseDir, "*", SearchOption.TopDirectoryOnly))
+                          .Returns(new[] { targetDir, symlinkDir });
+
+            mockFileSystem.Setup(fs => fs.DirectoryEnumerateFiles(targetDir, "*.txt", SearchOption.TopDirectoryOnly))
+                          .Returns(new[] { targetFile });
+            mockFileSystem.Setup(fs => fs.DirectoryEnumerateFiles(symlinkDir, "*.txt", SearchOption.TopDirectoryOnly))
+                          .Returns(new[] { Path.Combine(symlinkDir, "test.txt") });
+
+            mockFileSystem.Setup(fs => fs.IsSymbolicLink(targetDir)).Returns(false);
+            mockFileSystem.Setup(fs => fs.IsSymbolicLink(symlinkDir)).Returns(true);
+
+            var specifier = new OrderedFileSpecifier(Path.Combine(baseDir, "*.txt"), recurse: true, fileSystem: mockFileSystem.Object);
+            var artifacts = specifier.Artifacts.ToList();
+
+            artifacts.Count.Should().Be(1);
+            artifacts[0].Uri.LocalPath.Should().Be(targetFile);
+            artifacts[0].Uri.LocalPath.Should().Contain("target");
+            artifacts[0].Uri.LocalPath.Should().NotContain("symlink");
+
+            mockFileSystem.Verify(fs => fs.IsSymbolicLink(symlinkDir), Times.Once);
+        }
+
+        [Fact]
+        public void OrderedFileSpecifier_SkipsRealSymbolicLinkDirectoriesDuringRecursion()
+        {
+            string tempFolder = Path.GetTempPath();
+            string testBaseDir = Path.Combine(tempFolder, Guid.NewGuid().ToString());
+            string targetDir = Path.Combine(testBaseDir, "realTarget");
+            string symlinkDir = Path.Combine(testBaseDir, "realSymlink");
+            string targetFile1 = Path.Combine(targetDir, "target1.txt");
+            string targetFile2 = Path.Combine(targetDir, "target2.txt");
+
+            try
+            {
+                Directory.CreateDirectory(testBaseDir);
+                Directory.CreateDirectory(targetDir);
+                File.WriteAllText(targetFile1, "This is target file 1");
+                File.WriteAllText(targetFile2, "This is target file 2");
+
+                bool createdSymlink = TryCreateSymbolicLink(symlinkDir, targetDir, isDirectory: true);
+                createdSymlink.Should().BeTrue("symbolic link creation should succeed for this test to be valid");
+
+                Directory.Exists(symlinkDir).Should().BeTrue();
+                var fileSystem = new FileSystem();
+                fileSystem.IsSymbolicLink(symlinkDir).Should().BeTrue();
+                fileSystem.IsSymbolicLink(targetDir).Should().BeFalse();
+
+                var specifier = new OrderedFileSpecifier(Path.Combine(testBaseDir, "*.txt"), recurse: true);
+                var artifacts = specifier.Artifacts.ToList();
+
+                artifacts.Count.Should().Be(2);
+                
+                var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
+                filePaths.Should().Contain(targetFile1);
+                filePaths.Should().Contain(targetFile2);
+                
+                filePaths.Should().NotContain(path => path.Contains("realSymlink"));
+                filePaths.Should().AllSatisfy(path => path.Should().Contain("realTarget"));
+            }
+            finally
+            {
+                CleanupDirectoryOrFile(new[] { testBaseDir });
+            }
+        }
+
+        [Fact]
+        public void OrderedFileSpecifier_HandlesSymbolicLinkFiles()
+        {
+            string tempFolder = Path.GetTempPath();
+            string testBaseDir = Path.Combine(tempFolder, Guid.NewGuid().ToString());
+            string targetFile = Path.Combine(testBaseDir, "realTargetFile.txt");
+            string symlinkFile = Path.Combine(testBaseDir, "symlinkFile.txt");
+
+            try
+            {
+                Directory.CreateDirectory(testBaseDir);
+                File.WriteAllText(targetFile, "This is the real target file");
+
+                bool createdSymlink = TryCreateSymbolicLink(symlinkFile, targetFile, isDirectory: false);
+                createdSymlink.Should().BeTrue("symbolic link creation should succeed for this test to be valid");
+
+                File.Exists(symlinkFile).Should().BeTrue();
+                var fileSystem = new FileSystem();
+                fileSystem.IsSymbolicLink(symlinkFile).Should().BeTrue();
+                fileSystem.IsSymbolicLink(targetFile).Should().BeFalse();
+
+                var specifier = new OrderedFileSpecifier(Path.Combine(testBaseDir, "*.txt"), recurse: false);
+                var artifacts = specifier.Artifacts.ToList();
+
+                artifacts.Count.Should().Be(2);
+                
+                var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
+                filePaths.Should().Contain(targetFile);
+                filePaths.Should().Contain(symlinkFile);
+            }
+            finally
+            {
+                CleanupDirectoryOrFile(new[] { testBaseDir });
+            }
+        }
+
+        [Fact]
+        public void OrderedFileSpecifier_PreventsInfiniteLoopsWithCircularSymlinks()
+        {
+            string tempFolder = Path.GetTempPath();
+            string testBaseDir = Path.Combine(tempFolder, Guid.NewGuid().ToString());
+            string subDir1 = Path.Combine(testBaseDir, "subdir1");
+            string subDir2 = Path.Combine(testBaseDir, "subdir2");
+            string symlinkToParent = Path.Combine(subDir1, "linkToParent");
+            string symlinkToSibling = Path.Combine(subDir1, "linkToSibling");
+            string testFile1 = Path.Combine(subDir1, "file1.txt");
+            string testFile2 = Path.Combine(subDir2, "file2.txt");
+
+            try
+            {
+                Directory.CreateDirectory(testBaseDir);
+                Directory.CreateDirectory(subDir1);
+                Directory.CreateDirectory(subDir2);
+                File.WriteAllText(testFile1, "File in subdir1");
+                File.WriteAllText(testFile2, "File in subdir2");
+
+                bool createdParentLink = TryCreateSymbolicLink(symlinkToParent, testBaseDir, isDirectory: true);
+                bool createdSiblingLink = TryCreateSymbolicLink(symlinkToSibling, subDir2, isDirectory: true);
+
+                createdParentLink.Should().BeTrue("symbolic link to parent directory creation should succeed for this test to be valid");
+                createdSiblingLink.Should().BeTrue("symbolic link to sibling directory creation should succeed for this test to be valid");
+
+                Directory.Exists(symlinkToParent).Should().BeTrue();
+                Directory.Exists(symlinkToSibling).Should().BeTrue();
+                var fileSystem = new FileSystem();
+                fileSystem.IsSymbolicLink(symlinkToParent).Should().BeTrue();
+                fileSystem.IsSymbolicLink(symlinkToSibling).Should().BeTrue();
+
+                var specifier = new OrderedFileSpecifier(Path.Combine(testBaseDir, "*.txt"), recurse: true);
+                var artifacts = specifier.Artifacts.ToList();
+
+                artifacts.Count.Should().Be(2);
+                
+                var filePaths = artifacts.Select(a => a.Uri.LocalPath).ToList();
+                filePaths.Should().Contain(testFile1);
+                filePaths.Should().Contain(testFile2);
+                
+                filePaths.Should().NotContain(path => path.Contains("linkToParent"));
+                filePaths.Should().NotContain(path => path.Contains("linkToSibling"));
+            }
+            finally
+            {
+                CleanupDirectoryOrFile(new[] { testBaseDir });
+            }
+        }
+
+        /// <summary>
+        /// Attempts to create a symbolic link using cross-platform .NET methods.
+        /// Returns true if successful, false if symbolic links are not supported or permissions are insufficient.
+        /// </summary>
+        private bool TryCreateSymbolicLink(string linkPath, string targetPath, bool isDirectory)
+        {
+            try
+            {
+                if (isDirectory)
+                {
+                    Directory.CreateSymbolicLink(linkPath, targetPath);
+                }
+                else
+                {
+                    File.CreateSymbolicLink(linkPath, targetPath);
+                }
+                return true;
+            }
+            catch
+            {
+                // If any exception occurs during symbolic link creation, return false
+                // This handles cases where:
+                // - Insufficient permissions (common on Windows without admin rights)
+                // - Filesystem doesn't support symbolic links
+                // - Other platform-specific issues
+                return false;
+            }
+        }
+
+        private void CleanupDirectoryOrFile(string[] paths)
+        {
+            foreach (string path in paths)
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                    }
+                    else if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors to avoid test failures due to cleanup issues
+                }
+            }
         }
     }
 }

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/OrderedFileSpecifierTests.cs
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
+        [Trait(TestTraits.WindowsOnly, "true")]
         public void OrderedFileSpecifier_SkipsRealSymbolicLinkDirectoriesDuringRecursion()
         {
             string tempFolder = Path.GetTempPath();
@@ -238,6 +239,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
+        [Trait(TestTraits.WindowsOnly, "true")]
         public void OrderedFileSpecifier_HandlesSymbolicLinkFiles()
         {
             string tempFolder = Path.GetTempPath();


### PR DESCRIPTION
Add filtering of symbolic links to (Ordered)FileSpecifier.

This will prevent file and directory traversal from getting into an infinite recursive loop when a child directory symbolic links to a location previously within the traversal tree.