### PR TITLE
Stop emit verb tests from hanging on Linux/Mac CI agents

### DIFF
--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/AddInvocationCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/AddInvocationCommandTests.cs
@@ -246,11 +246,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Fact]
         public void Run_FailsWhenPayloadIsEmpty()
         {
-            // Under xUnit, Console.IsInputRedirected is always true (the test runner pipes
-            // stdin), so a verb invocation with no --input falls into the stdin-read branch
-            // and returns an empty string. The TryReadJsonPayload helper rejects empty
-            // payloads with a per-kind "is empty" message before any append.
+            // Pointing --input at an empty file deterministically hits TryReadJsonPayload's
+            // "is empty" diagnostic via the file branch. Falling through to the stdin branch
+            // (InputFilePath = null) hangs under xUnit on the ADO Linux/Mac agents:
+            // Console.IsInputRedirected reports true but the runner's stdin pipe never closes,
+            // so Console.OpenStandardInput().ReadToEnd() never returns.
             SeedRunHeader();
+            File.WriteAllText(InputPath, string.Empty);
 
             using var errWriter = new StringWriter();
             Console.SetError(errWriter);
@@ -258,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             int exit = new AddInvocationCommand().Run(new AddInvocationOptions
             {
                 OutputFilePath = OutPath,
-                InputFilePath = null,
+                InputFilePath = InputPath,
             });
 
             exit.Should().Be(CommandBase.FAILURE);

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitInitRunCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitInitRunCommandTests.cs
@@ -173,17 +173,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void Run_ReadsRunJsonFromStdin_WhenInputFlagOmitted()
+        public void Run_FailsWhenPayloadIsEmpty()
         {
-            // Stdin redirection via Console.SetIn. EmitEventLogHelpers.TryReadJsonPayload reads
-            // raw bytes from Console.OpenStandardInput which doesn't honor Console.SetIn —
-            // however the IsInputRedirected branch keys off of the redirected handle. We can
-            // exercise the "missing both" branch deterministically and assert it fails clean.
-            // (The actual stdin-byte-read path is integration-tested via AddResultCommandTests
-            // comment-equivalent skip and the CLI fixtures.)
-            int exit = NewCommand().Run(new EmitInitRunOptions { OutputFilePath = OutPath });
+            // Pointing --input at an empty file deterministically hits TryReadJsonPayload's
+            // "is empty" diagnostic via the file branch. Falling through to the stdin branch
+            // (InputFilePath = null) hangs under xUnit on the ADO Linux/Mac agents:
+            // Console.IsInputRedirected reports true but the runner's stdin pipe never closes,
+            // so Console.OpenStandardInput().ReadToEnd() never returns.
+            File.WriteAllText(InputPath, string.Empty);
+
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            int exit = NewCommand().Run(new EmitInitRunOptions
+            {
+                OutputFilePath = OutPath,
+                InputFilePath = InputPath,
+            });
 
             exit.Should().Be(CommandBase.FAILURE);
+            errWriter.ToString().Should().Contain("Run");
+            errWriter.ToString().Should().Contain("empty");
             File.Exists(WipPath).Should().BeFalse();
         }
 


### PR DESCRIPTION
Two tests left `InputFilePath` null to exercise the empty-payload diagnostic via `Console.OpenStandardInput().ReadToEnd()`. That returns empty under xUnit on Windows but blocks indefinitely on the ADO Linux/Mac agents — their stdin pipe stays open without EOF. The release pipeline on main hung exactly there after #2942 merged: `Test.UnitTests.Sarif.dll` finished, `Test.UnitTests.Sarif.Multitool.Library.dll` never returned.

Repoint both tests at an empty input file: `TryReadJsonPayload`'s file branch hits the same `"<Kind> JSON is empty"` diagnostic, assertions unchanged, stdin path never touched.

Production users are unaffected — interactive shells report `IsInputRedirected = false`, piped shells send EOF cleanly. Test-environment artifact only.
