### PR TITLE
Restore RuleKind.Ado as [Obsolete] alias for RuleKind.GHAzDO

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,15 @@ you're writing a PR description. Trim or split.
   `src/Shared/CommonAssemblyInfo.cs`. New `internal const` env-var name
   fields or test-only helpers are reachable from the standard test
   assemblies without needing to be made `public`.
+- **No historical references in code comments.** Don't cite past
+  renames, deprecated names, PR numbers, or "this used to be X" prose
+  inside code. Version control (`git log -p`, `git blame`, GitHub PR
+  history) already carries that story — both humans and AI know how to
+  mine it. Code comments earn their place by clarifying intent or
+  invariants that aren't obvious from the code itself, not by narrating
+  the codebase's past. The `[Obsolete]` attribute's own message is the
+  right place for a one-line "use X instead" pointer; everything
+  beyond that belongs in the commit / PR that introduced the change.
 
 ## Commit / PR mechanics
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -11,6 +11,9 @@ Each release entry below is prefixed with one of:
 
 `BRK` entries lead each section. Older sections may predate this convention.
 
+## **v5.0.2** UNRELEASED
+* NEW: Reintroduce `RuleKind.Ado` as an `[Obsolete]` alias for `RuleKind.GHAzDO`.
+
 ## **v5.0.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.1)
 * BRK: `multitool emit-init-run` removes the twelve typed content flags shipped in v5.0.0 (`--tool-driver-name`, `--tool-version`, `--tool-driver-semantic-version`, `--information-uri`, `--organization`, `--automation-guid`, `--automation-correlation-guid`, `--ai-origin`, `--vcp-repositoryuri`, `--vcp-revisionid`, `--vcp-branch`, `--srcroot`) and consumes a SARIF `Run` JSON document via `--input <path>` or stdin instead, matching the contract of `add-result` / `add-notification` / `add-reporting-descriptor`. `--force-overwrite` is retained.
 * BRK: `Microsoft.CodeAnalysis.Sarif.Multitool.AdoPipelineContext.ApplyTo(Run)` is replaced by `bool TryApplyTo(Run run, out string error)`; stamps `automationDetails.id` and the four `azuredevops/pipeline/build/*` properties only when absent and returns false on per-field conflict.

--- a/src/Sarif/RuleKind.cs
+++ b/src/Sarif/RuleKind.cs
@@ -1,8 +1,16 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
+    /// <summary>
+    /// Identifies the validator family that applies a SARIF reporting-descriptor rule.
+    /// </summary>
+    /// <remarks>
+    /// Not a <c>[Flags]</c> enum; combinations are expressed via <see cref="RuleKindSet"/>.
+    /// </remarks>
     public enum RuleKind
     {
         None = 0,
@@ -11,6 +19,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         Ghas = 3,
         GHAzDO = 4,
         AI = 5,
+
+        [Obsolete("Use RuleKind.GHAzDO instead.")]
+        Ado = GHAzDO,
     }
 }
 

--- a/src/Test.UnitTests.Sarif/RuleKindTests.cs
+++ b/src/Test.UnitTests.Sarif/RuleKindTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Xunit;
+
+namespace Test.UnitTests.Sarif
+{
+    public class RuleKindTests
+    {
+        [Fact]
+        public void RuleKind_AdoAlias_SharesUnderlyingValueWithGHAzDO()
+        {
+#pragma warning disable CS0618
+            ((int)RuleKind.Ado).Should().Be((int)RuleKind.GHAzDO);
+            RuleKind.Ado.Should().Be(RuleKind.GHAzDO);
+#pragma warning restore CS0618
+        }
+
+        [Fact]
+        public void RuleKind_AdoAlias_ParsesCaseInsensitively()
+        {
+            AssertParsesToGHAzDO("Ado");
+            AssertParsesToGHAzDO("ado");
+            AssertParsesToGHAzDO("ADO");
+        }
+
+        private static void AssertParsesToGHAzDO(string input)
+        {
+            RuleKind parsed = (RuleKind)Enum.Parse(typeof(RuleKind), input, ignoreCase: true);
+            parsed.Should().Be(RuleKind.GHAzDO);
+        }
+    }
+}


### PR DESCRIPTION
Restore `RuleKind.Ado` as an `[Obsolete]` alias for `RuleKind.GHAzDO`. #2928 renamed the enum value without leaving a back-compat alias; this resolves to the same underlying value (4) so pre-rename source compiles, and `--rule-kind ado` continues to bind on the multitool CLI via the existing case-insensitive enum parser. The obsolete-warning steers new callers at the canonical `GHAzDO` spelling without breaking them.

Two new `[Fact]` tests pin the alias contract: same underlying value, and case-insensitive parse of `ado` / `Ado` / `ADO` resolves to `RuleKind.GHAzDO`. Release history bullet added under new `v5.0.2 UNRELEASED` section.