### PR TITLE
Add optionally emitted analysis targets...

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -2,6 +2,7 @@
 
 ## **v4.6.1 UNRELEASED**
 * NEW: Add health check query parameter support for `--post-uri` validation. The driver now appends `?healthcheck=true` to POST URIs during validation and accepts HTTP 202 (Accepted), or 422 (Unprocessable Entity) as valid responses. This provides better support for endpoints that implement health check functionality while maintaining backwards compatibility with servers that return 422 for empty payloads.
+* NEW: `SarifLogger.AnalyzingTarget` now optionally emits an explicit artifacts table entry (with `AnalysisTarget` role) for every scan target when `OptionallyEmittedData.AnalysisTargets` is set via `--insert`.
 
 ## **v4.6.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.6.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.6.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.6.0)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.6.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.6.0)
 * BRK: Remove defunct and unsupported `kusto` command in `Sarif.Multitool`.

--- a/src/Sarif/OptionallyEmittedData.cs
+++ b/src/Sarif/OptionallyEmittedData.cs
@@ -86,6 +86,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         // Enrich SARIF log with partial fingerprint based on the CodeQL rolling hash algorithm.
         RollingHashPartialFingerprints = 0x4000,
 
+        // Persist an entry in the artifacts table for every analysis target, with the
+        // AnalysisTarget role, even if no result is reported for that target.
+        AnalysisTargets = 0x8000,
+
         // A special enum value that indicates that insertion should overwrite any existing
         // information in the SARIF log file. In the absence of this setting, any existing
         // data that would otherwise have been overwritten by the insert operation will

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -292,6 +292,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public bool Optimize => _filePersistenceOptions.HasFlag(FilePersistenceOptions.Optimize);
 
+        public bool PersistAnalysisTargets => _dataToInsert.HasFlag(OptionallyEmittedData.AnalysisTargets);
+
         public virtual void Dispose()
         {
             // Disposing the json writer closes the stream but the textwriter
@@ -552,6 +554,45 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public void AnalyzingTarget(IAnalysisContext context)
         {
+            if (PersistAnalysisTargets && context?.CurrentTarget?.Uri != null)
+            {
+                Uri targetUri = context.CurrentTarget.Uri;
+
+                Encoding encoding = null;
+                if (_run.DefaultEncoding != null)
+                {
+                    try
+                    {
+                        encoding = Encoding.GetEncoding(_run.DefaultEncoding);
+                    }
+                    catch (ArgumentException) { } // Unrecognized encoding name
+                }
+
+                HashData hashData = null;
+                if (_dataToInsert.HasFlag(OptionallyEmittedData.Hashes) && FileRegionsCache != null)
+                {
+                    hashData = FileRegionsCache.GetHashData(targetUri);
+                }
+
+                var fileLocation = new ArtifactLocation
+                {
+                    Uri = new Uri(UriHelper.MakeValidUri(targetUri.OriginalString), UriKind.RelativeOrAbsolute)
+                };
+
+                // GetFileIndex will deduplicate: if the artifact is already present,
+                // it returns the existing index rather than creating a new entry.
+                int index = _run.GetFileIndex(
+                    fileLocation,
+                    addToFilesTableIfNotPresent: true,
+                    dataToInsert: _dataToInsert,
+                    encoding: encoding,
+                    hashData: hashData);
+
+                if (index > -1)
+                {
+                    _run.Artifacts[index].Roles |= ArtifactRoles.AnalysisTarget;
+                }
+            }
         }
 
         public void TargetAnalyzed(IAnalysisContext context)

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -1234,5 +1234,175 @@ namespace Microsoft.CodeAnalysis.Sarif
             string logText = stringBuilder.ToString();
             return JsonConvert.DeserializeObject<SarifLog>(logText);
         }
+
+        [Fact]
+        public void SarifLogger_AnalyzingTarget_PersistsArtifactWithAnalysisTargetRole()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         dataToInsert: OptionallyEmittedData.AnalysisTargets,
+                                                         levels: BaseLogger.ErrorWarning,
+                                                         kinds: BaseLogger.Fail))
+                {
+                    var context = new TestAnalysisContext
+                    {
+                        CurrentTarget = new EnumeratedArtifact(FileSystem.Instance)
+                        {
+                            Uri = new Uri("file:///c:/src/target.cpp")
+                        }
+                    };
+
+                    sarifLogger.AnalyzingTarget(context);
+                }
+            }
+
+            string logText = sb.ToString();
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            IList<Artifact> artifacts = sarifLog.Runs[0].Artifacts;
+            artifacts.Should().NotBeNull();
+            artifacts.Count.Should().Be(1);
+            artifacts[0].Roles.Should().HaveFlag(ArtifactRoles.AnalysisTarget);
+        }
+
+        [Fact]
+        public void SarifLogger_AnalyzingTarget_DoesNotPersistWhenFlagNotSet()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         dataToInsert: OptionallyEmittedData.None,
+                                                         levels: BaseLogger.ErrorWarning,
+                                                         kinds: BaseLogger.Fail))
+                {
+                    var context = new TestAnalysisContext
+                    {
+                        CurrentTarget = new EnumeratedArtifact(FileSystem.Instance)
+                        {
+                            Uri = new Uri("file:///c:/src/target.cpp")
+                        }
+                    };
+
+                    sarifLogger.AnalyzingTarget(context);
+                }
+            }
+
+            string logText = sb.ToString();
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            sarifLog.Runs[0].Artifacts.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void SarifLogger_AnalyzingTarget_DeduplicatesWhenResultFiresForSameTarget()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         dataToInsert: OptionallyEmittedData.AnalysisTargets,
+                                                         levels: BaseLogger.ErrorWarning,
+                                                         kinds: BaseLogger.Fail))
+                {
+                    var targetUri = new Uri("file:///c:/src/target.cpp");
+
+                    var context = new TestAnalysisContext
+                    {
+                        CurrentTarget = new EnumeratedArtifact(FileSystem.Instance)
+                        {
+                            Uri = targetUri
+                        }
+                    };
+
+                    // First, the logger records the analysis target.
+                    sarifLogger.AnalyzingTarget(context);
+
+                    // Then a result fires that references the same file.
+                    string ruleId = "TEST001";
+                    var rule = new ReportingDescriptor { Id = ruleId };
+                    var result = new Result
+                    {
+                        RuleId = ruleId,
+                        Message = new Message { Text = "A finding." },
+                        AnalysisTarget = new ArtifactLocation { Uri = targetUri },
+                        Locations = new[]
+                        {
+                            new Location
+                            {
+                                PhysicalLocation = new PhysicalLocation
+                                {
+                                    ArtifactLocation = new ArtifactLocation { Uri = targetUri }
+                                }
+                            }
+                        }
+                    };
+
+                    sarifLogger.Log(rule, result, null);
+                }
+            }
+
+            string logText = sb.ToString();
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            // Despite the target being referenced by both AnalyzingTarget and the result,
+            // only one artifact entry should exist (deduplication).
+            IList<Artifact> artifacts = sarifLog.Runs[0].Artifacts;
+            artifacts.Should().NotBeNull();
+            artifacts.Count.Should().Be(1);
+            artifacts[0].Roles.Should().HaveFlag(ArtifactRoles.AnalysisTarget);
+        }
+
+        [Fact]
+        public void SarifLogger_AnalyzingTarget_PersistsMultipleTargets()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(textWriter,
+                                                         dataToInsert: OptionallyEmittedData.AnalysisTargets,
+                                                         levels: BaseLogger.ErrorWarning,
+                                                         kinds: BaseLogger.Fail))
+                {
+                    var targets = new[]
+                    {
+                        new Uri("file:///c:/src/file1.cpp"),
+                        new Uri("file:///c:/src/file2.cpp"),
+                        new Uri("file:///c:/src/file3.cpp"),
+                    };
+
+                    foreach (Uri targetUri in targets)
+                    {
+                        var context = new TestAnalysisContext
+                        {
+                            CurrentTarget = new EnumeratedArtifact(FileSystem.Instance)
+                            {
+                                Uri = targetUri
+                            }
+                        };
+
+                        sarifLogger.AnalyzingTarget(context);
+                    }
+                }
+            }
+
+            string logText = sb.ToString();
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            IList<Artifact> artifacts = sarifLog.Runs[0].Artifacts;
+            artifacts.Should().NotBeNull();
+            artifacts.Count.Should().Be(3);
+
+            foreach (Artifact artifact in artifacts)
+            {
+                artifact.Roles.Should().HaveFlag(ArtifactRoles.AnalysisTarget);
+            }
+        }
     }
 }


### PR DESCRIPTION
…i.e., an explicit artifacts table entry on every request to scan a target.