### PR TITLE
Add health check query parameter support for `--post-uri` validation.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v4.6.1 UNRELEASED**
+* NEW: Add health check query parameter support for `--post-uri` validation. The driver now appends `?healthcheck=true` to POST URIs during validation and accepts HTTP 202 (Accepted), or 422 (Unprocessable Entity) as valid responses. This provides better support for endpoints that implement health check functionality while maintaining backwards compatibility with servers that return 422 for empty payloads.
+
 ## **v4.6.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.6.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.6.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.6.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.6.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.6.0)
 * BRK: Remove defunct and unsupported `kusto` command in `Sarif.Multitool`.
 * BRK: Remove support for .NET Core 3.1 and .NET 6.0 in preference of a [supported version of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), `net8.0`.

--- a/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
+++ b/src/Sarif.Driver/Sdk/PluginDriverCommand.cs
@@ -223,8 +223,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         protected virtual void PostLogFile(IAnalysisContext globalContext)
         {
-            using var httpClient = new HttpClientWrapper();
+            using HttpClientWrapper httpClient = GetHttpClientWrapper();
             SarifPost(globalContext, httpClient);
+        }
+
+        protected virtual HttpClientWrapper GetHttpClientWrapper()
+        {
+            return new HttpClientWrapper();
         }
 
         internal static void SarifPost(IAnalysisContext globalContext, HttpClientWrapper httpClient)

--- a/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
+++ b/src/Test.UnitTests.Sarif.Driver/TestMultithreadedAnalyzeCommand.cs
@@ -10,8 +10,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 {
     public class TestMultithreadedAnalyzeCommand : MultithreadedAnalyzeCommandBase<TestAnalysisContext, TestAnalyzeOptions>, ITestAnalyzeCommand
     {
+        private readonly HttpClientWrapper _httpClientWrapper;
+
         public TestMultithreadedAnalyzeCommand(IFileSystem fileSystem = null) : base(fileSystem)
         {
+            TestRule.s_testRuleBehaviors = 0;
+        }
+
+        public TestMultithreadedAnalyzeCommand(IFileSystem fileSystem, HttpClientWrapper httpClientWrapper)
+            : base(fileSystem)
+        {
+            _httpClientWrapper = httpClientWrapper;
             TestRule.s_testRuleBehaviors = 0;
         }
 
@@ -98,6 +107,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public new void CheckIncompatibleRules(IEnumerable<Skimmer<TestAnalysisContext>> skimmers, TestAnalysisContext context, ISet<string> disabledSkimmers)
         {
             base.CheckIncompatibleRules(skimmers, context, disabledSkimmers);
+        }
+
+        protected override HttpClientWrapper GetHttpClientWrapper()
+        {
+            return _httpClientWrapper ?? base.GetHttpClientWrapper();
         }
     }
 }


### PR DESCRIPTION
The driver now appends `?healthcheck=true` to POST URIs during validation and accepts HTTP 202 (Accepted), or 422 (Unprocessable Entity) as valid responses. This provides better support for endpoints that implement health check functionality while maintaining backwards compatibility with servers that return 422 for empty payloads.