### PR TITLE
Adding EscapeNonAscii when using SarifLogger

### DIFF
--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -78,7 +78,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             _textWriter = textWriter;
             _closeWriterOnDispose = closeWriterOnDispose;
-            _jsonTextWriter = new JsonTextWriter(_textWriter);
+            _jsonTextWriter = new JsonTextWriter(_textWriter)
+            {
+                StringEscapeHandling = StringEscapeHandling.EscapeNonAscii
+            };
 
             _filePersistenceOptions = logFilePersistenceOptions;
 

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -995,7 +995,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 }
-                ;
 
                 // Validates overload that accepts any 
                 // TextWriter (for example, one instantiated over a
@@ -1009,7 +1008,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 }
-                ;
             }
             catch (Exception e)
             {

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -1234,17 +1234,5 @@ namespace Microsoft.CodeAnalysis.Sarif
             string logText = stringBuilder.ToString();
             return JsonConvert.DeserializeObject<SarifLog>(logText);
         }
-
-
-        internal static readonly ResultKindSet s_kinds = [ResultKind.Fail];
-        internal static readonly FilePersistenceOptions s_logFilePersistenceOptions = FilePersistenceOptions.None;
-
-        public FailureLevelSet FailureLevels => [FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note];
-        public OptionallyEmittedData DataToInsert => OptionallyEmittedData.ComprehensiveRegionProperties
-                                                                        | OptionallyEmittedData.ContextRegionSnippets
-                                                                        | OptionallyEmittedData.Guids
-                                                                        | OptionallyEmittedData.Hashes
-                                                                        | OptionallyEmittedData.RegionSnippets
-                                                                        | OptionallyEmittedData.RollingHashPartialFingerprints;
     }
 }

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -994,7 +994,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                                                 kinds: BaseLogger.Fail))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
-                };
+                }
+                ;
 
                 // Validates overload that accepts any 
                 // TextWriter (for example, one instantiated over a
@@ -1007,7 +1008,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                                                 kinds: BaseLogger.Fail))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
-                };
+                }
+                ;
             }
             catch (Exception e)
             {
@@ -1137,6 +1139,66 @@ namespace Microsoft.CodeAnalysis.Sarif
             invocation.ToolConfigurationNotifications.Where(notification => notification.Locations != null).Should().HaveCount(1);
         }
 
+        [Fact]
+        public void SarifLogger_ShouldNotThrowWhenWritingInvalidSequences()
+        {
+            var sb = new StringBuilder();
+
+            // Basic Latin
+            sb.Append("ASCII: Hello!");
+
+            // Accented Latin (still single UTF-16 code units in BMP)
+            sb.Append(" Café Español München");
+
+            // Greek
+            sb.Append(" Ελληνικά");
+
+            // Cyrillic
+            sb.Append(" Кириллица");
+
+            // CJK
+            sb.Append(" 漢字かなカナ");
+
+            // Music symbol (U+1D11E) -> surrogate pair
+            sb.Append(" MusicalSymbol: ").Append(char.ConvertFromUtf32(0x1D11E));
+
+            // Rocket emoji (U+1F680) -> surrogate pair
+            sb.Append(" Rocket: ").Append(char.ConvertFromUtf32(0x1F680));
+
+            // Explicit escape for a single BMP code unit (snowman U+2603)
+            sb.Append(" Snowman: \u2603");
+
+            // Explicit surrogate pair via UTF-32 for U+1F600 (grinning face)
+            int grinningFace = 0x1F600;
+            sb.Append(" Grin: ").Append(char.ConvertFromUtf32(grinningFace));
+
+            // Add some edge cases: lone high/low surrogate replaced with U+FFFD if sanitized
+            // (Normally you should AVOID constructing invalid sequences; shown only for testing.)
+            sb.Append('\uD800').Append('\uDC00'); // Valid pair for U+10000
+            sb.Append('\uD800'); // Lone high surrogate (invalid)
+            sb.Append('\uDC00'); // Lone low surrogate (invalid)
+            sb.Append('\uD83D');
+
+            string content = sb.ToString();
+            string serializedSarif = string.Empty;
+
+            using (var sarifLogger = new MemoryStreamSarifLogger())
+            {
+                var result = new Result
+                {
+                    Message = new Message
+                    {
+                        Text = content
+                    }
+                };
+
+                sarifLogger.Log(new ReportingDescriptor(), result, null);
+                serializedSarif = JsonConvert.SerializeObject(sarifLogger.ToSarifLog());
+            }
+
+            serializedSarif.Should().NotBeNull();
+        }
+
         private static void VerifySarifLogHonoredKindAndLevel(FailureLevelSet desiredFailureLevels, ResultKindSet desiredResultKinds, SarifLog sarifLog)
         {
             int expectedCount = desiredResultKinds.Count * desiredFailureLevels.Count;
@@ -1174,5 +1236,17 @@ namespace Microsoft.CodeAnalysis.Sarif
             string logText = stringBuilder.ToString();
             return JsonConvert.DeserializeObject<SarifLog>(logText);
         }
+
+
+        internal static readonly ResultKindSet s_kinds = [ResultKind.Fail];
+        internal static readonly FilePersistenceOptions s_logFilePersistenceOptions = FilePersistenceOptions.None;
+
+        public FailureLevelSet FailureLevels => [FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note];
+        public OptionallyEmittedData DataToInsert => OptionallyEmittedData.ComprehensiveRegionProperties
+                                                                        | OptionallyEmittedData.ContextRegionSnippets
+                                                                        | OptionallyEmittedData.Guids
+                                                                        | OptionallyEmittedData.Hashes
+                                                                        | OptionallyEmittedData.RegionSnippets
+                                                                        | OptionallyEmittedData.RollingHashPartialFingerprints;
     }
 }


### PR DESCRIPTION
## Context

The team is using SarifLogger to generate a SARIF after scanning some content. From time to time, we scan content containing emojis and other symbols. In the scanner, when retrieving the context region snippet, you might retrieve a partial character, and with that, you break it, generating a problem when writing.

## Exception

```
System.Text.EncoderFallbackException
  HResult=0x80070057
  Message=Unable to translate Unicode character \\uD83D at index -1 to specified code page.
  Source=System.Private.CoreLib
  StackTrace:
...
...
...
   at Microsoft.CodeAnalysis.Sarif.Writers.ResultLogJsonWriter.WriteResult(Result result) in C:\repos\sarif-sdk\src\Sarif\Writers\ResultLogJsonWriter.cs:line 223
   at Microsoft.CodeAnalysis.Sarif.Writers.SarifLogger.Log(ReportingDescriptor rule, Result result, Nullable`1 extensionIndex) in C:\repos\sarif-sdk\src\Sarif\Writers\SarifLogger.cs:line 382
   at Microsoft.CodeAnalysis.Sarif.SarifLoggerTests.SarifLogger_ShouldNotThrowWhenWritingInvalidSequences() in C:\repos\sarif-sdk\src\Test.UnitTests.Sarif\Writers\SarifLoggerTests.cs:line 1194
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

## Solution

To prevent an unhandled exception when using SarifLogger, by enabling the option `StringEscapeHandling = StringEscapeHandling.EscapeNonAscii`, the writer properly handles broken characters, allowing us to write properly.

## Tests

The below text is the message written retrieved from the SARIF to prove that the content was kept:
```json
"message": {
    "text": "ASCII: Hello! Café Español München Ελληνικά Кириллица 漢字かなカナ MusicalSymbol: 𝄞 Rocket: 🚀 Snowman: ☃ Grin: 😀𐀀𐀀�"
}
```

As you can see the last character is the broken one that was introduced.