### PR TITLE
Drop AI1015 ProvideRunDefaultSourceLanguage from AI authoring guidance

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -12,7 +12,7 @@ Each release entry below is prefixed with one of:
 `BRK` entries lead each section. Older sections may predate this convention.
 
 ## **v5.0.2** UNRELEASED
-* NEW: Drop AI1015 (`ProvideRunDefaultSourceLanguage`); AI runs are no longer required to set `run.defaultSourceLanguage` or partition by `(repository, branch, language)` tuple. The field remains accepted as an optional SARIF Run property.
+* BUG: Drop AI1015 (`ProvideRunDefaultSourceLanguage`); AI runs are no longer required to set `run.defaultSourceLanguage`.
 
 ## **v5.0.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.1)
 * BRK: `multitool emit-init-run` removes the twelve typed content flags shipped in v5.0.0 (`--tool-driver-name`, `--tool-version`, `--tool-driver-semantic-version`, `--information-uri`, `--organization`, `--automation-guid`, `--automation-correlation-guid`, `--ai-origin`, `--vcp-repositoryuri`, `--vcp-revisionid`, `--vcp-branch`, `--srcroot`) and consumes a SARIF `Run` JSON document via `--input <path>` or stdin instead, matching the contract of `add-result` / `add-notification` / `add-reporting-descriptor`. `--force-overwrite` is retained.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -11,6 +11,9 @@ Each release entry below is prefixed with one of:
 
 `BRK` entries lead each section. Older sections may predate this convention.
 
+## **v5.0.2** UNRELEASED
+* NEW: Drop AI1015 (`ProvideRunDefaultSourceLanguage`); AI runs are no longer required to set `run.defaultSourceLanguage` or partition by `(repository, branch, language)` tuple. The field remains accepted as an optional SARIF Run property.
+
 ## **v5.0.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.1)
 * BRK: `multitool emit-init-run` removes the twelve typed content flags shipped in v5.0.0 (`--tool-driver-name`, `--tool-version`, `--tool-driver-semantic-version`, `--information-uri`, `--organization`, `--automation-guid`, `--automation-correlation-guid`, `--ai-origin`, `--vcp-repositoryuri`, `--vcp-revisionid`, `--vcp-branch`, `--srcroot`) and consumes a SARIF `Run` JSON document via `--input <path>` or stdin instead, matching the contract of `add-result` / `add-notification` / `add-reporting-descriptor`. `--force-overwrite` is retained.
 * BRK: `Microsoft.CodeAnalysis.Sarif.Multitool.AdoPipelineContext.ApplyTo(Run)` is replaced by `bool TryApplyTo(Run run, out string error)`; stamps `automationDetails.id` and the four `azuredevops/pipeline/build/*` properties only when absent and returns false on per-field conflict.

--- a/docs/ai/generating-sarif.md
+++ b/docs/ai/generating-sarif.md
@@ -211,20 +211,6 @@ The `ai/nearestCwe` property orients consumers to the closest known vulnerabilit
 ]
 ```
 
-### Run partitioning by language
-
-AI runs MUST be partitioned by source language: a single run MUST cover exactly one `(repository, branch, language)` tuple. `run.defaultSourceLanguage` (§3.14.25) MUST be set to a value from SARIF Appendix J (compared case-insensitively per §3.24.10.2).
-
-```json
-"defaultSourceLanguage": "python"
-```
-
-A SARIF log MAY carry multiple runs to cover multiple languages or branches; each run is independently a `(repository, branch, language)` slice. A run MAY span multiple CWEs.
-
-`artifact.sourceLanguage` (§3.24.10) and `region.sourceLanguage` (§3.30.15) MAY be present for SARIF-viewer rendering but MUST NOT be the sole signal of a result's language — downstream consumers (notably GHAZDO bucket partitioning) resolve language at run scope only.
-
-This is stricter than the SARIF spec allows and is intentional: it makes per-language alert identity stable without per-result language inference at ingestion time.
-
 ---
 
 ## Result Structure
@@ -1704,7 +1690,6 @@ sarif validate my-results.sarif --rule-kind AI
 | AI1011 | RedactedRunMarker | error | `ai/redacted` SHALL be `true` or absent (never `false`). When `true`, `run.redactionTokens` SHOULD be non-empty. `ai/fullLogLocation` SHALL NOT appear unless `ai/redacted` is `true`. |
 | AI1012 | ProvideRuleSubId | error | Every `result.ruleId` MUST include a sub-ID for disambiguation (e.g., `CWE-78/api-handler`). Rule descriptors (`tool.driver.rules[].id`) use the base ID only (e.g., `CWE-78`). |
 | AI1013 | ProvideNotificationAssociatedRule | error | If `notification.associatedRule` is present, it SHALL resolve to a valid rule in `tool.driver.rules[]` or an extension's `rules[]` via `index` or `guid`. |
-| AI1015 | ProvideRunDefaultSourceLanguage | error | Every run MUST set `run.defaultSourceLanguage` (§3.14.25) to a value from SARIF Appendix J. A single run MUST cover exactly one `(repository, branch, language)` tuple. |
 | AI2003 | ProvideSemanticVersion | warning | `tool.driver` SHOULD supply `semanticVersion` for reproducibility. |
 | AI2005 | ProvideAutomationDetails | warning | `run.automationDetails.guid` SHOULD be present for deduplication. |
 | AI2010 | ProvideResultRank | note | Each `result.rank` SHOULD be populated (tool-specific confidence score, 0.0–100.0). |


### PR DESCRIPTION
The per-run partition-by-language MUST in `docs/ai/generating-sarif.md` was originally meant to enable replacing AI results for one language (e.g. C#) while retaining results for another (e.g. JS) on receipt of a new log file. That partition strategy turned out to be insufficient as a baseline-updating solution, so the rule has no remaining business value.

This drop is doc-only — no implementing class exists for AI1015 in `src/Sarif.Multitool.Library/Rules/`. `defaultSourceLanguage` itself remains an accepted optional SARIF Run field; we simply no longer mandate it (or per-language run partitioning).

### Changes
- Remove the `### Run partitioning by language` section from `docs/ai/generating-sarif.md` (heading + 5 paragraphs + JSON example).
- Remove the AI1015 row from the rule table at the bottom of the same doc.
- Open `v5.0.2 UNRELEASED` in `ReleaseHistory.md` with a single `NEW:` bullet documenting the contract relaxation.