### PR TITLE
Fix SARIF1012 NRE when result.ruleId does not resolve (#2944)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,7 @@ Each release entry below is prefixed with one of:
 
 ## **v5.0.2** UNRELEASED
 * BUG: Drop AI1015 (`ProvideRunDefaultSourceLanguage`); AI runs are no longer required to set `run.defaultSourceLanguage`.
+* BUG: `SARIF1012.MessageArgumentsMustBeConsistentWithRule` no longer throws `NullReferenceException` when `result.message.id` is set but `result.ruleId` does not resolve (no matching rule by id, ruleIndex, or hierarchical base).
 
 ## **v5.0.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.1)
 * BRK: `multitool emit-init-run` removes the twelve typed content flags shipped in v5.0.0 (`--tool-driver-name`, `--tool-version`, `--tool-driver-semantic-version`, `--information-uri`, `--organization`, `--automation-guid`, `--automation-correlation-guid`, `--ai-origin`, `--vcp-repositoryuri`, `--vcp-revisionid`, `--vcp-branch`, `--srcroot`) and consumes a SARIF `Run` JSON document via `--input <path>` or stdin instead, matching the contract of `add-result` / `add-notification` / `add-reporting-descriptor`. `--force-overwrite` is retained.

--- a/src/Sarif.Multitool.Library/Rules/SARIF1012.MessageArgumentsMustBeConsistentWithRule.cs
+++ b/src/Sarif.Multitool.Library/Rules/SARIF1012.MessageArgumentsMustBeConsistentWithRule.cs
@@ -42,15 +42,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         protected override void Analyze(Result result, string resultPointer)
         {
             Run run = Context.CurrentRun;
-            IList<ReportingDescriptor> currentRules = run?.Tool.Driver?.Rules;
 
             // If message.id is present, check that a message with that id exists in the rule.
             if (!string.IsNullOrEmpty(result.Message.Id))
             {
                 ReportingDescriptor rule = result.GetRule(run);
 
-                if (currentRules == null
-                    || rule.MessageStrings?.ContainsKey(result.Message.Id) == false)
+                if (rule == null
+                    || rule.MessageStrings == null
+                    || !rule.MessageStrings.ContainsKey(result.Message.Id))
                 {
                     // {0}: This message object refers to the message with id '{1}' in rule '{2}',
                     // but that rule does not define a message with that id. When a tool creates a

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
@@ -124,6 +124,32 @@
               }
             }
           ]
+        },
+        {
+          "ruleId": "SARIF1012",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_MessageIdMustExist",
+            "arguments": [
+              "runs[0].results[3]",
+              "AnyId",
+              "NoSuchRule"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 53,
+                  "startColumn": 9
+                }
+              }
+            }
+          ]
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif
@@ -49,6 +49,12 @@
               "runs[0].originalUriBaseIds.SRCINVALID"
             ]
           }
+        },
+        {
+          "ruleId": "NoSuchRule",
+          "message": {
+            "id": "AnyId"
+          }
         }
       ],
       "columnKind": "utf16CodeUnits"


### PR DESCRIPTION
Resolves #2944. `SARIF1012.MessageArgumentsMustBeConsistentWithRule` threw `NullReferenceException` when `result.message.id` was set but `result.ruleId` did not resolve (no matching rule by id, ruleIndex, or hierarchical base).

### Root cause

The pre-fix guard was:

`csharp
if (currentRules == null
    || rule.MessageStrings?.ContainsKey(result.Message.Id) == false)
`

Two flaws:
1. It checked the rules collection rather than the resolved rule, so a populated `rules` array with no match still hit the NRE.
2. `rule.MessageStrings?...` short-circuits to null when `rule.MessageStrings` is null; `null == false` evaluates to `false`; the diagnostic never fired and the NRE landed on the next line (`rule.MessageStrings[result.Message.Id].Text`).

### Fix

Replace the guard with explicit nulls on `rule`, `rule.MessageStrings`, and the key lookup. All three cases now emit the existing `MessageIdMustExist` diagnostic, formatted with `result.ResolvedRuleId(run) ?? "null"`.

### Regression test

Adds a fourth result to `SARIF1012.MessageArgumentsMustBeConsistentWithRule_Invalid.sarif` with `ruleId: NoSuchRule` (not in the driver) and `message.id: AnyId`. Expected output picks up the corresponding `MessageIdMustExist` diagnostic. Before the fix this input crashed; after the fix it produces the expected diagnostic.

Local: `Test.FunctionalTests.Sarif` SARIF1012 facts 2/2 green.