### PR TITLE
Partition by rule

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **UNRELEASED**
+* NEW: Add `partition` multitool verb that splits one SARIF log into many by strategy (`PerRule` (default), `PerRunPerRule`, `PerRun`, `PerResult`, `PerRunPerTarget`, `PerRunPerTargetPerRule`, `PerIndexList`). Wraps `SarifPartitioner.Partition`, so each output gets its `tool.driver.rules` and `run.artifacts` pruned to only what the partition references.
+* NEW: Add `SplittingStrategy.PerIndexList` plus the `--indices` mini-language for explicit per-result bucket assignment: `<runId>:<r1>,<r2>;<runId>:...|<bucket>...`, with bare-int shorthand for run 0 and SARIF URL fallback (`sarif:/runs/X/results/Y`, §3.10.3). Optional `--spillover-bucket NAME` captures uncovered results; `--strict-coverage` errors on uncovered results. Duplicate or out-of-range addresses error.
+* NEW: Add public SDK helper `Microsoft.CodeAnalysis.Sarif.Writers.PartitionFunctions` (`ForStrategy`, `ForIndexList`, `ParseIndexSpec`, `ResultAddress`) to centralize partition-key derivation across SDK consumers.
+
 ## **v4.6.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v4.6.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v4.6.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v4.6.3)  | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v4.6.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v4.6.3)
 * BRK: Renumber AI validation rules for RFC 2119 compliance (`AI1xxx` = MUST/SHALL error; `AI2xxx` = SHOULD warning/note). `AI2006` → `AI1005`, `AI1007` → `AI2014`. The `AI3xxx` series is eliminated.
 * NEW: Add `AI1010.EvidenceBackingResolvable` (error) — every `sarif:` URI in `ai/evidence[].backing` SHALL resolve to an element within the log file (§3.10.3).

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## **UNRELEASED**
+* BRK: Rename `Microsoft.CodeAnalysis.Sarif.Multitool.OptionsInterpretter` (and its test class `OptionsInterpretterTests`) to `OptionsInterpreter` / `OptionsInterpreterTests` (single `t`). External callers of `Sarif.Multitool.Library` constructing `new OptionsInterpretter(...)` must update to `new OptionsInterpreter(...)`.
 * NEW: Add `partition` multitool verb that splits one SARIF log into many by strategy (`PerRule` (default), `PerRunPerRule`, `PerRun`, `PerResult`, `PerRunPerTarget`, `PerRunPerTargetPerRule`, `PerIndexList`). Wraps `SarifPartitioner.Partition`, so each output gets its `tool.driver.rules` and `run.artifacts` pruned to only what the partition references.
 * NEW: Add `SplittingStrategy.PerIndexList` plus the `--indices` mini-language for explicit per-result bucket assignment: `<runId>:<r1>,<r2>;<runId>:...|<bucket>...`, with bare-int shorthand for run 0 and SARIF URL fallback (`sarif:/runs/X/results/Y`, §3.10.3). Optional `--spillover-bucket NAME` captures uncovered results; `--strict-coverage` errors on uncovered results. Duplicate or out-of-range addresses error.
 * NEW: Add public SDK helper `Microsoft.CodeAnalysis.Sarif.Writers.PartitionFunctions` (`ForStrategy`, `ForIndexList`, `ParseIndexSpec`, `ResultAddress`) to centralize partition-key derivation across SDK consumers.

--- a/src/Sarif.Multitool.Library/OptionsInterpreter.cs
+++ b/src/Sarif.Multitool.Library/OptionsInterpreter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -9,14 +9,14 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    public class OptionsInterpretter
+    public class OptionsInterpreter
     {
         //  Poor man's dependency injection
-        public OptionsInterpretter() : this(new EnvironmentVariableGetter())
+        public OptionsInterpreter() : this(new EnvironmentVariableGetter())
         {
         }
 
-        public OptionsInterpretter(IEnvironmentVariableGetter environmentVariableGetter)
+        public OptionsInterpreter(IEnvironmentVariableGetter environmentVariableGetter)
         {
             _environmentVariableGetter = environmentVariableGetter ?? throw new ArgumentNullException(nameof(environmentVariableGetter));
         }

--- a/src/Sarif.Multitool.Library/OptionsInterpretter.cs
+++ b/src/Sarif.Multitool.Library/OptionsInterpretter.cs
@@ -145,6 +145,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             ConsumeEnvVarsAndInterpretOptions((MultipleFilesOptionsBase)rebaseUriOptions);
         }
 
+        public void ConsumeEnvVarsAndInterpretOptions(PartitionOptions partitionOptions)
+        {
+            ConsumeEnvVarsAndInterpretOptions((SingleFileOptionsBase)partitionOptions);
+        }
+
         public void ConsumeEnvVarsAndInterpretOptions(RewriteOptions rewriteOptions)
         {
             ConsumeEnvVarsAndInterpretOptions((SingleFileOptionsBase)rewriteOptions);

--- a/src/Sarif.Multitool.Library/PartitionCommand.cs
+++ b/src/Sarif.Multitool.Library/PartitionCommand.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+using Microsoft.CodeAnalysis.Sarif.Visitors;
+using Microsoft.CodeAnalysis.Sarif.Writers;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    public class PartitionCommand : CommandBase
+    {
+        private readonly IFileSystem _fileSystem;
+
+        public PartitionCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? Sarif.FileSystem.Instance;
+        }
+
+        public int Run(PartitionOptions options)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                if (!ValidateOptions(options))
+                {
+                    return FAILURE;
+                }
+
+                string outputDirectory = string.IsNullOrEmpty(options.OutputDirectoryPath)
+                    ? Environment.CurrentDirectory
+                    : options.OutputDirectoryPath;
+
+                Console.WriteLine($"Partitioning '{options.InputFilePath}' using strategy '{options.SplittingStrategy}'...");
+
+                SarifLog inputLog = ReadSarifFile<SarifLog>(_fileSystem, options.InputFilePath);
+
+                PartitionFunction<string> partitionFunction = options.SplittingStrategy == SplittingStrategy.PerIndexList
+                    ? PartitionFunctions.ForIndexList(
+                          inputLog,
+                          options.Indices,
+                          string.IsNullOrEmpty(options.SpilloverBucket) ? null : options.SpilloverBucket,
+                          options.StrictCoverage)
+                    : PartitionFunctions.ForStrategy(inputLog, options.SplittingStrategy);
+
+                IDictionary<string, SarifLog> partitions = SarifPartitioner.Partition(
+                    inputLog,
+                    partitionFunction,
+                    deepClone: true);
+
+                _fileSystem.DirectoryCreateDirectory(outputDirectory);
+
+                int written = 0;
+                foreach (KeyValuePair<string, SarifLog> entry in partitions)
+                {
+                    string fileName = BuildOutputFileName(options.OutputFilePrefix, entry.Key);
+                    string outputPath = Path.Combine(outputDirectory, fileName);
+
+                    if (!options.ForceOverwrite && _fileSystem.FileExists(outputPath))
+                    {
+                        Console.Error.WriteLine(
+                            $"Output file '{outputPath}' already exists. Pass --log ForceOverwrite to overwrite.");
+                        return FAILURE;
+                    }
+
+                    SarifLog partitionLog = entry.Value;
+                    partitionLog.Version = SarifVersion.Current;
+                    partitionLog.SchemaUri = partitionLog.Version.ConvertToSchemaUri();
+
+                    WriteSarifFile(_fileSystem, partitionLog, outputPath, options.Minify);
+                    written++;
+                }
+
+                Console.WriteLine($"Wrote {written.ToString(CultureInfo.InvariantCulture)} partition file(s) to '{outputDirectory}'.");
+                return SUCCESS;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return FAILURE;
+            }
+            finally
+            {
+                Console.WriteLine($"Partition completed in {stopwatch.Elapsed}.");
+            }
+        }
+
+        internal static string BuildOutputFileName(string prefix, string partitionKey)
+        {
+            string safePrefix = string.IsNullOrEmpty(prefix) ? "partition" : prefix;
+            string safeKey = string.IsNullOrEmpty(partitionKey) ? "default" : partitionKey;
+            return ($"{safePrefix}_{safeKey}.sarif").ReplaceInvalidCharInFileName(".");
+        }
+
+        private static bool ValidateOptions(PartitionOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(options.InputFilePath))
+            {
+                Console.Error.WriteLine("An input SARIF file is required.");
+                return false;
+            }
+
+            if (options.SplittingStrategy == SplittingStrategy.None)
+            {
+                Console.Error.WriteLine(
+                    "Splitting strategy 'None' would produce a single output identical to the input. " +
+                    "Pick PerRule, PerRunPerRule, PerRunPerTarget, PerRunPerTargetPerRule, PerRun, PerResult, or PerIndexList.");
+                return false;
+            }
+
+            if (options.SplittingStrategy == SplittingStrategy.PerIndexList
+                && string.IsNullOrWhiteSpace(options.Indices))
+            {
+                Console.Error.WriteLine("--indices is required when --strategy=PerIndexList.");
+                return false;
+            }
+
+            if (options.SplittingStrategy != SplittingStrategy.PerIndexList
+                && !string.IsNullOrWhiteSpace(options.Indices))
+            {
+                Console.Error.WriteLine("--indices is only valid when --strategy=PerIndexList.");
+                return false;
+            }
+
+            if (options.SplittingStrategy != SplittingStrategy.PerIndexList && options.StrictCoverage)
+            {
+                Console.Error.WriteLine("--strict-coverage is only valid when --strategy=PerIndexList.");
+                return false;
+            }
+
+            if (options.SplittingStrategy != SplittingStrategy.PerIndexList && !string.IsNullOrEmpty(options.SpilloverBucket))
+            {
+                Console.Error.WriteLine("--spillover-bucket is only valid when --strategy=PerIndexList.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Sarif.Multitool.Library/PartitionOptions.cs
+++ b/src/Sarif.Multitool.Library/PartitionOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    [Verb("partition", HelpText = "Partition a single SARIF log into multiple logs according to a splitting strategy.")]
+    public class PartitionOptions : SingleFileOptionsBase
+    {
+        [Option(
+            "output-directory",
+            HelpText = "The directory to write the partitioned SARIF logs to. Defaults to the current directory.")]
+        public string OutputDirectoryPath { get; set; }
+
+        [Option(
+            "output-file-prefix",
+            Default = "partition",
+            HelpText = "Filename prefix for each output log. Files are named '{prefix}_{partitionKey}.sarif'.")]
+        public string OutputFilePrefix { get; set; }
+
+        [Option(
+            "strategy",
+            Default = SplittingStrategy.PerRule,
+            HelpText = "Splitting strategy. Supported values: PerRule, PerRunPerRule, PerRunPerTarget, " +
+                       "PerRunPerTargetPerRule, PerRun, PerResult, PerIndexList. " +
+                       "PerIndexList requires --indices.")]
+        public SplittingStrategy SplittingStrategy { get; set; }
+
+        [Option(
+            "indices",
+            HelpText = "Required when --strategy=PerIndexList. A spec in the compact mini-language: " +
+                       "'<runId>:<r1>,<r2>,...;<runId>:...|<bucket>|...'. " +
+                       "The '<runId>:' prefix is optional and defaults to 0. " +
+                       "SARIF URLs ('sarif:/runs/X/results/Y') are also accepted as segments. " +
+                       "Buckets are separated by '|', segments within a bucket by ';', and indices within a segment by ','. " +
+                       "Buckets are auto-named 'bucket0', 'bucket1', etc. Duplicate or out-of-range addresses cause an error.")]
+        public string Indices { get; set; }
+
+        [Option(
+            "spillover-bucket",
+            HelpText = "Optional bucket name (only meaningful with --strategy=PerIndexList). When set, any result not " +
+                       "addressed by --indices is written to this bucket instead of being discarded.")]
+        public string SpilloverBucket { get; set; }
+
+        [Option(
+            "strict-coverage",
+            HelpText = "Only meaningful with --strategy=PerIndexList. When set, every result in the input log must be " +
+                       "addressed by --indices (or covered by --spillover-bucket); otherwise the command fails.")]
+        public bool StrictCoverage { get; set; }
+    }
+}

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 ResultMatchingOptions,
                 MergeOptions,
                 PageOptions,
+                PartitionOptions,
                 QueryOptions,
                 RebaseUriOptions,
                 RewriteOptions,
@@ -50,6 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 .WithParsed<ResultMatchingOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .WithParsed<MergeOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .WithParsed<PageOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<PartitionOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .WithParsed<QueryOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .WithParsed<RebaseUriOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .WithParsed<RewriteOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
@@ -68,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 (ResultMatchingOptions baselineOptions) => new ResultMatchingCommand().Run(baselineOptions),
                 (MergeOptions mergeOptions) => new MergeCommand().Run(mergeOptions),
                 (PageOptions pageOptions) => new PageCommand().Run(pageOptions),
+                (PartitionOptions partitionOptions) => new PartitionCommand().Run(partitionOptions),
                 (QueryOptions queryOptions) => new QueryCommand().Run(queryOptions),
                 (RebaseUriOptions rebaseOptions) => new RebaseUriCommand().Run(rebaseOptions),
                 (RewriteOptions rewriteOptions) => new RewriteCommand().Run(rewriteOptions),

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         /// <returns>0 on success; nonzero on failure.</returns>
         public static int Main(string[] args)
         {
-            var optionsInterpretter = new OptionsInterpretter();
+            var optionsInterpreter = new OptionsInterpreter();
 
             return Parser.Default.ParseArguments<
                 // Keep this in alphabetical order
@@ -39,24 +39,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 RewriteOptions,
                 SuppressOptions,
                 ValidateOptions>(args)
-                .WithParsed<AbsoluteUriOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<AbsoluteUriOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
 #if DEBUG
-                .WithParsed<AnalyzeTestOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<AnalyzeTestOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
 #endif
-                .WithParsed<ApplyPolicyOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<ConvertOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<ExportValidationConfigurationOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<ExportValidationRulesMetadataOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<FileWorkItemsOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<ResultMatchingOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<MergeOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<PageOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<PartitionOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<QueryOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<RebaseUriOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<RewriteOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<SuppressOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
-                .WithParsed<ValidateOptions>(x => { optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ApplyPolicyOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ConvertOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ExportValidationConfigurationOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ExportValidationRulesMetadataOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<FileWorkItemsOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ResultMatchingOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<MergeOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<PageOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<PartitionOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<QueryOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<RebaseUriOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<RewriteOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<SuppressOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
+                .WithParsed<ValidateOptions>(x => { optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(x); })
                 .MapResult(
                 (AbsoluteUriOptions absoluteUriOptions) => new AbsoluteUriCommand().Run(absoluteUriOptions),
 #if DEBUG

--- a/src/Sarif/SplittingStrategy.cs
+++ b/src/Sarif/SplittingStrategy.cs
@@ -75,5 +75,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// I.e., the total number of log files created is the sum of distinct property bag property across all logs.
         /// </summary>
         PerPropertyBagProperty,
+
+        /// <summary>
+        /// Split SARIF log files according to an explicit list of result addresses
+        /// grouped into buckets. Used for AI-driven splitting where the caller
+        /// dictates exactly which results land in which output file.
+        /// </summary>
+        PerIndexList,
     }
 }

--- a/src/Sarif/Writers/PartitionFunctions.cs
+++ b/src/Sarif/Writers/PartitionFunctions.cs
@@ -1,0 +1,464 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+using Microsoft.CodeAnalysis.Sarif.Visitors;
+
+namespace Microsoft.CodeAnalysis.Sarif.Writers
+{
+    /// <summary>
+    /// Provides ready-made <see cref="PartitionFunction{T}"/> implementations for the
+    /// well-known <see cref="SplittingStrategy"/> values, plus an explicit address-list
+    /// strategy ("PerIndexList") that lets a caller dictate exactly which results land
+    /// in each output bucket.
+    /// </summary>
+    /// <remarks>
+    /// All factory methods perform a single O(N) pre-walk of the log to compute a
+    /// per-result partition key, then return an O(1) closure that the
+    /// <see cref="PartitioningVisitor{T}"/> can call during its own traversal.
+    /// Results are looked up by reference equality, which is safe because the visitor
+    /// hands the same <see cref="Result"/> instances it walked to the partition function.
+    /// </remarks>
+    public static class PartitionFunctions
+    {
+        /// <summary>
+        /// Auto-generated bucket name used when an explicit address-list spec does not
+        /// itself name buckets. Buckets are numbered in spec order, starting at zero.
+        /// </summary>
+        public const string IndexListBucketPrefix = "bucket";
+
+        /// <summary>
+        /// Returns a <see cref="PartitionFunction{T}"/> implementing the specified
+        /// <see cref="SplittingStrategy"/> against the given log.
+        /// </summary>
+        /// <param name="log">The SARIF log to be partitioned.</param>
+        /// <param name="strategy">The splitting strategy to apply.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="log"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="strategy"/> is not supported by this helper.
+        /// Use <see cref="ForIndexList"/> for <see cref="SplittingStrategy.PerIndexList"/>.
+        /// </exception>
+        public static PartitionFunction<string> ForStrategy(SarifLog log, SplittingStrategy strategy)
+        {
+            if (log == null) { throw new ArgumentNullException(nameof(log)); }
+
+            var keyMap = new Dictionary<Result, string>(ResultReferenceComparer.Instance);
+
+            if (log.Runs == null)
+            {
+                return _ => null;
+            }
+
+            int globalResultIndex = 0;
+
+            for (int runIndex = 0; runIndex < log.Runs.Count; runIndex++)
+            {
+                Run run = log.Runs[runIndex];
+                if (run?.Results == null) { continue; }
+
+                for (int resultIndex = 0; resultIndex < run.Results.Count; resultIndex++)
+                {
+                    Result result = run.Results[resultIndex];
+                    if (result == null) { continue; }
+
+                    keyMap[result] = ComputeStrategyKey(strategy, run, result, runIndex, globalResultIndex);
+                    globalResultIndex++;
+                }
+            }
+
+            return result => (result != null && keyMap.TryGetValue(result, out string key)) ? key : null;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="PartitionFunction{T}"/> that places each result into a
+        /// caller-specified bucket according to its address in the input log.
+        /// </summary>
+        /// <param name="log">The SARIF log to be partitioned.</param>
+        /// <param name="indexSpec">
+        /// A spec in the compact mini-language understood by <see cref="ParseIndexSpec"/>.
+        /// </param>
+        /// <param name="spilloverBucket">
+        /// Optional bucket name to receive any result not addressed by
+        /// <paramref name="indexSpec"/>. When null, unmatched results are discarded.
+        /// </param>
+        /// <param name="strictCoverage">
+        /// When true, throws if any result in the log is not addressed by
+        /// <paramref name="indexSpec"/> (and no <paramref name="spilloverBucket"/> is set).
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="log"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="indexSpec"/> is null or empty.</exception>
+        /// <exception cref="FormatException">Thrown when the spec cannot be parsed.</exception>
+        public static PartitionFunction<string> ForIndexList(
+            SarifLog log,
+            string indexSpec,
+            string spilloverBucket = null,
+            bool strictCoverage = false)
+        {
+            if (log == null) { throw new ArgumentNullException(nameof(log)); }
+            if (string.IsNullOrWhiteSpace(indexSpec))
+            {
+                throw new ArgumentException("Index spec must not be null or empty.", nameof(indexSpec));
+            }
+
+            IDictionary<ResultAddress, string> addressToBucket = ParseIndexSpec(indexSpec);
+
+            ValidateAddressesAgainstLog(addressToBucket, log);
+
+            var keyMap = new Dictionary<Result, string>(ResultReferenceComparer.Instance);
+            int unmatchedCount = 0;
+
+            if (log.Runs != null)
+            {
+                for (int runIndex = 0; runIndex < log.Runs.Count; runIndex++)
+                {
+                    Run run = log.Runs[runIndex];
+                    if (run?.Results == null) { continue; }
+
+                    for (int resultIndex = 0; resultIndex < run.Results.Count; resultIndex++)
+                    {
+                        Result result = run.Results[resultIndex];
+                        if (result == null) { continue; }
+
+                        var address = new ResultAddress(runIndex, resultIndex);
+                        if (addressToBucket.TryGetValue(address, out string bucket))
+                        {
+                            keyMap[result] = bucket;
+                        }
+                        else if (spilloverBucket != null)
+                        {
+                            keyMap[result] = spilloverBucket;
+                        }
+                        else
+                        {
+                            unmatchedCount++;
+                        }
+                    }
+                }
+            }
+
+            if (strictCoverage && unmatchedCount > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Strict coverage failed: {unmatchedCount} result(s) in the log were not addressed by the index spec and no spillover bucket was specified.");
+            }
+
+            return result => (result != null && keyMap.TryGetValue(result, out string key)) ? key : null;
+        }
+
+        /// <summary>
+        /// Parses a partition spec written in the compact mini-language.
+        /// </summary>
+        /// <remarks>
+        /// Grammar:
+        /// <code>
+        /// spec    ::= bucket ( "|" bucket )*
+        /// bucket  ::= segment ( ";" segment )*
+        /// segment ::= compactSeg | sarifUri
+        /// compactSeg ::= [ runId ":" ] resultIdx ( "," resultIdx )*
+        /// sarifUri   ::= "sarif:/runs/" runId "/results/" resultIdx
+        /// </code>
+        /// Buckets are auto-named "bucket0", "bucket1", ... in spec order. The
+        /// <c>runId</c> prefix on a compact segment is optional; if omitted, run 0 is
+        /// assumed (handy for the very common single-run AI workflow). Whitespace
+        /// around any token is ignored.
+        /// </remarks>
+        /// <param name="spec">The spec string to parse.</param>
+        /// <returns>
+        /// A dictionary mapping each addressed <see cref="ResultAddress"/> to the
+        /// auto-generated bucket name it belongs to.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="spec"/> is null or empty.</exception>
+        /// <exception cref="FormatException">Thrown when the spec is malformed or contains a duplicate address.</exception>
+        public static IDictionary<ResultAddress, string> ParseIndexSpec(string spec)
+        {
+            if (string.IsNullOrWhiteSpace(spec))
+            {
+                throw new ArgumentException("Spec must not be null or empty.", nameof(spec));
+            }
+
+            var addressToBucket = new Dictionary<ResultAddress, string>();
+
+            string[] bucketTexts = spec.Split('|');
+            for (int b = 0; b < bucketTexts.Length; b++)
+            {
+                string bucketName = IndexListBucketPrefix + b.ToString(CultureInfo.InvariantCulture);
+                string bucketText = bucketTexts[b].Trim();
+                if (bucketText.Length == 0)
+                {
+                    throw new FormatException($"Empty bucket at position {b} in spec '{spec}'.");
+                }
+
+                foreach (string segmentRaw in bucketText.Split(';'))
+                {
+                    string segment = segmentRaw.Trim();
+                    if (segment.Length == 0)
+                    {
+                        throw new FormatException($"Empty segment in bucket {b} of spec '{spec}'.");
+                    }
+
+                    foreach (ResultAddress address in ParseSegment(segment))
+                    {
+                        if (addressToBucket.ContainsKey(address))
+                        {
+                            throw new FormatException(
+                                $"Duplicate address {address} in spec '{spec}'. Each result address may appear in at most one bucket.");
+                        }
+
+                        addressToBucket[address] = bucketName;
+                    }
+                }
+            }
+
+            return addressToBucket;
+        }
+
+        /// <summary>
+        /// An address into a SARIF log: a (run index, result index) pair.
+        /// </summary>
+        public readonly struct ResultAddress : IEquatable<ResultAddress>
+        {
+            public ResultAddress(int runIndex, int resultIndex)
+            {
+                RunIndex = runIndex;
+                ResultIndex = resultIndex;
+            }
+
+            public int RunIndex { get; }
+
+            public int ResultIndex { get; }
+
+            public bool Equals(ResultAddress other)
+                => RunIndex == other.RunIndex && ResultIndex == other.ResultIndex;
+
+            public override bool Equals(object obj) => obj is ResultAddress other && Equals(other);
+
+            public override int GetHashCode()
+                => unchecked((RunIndex * 397) ^ ResultIndex);
+
+            public override string ToString()
+                => $"sarif:/runs/{RunIndex.ToString(CultureInfo.InvariantCulture)}/results/{ResultIndex.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        private static string ComputeStrategyKey(
+            SplittingStrategy strategy,
+            Run run,
+            Result result,
+            int runIndex,
+            int globalResultIndex)
+        {
+            string ruleId = result.RuleId ?? string.Empty;
+            string runIndexText = runIndex.ToString(CultureInfo.InvariantCulture);
+
+            switch (strategy)
+            {
+                case SplittingStrategy.PerRule:
+                    return ruleId;
+
+                case SplittingStrategy.PerRunPerRule:
+                    return $"run{runIndexText}_{ruleId}";
+
+                case SplittingStrategy.PerRunPerTarget:
+                    return $"run{runIndexText}_{GetTargetKey(run, result)}";
+
+                case SplittingStrategy.PerRunPerTargetPerRule:
+                    return $"run{runIndexText}_{GetTargetKey(run, result)}_{ruleId}";
+
+                case SplittingStrategy.PerRun:
+                    return $"run{runIndexText}";
+
+                case SplittingStrategy.PerResult:
+                    return $"result{globalResultIndex.ToString(CultureInfo.InvariantCulture)}";
+
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(strategy),
+                        strategy,
+                        $"Strategy '{strategy}' is not supported by {nameof(PartitionFunctions)}.{nameof(ForStrategy)}. " +
+                        $"Use {nameof(ForIndexList)} for {nameof(SplittingStrategy.PerIndexList)}.");
+            }
+        }
+
+        private static string GetTargetKey(Run run, Result result)
+        {
+            if (result?.Locations == null || result.Locations.Count == 0) { return "noTarget"; }
+
+            Location loc = result.Locations[0];
+            ArtifactLocation artifactLocation = loc?.PhysicalLocation?.ArtifactLocation;
+            if (artifactLocation == null) { return "noTarget"; }
+
+            if (artifactLocation.Uri != null)
+            {
+                return artifactLocation.Uri.OriginalString;
+            }
+
+            // Fall back to the run-level artifact entry referenced by Index, if any.
+            if (artifactLocation.Index >= 0
+                && run?.Artifacts != null
+                && artifactLocation.Index < run.Artifacts.Count)
+            {
+                Artifact artifact = run.Artifacts[artifactLocation.Index];
+                Uri uri = artifact?.Location?.Uri;
+                if (uri != null) { return uri.OriginalString; }
+            }
+
+            return "noTarget";
+        }
+
+        private static IEnumerable<ResultAddress> ParseSegment(string segment)
+        {
+            // Two shapes are accepted within a segment:
+            //   1) A compact form:    "[<runId>:]<r1>[,<r2>...]"
+            //   2) One or more SARIF URLs: "sarif:/runs/<r>/results/<m>[,sarif:/...]"
+            //
+            // SARIF URLs and bare integers can be intermixed within a comma list. The optional
+            // "<runId>:" prefix only applies to the bare-integer tokens that follow it within
+            // the segment; SARIF URLs always carry their own run index.
+            int runIndex = 0;
+            string body = segment;
+
+            int colonIndex = IndexOfRunPrefixColon(segment);
+            if (colonIndex >= 0)
+            {
+                string runText = segment.Substring(0, colonIndex).Trim();
+                body = segment.Substring(colonIndex + 1).Trim();
+
+                if (!int.TryParse(runText, NumberStyles.Integer, CultureInfo.InvariantCulture, out runIndex)
+                    || runIndex < 0)
+                {
+                    throw new FormatException($"Invalid run index '{runText}' in segment '{segment}'.");
+                }
+            }
+
+            if (body.Length == 0)
+            {
+                throw new FormatException($"Segment '{segment}' has no result addresses.");
+            }
+
+            foreach (string token in body.Split(','))
+            {
+                string trimmed = token.Trim();
+                if (trimmed.Length == 0)
+                {
+                    throw new FormatException($"Empty address in segment '{segment}'.");
+                }
+
+                if (trimmed.StartsWith("sarif:", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return ParseSarifUri(trimmed);
+                    continue;
+                }
+
+                if (!int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out int resultIndex)
+                    || resultIndex < 0)
+                {
+                    throw new FormatException($"Invalid result index '{trimmed}' in segment '{segment}'.");
+                }
+
+                yield return new ResultAddress(runIndex, resultIndex);
+            }
+        }
+
+        private static int IndexOfRunPrefixColon(string segment)
+        {
+            // The "<runId>:" prefix is only valid for the compact form. A leading "sarif:" is part
+            // of the URI scheme, not a run prefix.
+            if (segment.StartsWith("sarif:", StringComparison.OrdinalIgnoreCase))
+            {
+                return -1;
+            }
+
+            int colonIndex = segment.IndexOf(':');
+            if (colonIndex < 0)
+            {
+                return -1;
+            }
+
+            // Everything before the colon must be digits for it to be a run prefix; otherwise the
+            // colon belongs to a later token (e.g., an embedded sarif: URL).
+            for (int i = 0; i < colonIndex; i++)
+            {
+                if (!char.IsDigit(segment[i]) && !char.IsWhiteSpace(segment[i]))
+                {
+                    return -1;
+                }
+            }
+
+            return colonIndex;
+        }
+
+        private static ResultAddress ParseSarifUri(string uri)
+        {
+            // Per the SARIF 2.1.0 spec section 3.10.3, a SARIF URL has the form
+            // "sarif:" + JSON-Pointer. For result addresses the pointer is
+            // "/runs/<n>/results/<m>", so the full URI looks like
+            // "sarif:/runs/<n>/results/<m>" with a single '/' after the scheme.
+            const string expected = "sarif:/runs/{N}/results/{M}";
+            const string scheme = "sarif:";
+
+            if (!uri.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new FormatException($"SARIF URI '{uri}' does not match the expected form '{expected}'.");
+            }
+
+            string pointer = uri.Substring(scheme.Length);
+            // pointer should be "/runs/<n>/results/<m>"; Split('/') yields
+            // ["", "runs", "<n>", "results", "<m>"].
+            string[] parts = pointer.Split('/');
+            if (parts.Length != 5
+                || parts[0].Length != 0
+                || !string.Equals(parts[1], "runs", StringComparison.Ordinal)
+                || !string.Equals(parts[3], "results", StringComparison.Ordinal))
+            {
+                throw new FormatException($"SARIF URI '{uri}' does not match the expected form '{expected}'.");
+            }
+
+            if (!int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out int runIndex)
+                || runIndex < 0)
+            {
+                throw new FormatException($"Invalid run index '{parts[2]}' in SARIF URI '{uri}'.");
+            }
+
+            if (!int.TryParse(parts[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out int resultIndex)
+                || resultIndex < 0)
+            {
+                throw new FormatException($"Invalid result index '{parts[4]}' in SARIF URI '{uri}'.");
+            }
+
+            return new ResultAddress(runIndex, resultIndex);
+        }
+
+        private static void ValidateAddressesAgainstLog(IDictionary<ResultAddress, string> addresses, SarifLog log)
+        {
+            int runCount = log.Runs?.Count ?? 0;
+            foreach (ResultAddress address in addresses.Keys)
+            {
+                if (address.RunIndex >= runCount)
+                {
+                    throw new InvalidOperationException(
+                        $"Address {address} references run {address.RunIndex}, but the log contains only {runCount} run(s).");
+                }
+
+                Run run = log.Runs[address.RunIndex];
+                int resultCount = run?.Results?.Count ?? 0;
+                if (address.ResultIndex >= resultCount)
+                {
+                    throw new InvalidOperationException(
+                        $"Address {address} references result {address.ResultIndex}, but run {address.RunIndex} contains only {resultCount} result(s).");
+                }
+            }
+        }
+
+        private sealed class ResultReferenceComparer : IEqualityComparer<Result>
+        {
+            public static readonly ResultReferenceComparer Instance = new ResultReferenceComparer();
+
+            public bool Equals(Result x, Result y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(Result obj) => RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif.Multitool.Library/OptionsInterpreterTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/OptionsInterpreterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -12,15 +12,15 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    public class OptionsInterpretterTests
+    public class OptionsInterpreterTests
     {
         [Fact]
-        public void OptionsInterpretter_ChangesNothingWhenEnvVarsEmpty()
+        public void OptionsInterpreter_ChangesNothingWhenEnvVarsEmpty()
         {
             var mockEnvironmentVariableGetter = new Mock<IEnvironmentVariableGetter>();
             //  Don't setup any responses so they always return null
 
-            var optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
+            var optionsInterpreter = new OptionsInterpreter(mockEnvironmentVariableGetter.Object);
 
             var beforeAndAfter = new List<ValidateOptions>(2);
 
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 });
             }
 
-            optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(beforeAndAfter[1]);
+            optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(beforeAndAfter[1]);
 
             Assert.True(beforeAndAfter[0].DataToInsert.SequenceEqual(beforeAndAfter[1].DataToInsert));
             Assert.True(beforeAndAfter[0].DataToRemove.SequenceEqual(beforeAndAfter[1].DataToRemove));
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void OptionsInterpretter_CorrectlyAddsAdditiveEnvVars()
+        public void OptionsInterpreter_CorrectlyAddsAdditiveEnvVars()
         {
             var mockEnvironmentVariableGetter = new Mock<IEnvironmentVariableGetter>();
             mockEnvironmentVariableGetter.Setup(x => x.GetEnvironmentVariable("SARIF_DATATOINSERT_ADDITION")).Returns("TextFiles;BinaryFiles;");
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             //  Deliberately more delimeters than needed
             mockEnvironmentVariableGetter.Setup(x => x.GetEnvironmentVariable("SARIF_LEVEL_ADDITION")).Returns("Note");
 
-            var optionsInterpretter = new OptionsInterpretter(mockEnvironmentVariableGetter.Object);
+            var optionsInterpreter = new OptionsInterpreter(mockEnvironmentVariableGetter.Object);
 
             var analyzeOptionsBase = new ValidateOptions
             {
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning }
             };
 
-            optionsInterpretter.ConsumeEnvVarsAndInterpretOptions(analyzeOptionsBase);
+            optionsInterpreter.ConsumeEnvVarsAndInterpretOptions(analyzeOptionsBase);
 
             analyzeOptionsBase.DataToInsert.Should().Contain(OptionallyEmittedData.TextFiles);
             analyzeOptionsBase.DataToInsert.Should().Contain(OptionallyEmittedData.BinaryFiles);

--- a/src/Test.UnitTests.Sarif/Writers/PartitionFunctionsTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/PartitionFunctionsTests.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Visitors;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Writers
+{
+    public class PartitionFunctionsTests
+    {
+        // ---- ParseIndexSpec ---------------------------------------------------
+
+        [Fact]
+        public void ParseIndexSpec_BareIntsAssumeRunZero()
+        {
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("0,2|1");
+
+            map.Should().HaveCount(3);
+            map[new PartitionFunctions.ResultAddress(0, 0)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(0, 2)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(0, 1)].Should().Be("bucket1");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_RunPrefix_AppliesToFollowingTokensOnly()
+        {
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("1:0,3|0:2");
+
+            map.Should().HaveCount(3);
+            map[new PartitionFunctions.ResultAddress(1, 0)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(1, 3)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(0, 2)].Should().Be("bucket1");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_SegmentSeparatorDoesNotCarryRunPrefix()
+        {
+            // After the ';' the runId resets to default (0) unless a new prefix is supplied.
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("1:5;6");
+
+            map.Should().HaveCount(2);
+            map[new PartitionFunctions.ResultAddress(1, 5)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(0, 6)].Should().Be("bucket0");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_AcceptsSarifUrls()
+        {
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("sarif:/runs/0/results/3|sarif:/runs/2/results/7");
+
+            map.Should().HaveCount(2);
+            map[new PartitionFunctions.ResultAddress(0, 3)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(2, 7)].Should().Be("bucket1");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_MixesCompactAndSarifUrlsInSameBucket()
+        {
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("1:5,sarif:/runs/2/results/7");
+
+            map.Should().HaveCount(2);
+            map[new PartitionFunctions.ResultAddress(1, 5)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(2, 7)].Should().Be("bucket0");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_TrimsWhitespace()
+        {
+            IDictionary<PartitionFunctions.ResultAddress, string> map =
+                PartitionFunctions.ParseIndexSpec("  1 : 0 , 2  |  3  ");
+
+            map.Should().HaveCount(3);
+            map[new PartitionFunctions.ResultAddress(1, 0)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(1, 2)].Should().Be("bucket0");
+            map[new PartitionFunctions.ResultAddress(0, 3)].Should().Be("bucket1");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_DuplicateAcrossBuckets_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("0,1|1,2");
+            act.Should().Throw<FormatException>().WithMessage("*Duplicate*");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_DuplicateWithinBucket_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("0,0");
+            act.Should().Throw<FormatException>().WithMessage("*Duplicate*");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_DuplicateAcrossFormShorthandAndUrl_Throws()
+        {
+            // 0,1 (shorthand for run 0) and sarif:/runs/0/results/1 are the same address.
+            Action act = () => PartitionFunctions.ParseIndexSpec("0,1|sarif:/runs/0/results/1");
+            act.Should().Throw<FormatException>().WithMessage("*Duplicate*");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_EmptyBucket_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("0||1");
+            act.Should().Throw<FormatException>().WithMessage("*Empty bucket*");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_EmptySegment_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("0;;1");
+            act.Should().Throw<FormatException>().WithMessage("*Empty segment*");
+        }
+
+        [Fact]
+        public void ParseIndexSpec_NullOrWhiteSpace_Throws()
+        {
+            Action a1 = () => PartitionFunctions.ParseIndexSpec(null);
+            Action a2 = () => PartitionFunctions.ParseIndexSpec("   ");
+
+            a1.Should().Throw<ArgumentException>();
+            a2.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void ParseIndexSpec_NegativeIndex_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("-1");
+            act.Should().Throw<FormatException>();
+        }
+
+        [Fact]
+        public void ParseIndexSpec_MalformedSarifUrl_Throws()
+        {
+            Action act = () => PartitionFunctions.ParseIndexSpec("sarif://runs/0/results/0");
+            act.Should().Throw<FormatException>().WithMessage("*does not match the expected form*");
+        }
+
+        // ---- ForStrategy ------------------------------------------------------
+
+        [Fact]
+        public void ForStrategy_PerRule_KeysByRuleId()
+        {
+            SarifLog log = BuildLog(
+                runs: 1,
+                resultsPerRun: 3,
+                ruleIdSelector: (run, idx) => $"R{idx}");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerRule);
+
+            HashSet<string> keys = new HashSet<string>(log.Runs[0].Results.Select(r => fn(r)));
+            keys.Should().BeEquivalentTo(new[] { "R0", "R1", "R2" });
+        }
+
+        [Fact]
+        public void ForStrategy_PerRunPerRule_KeysByRunAndRule()
+        {
+            SarifLog log = BuildLog(
+                runs: 2,
+                resultsPerRun: 2,
+                ruleIdSelector: (run, idx) => $"R{idx}");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerRunPerRule);
+
+            fn(log.Runs[0].Results[0]).Should().Be("run0_R0");
+            fn(log.Runs[0].Results[1]).Should().Be("run0_R1");
+            fn(log.Runs[1].Results[0]).Should().Be("run1_R0");
+            fn(log.Runs[1].Results[1]).Should().Be("run1_R1");
+        }
+
+        [Fact]
+        public void ForStrategy_PerRun_KeysByRunOnly()
+        {
+            SarifLog log = BuildLog(2, 2, (r, i) => "R0");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerRun);
+
+            fn(log.Runs[0].Results[0]).Should().Be("run0");
+            fn(log.Runs[1].Results[1]).Should().Be("run1");
+        }
+
+        [Fact]
+        public void ForStrategy_PerResult_AssignsUniqueKeyPerResult()
+        {
+            SarifLog log = BuildLog(1, 4, (r, i) => "R0");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerResult);
+
+            HashSet<string> keys = new HashSet<string>(log.Runs[0].Results.Select(r => fn(r)));
+            keys.Should().HaveCount(4);
+        }
+
+        [Fact]
+        public void ForStrategy_PerRunPerTarget_KeysByPrimaryLocationUri()
+        {
+            SarifLog log = BuildLog(1, 2, (r, i) => "R0");
+            log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.Uri = new Uri("file:///a.cs");
+            log.Runs[0].Results[1].Locations[0].PhysicalLocation.ArtifactLocation.Uri = new Uri("file:///b.cs");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerRunPerTarget);
+
+            fn(log.Runs[0].Results[0]).Should().Be("run0_file:///a.cs");
+            fn(log.Runs[0].Results[1]).Should().Be("run0_file:///b.cs");
+        }
+
+        [Fact]
+        public void ForStrategy_PerRunPerTargetPerRule_CombinesAll()
+        {
+            SarifLog log = BuildLog(1, 2, (r, i) => $"R{i}");
+            log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.Uri = new Uri("file:///a.cs");
+            log.Runs[0].Results[1].Locations[0].PhysicalLocation.ArtifactLocation.Uri = new Uri("file:///b.cs");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForStrategy(log, SplittingStrategy.PerRunPerTargetPerRule);
+
+            fn(log.Runs[0].Results[0]).Should().Be("run0_file:///a.cs_R0");
+            fn(log.Runs[0].Results[1]).Should().Be("run0_file:///b.cs_R1");
+        }
+
+        // ---- ForIndexList -----------------------------------------------------
+
+        [Fact]
+        public void ForIndexList_AssignsResultsToBuckets()
+        {
+            SarifLog log = BuildLog(1, 4, (r, i) => "R0");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForIndexList(
+                log,
+                "0,2|1",
+                spilloverBucket: null,
+                strictCoverage: false);
+
+            fn(log.Runs[0].Results[0]).Should().Be("bucket0");
+            fn(log.Runs[0].Results[1]).Should().Be("bucket1");
+            fn(log.Runs[0].Results[2]).Should().Be("bucket0");
+            fn(log.Runs[0].Results[3]).Should().BeNull();
+        }
+
+        [Fact]
+        public void ForIndexList_Spillover_ReceivesUnaddressedResults()
+        {
+            SarifLog log = BuildLog(1, 3, (r, i) => "R0");
+
+            PartitionFunction<string> fn = PartitionFunctions.ForIndexList(
+                log,
+                "0",
+                spilloverBucket: "rest",
+                strictCoverage: false);
+
+            fn(log.Runs[0].Results[0]).Should().Be("bucket0");
+            fn(log.Runs[0].Results[1]).Should().Be("rest");
+            fn(log.Runs[0].Results[2]).Should().Be("rest");
+        }
+
+        [Fact]
+        public void ForIndexList_StrictCoverage_FailsOnUnaddressedResults()
+        {
+            SarifLog log = BuildLog(1, 3, (r, i) => "R0");
+
+            Action act = () => PartitionFunctions.ForIndexList(
+                log,
+                "0",
+                spilloverBucket: null,
+                strictCoverage: true);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*Strict coverage failed*");
+        }
+
+        [Fact]
+        public void ForIndexList_OutOfRangeIndex_Throws()
+        {
+            SarifLog log = BuildLog(1, 2, (r, i) => "R0");
+
+            Action act = () => PartitionFunctions.ForIndexList(log, "0,5", null, false);
+            act.Should().Throw<InvalidOperationException>().WithMessage("*references result 5*");
+        }
+
+        [Fact]
+        public void ForIndexList_OutOfRangeRun_Throws()
+        {
+            SarifLog log = BuildLog(1, 2, (r, i) => "R0");
+
+            Action act = () => PartitionFunctions.ForIndexList(log, "1:0", null, false);
+            act.Should().Throw<InvalidOperationException>().WithMessage("*references run 1*");
+        }
+
+        // ---- helpers ----------------------------------------------------------
+
+        private static SarifLog BuildLog(int runs, int resultsPerRun, Func<int, int, string> ruleIdSelector)
+        {
+            var log = new SarifLog
+            {
+                Runs = new List<Run>(),
+            };
+
+            for (int r = 0; r < runs; r++)
+            {
+                var run = new Run
+                {
+                    Tool = new Tool
+                    {
+                        Driver = new ToolComponent
+                        {
+                            Name = $"tool{r}",
+                            Rules = new List<ReportingDescriptor>(),
+                        },
+                    },
+                    Results = new List<Result>(),
+                };
+
+                for (int i = 0; i < resultsPerRun; i++)
+                {
+                    string ruleId = ruleIdSelector(r, i);
+
+                    if (!run.Tool.Driver.Rules.Any(rd => rd.Id == ruleId))
+                    {
+                        run.Tool.Driver.Rules.Add(new ReportingDescriptor { Id = ruleId });
+                    }
+
+                    run.Results.Add(new Result
+                    {
+                        RuleId = ruleId,
+                        Message = new Message { Text = $"r{r}-i{i}" },
+                        Locations = new List<Location>
+                        {
+                            new Location
+                            {
+                                PhysicalLocation = new PhysicalLocation
+                                {
+                                    ArtifactLocation = new ArtifactLocation
+                                    {
+                                        Uri = new Uri($"file:///run{r}/result{i}.cs"),
+                                    },
+                                },
+                            },
+                        },
+                    });
+                }
+
+                log.Runs.Add(run);
+            }
+
+            return log;
+        }
+    }
+}


### PR DESCRIPTION
* NEW: Add `partition` multitool verb that splits one SARIF log into many by strategy (`PerRule` (default), `PerRunPerRule`, `PerRun`, `PerResult`, `PerRunPerTarget`, `PerRunPerTargetPerRule`, `PerIndexList`). Wraps `SarifPartitioner.Partition`, so each output gets its `tool.driver.rules` and `run.artifacts` pruned to only what the partition references.
* NEW: Add `SplittingStrategy.PerIndexList` plus the `--indices` mini-language for explicit per-result bucket assignment: `<runId>:<r1>,<r2>;<runId>:...|<bucket>...`, with bare-int shorthand for run 0 and SARIF URL fallback (`sarif:/runs/X/results/Y`, §3.10.3). Optional `--spillover-bucket NAME` captures uncovered results; `--strict-coverage` errors on uncovered results. Duplicate or out-of-range addresses error.
* NEW: Add public SDK helper `Microsoft.CodeAnalysis.Sarif.Writers.PartitionFunctions` (`ForStrategy`, `ForIndexList`, `ParseIndexSpec`, `ResultAddress`) to centralize partition-key derivation across SDK consumers.