### PR TITLE
Add GHAzDO1021 (ProvideShortBranchNameInVcp) (#2954)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,7 @@ Each release entry below is prefixed with one of:
 
 ## **v5.0.2** UNRELEASED
 * BRK: Replace `scripts/Generate-CweTaxonomy.ps1` with `scripts/generate_cwe_taxonomy.py`, a Python 3 (stdlib only) regenerator runnable on Linux, macOS, and Windows without `pwsh`. Invoke as `python3 scripts/generate_cwe_taxonomy.py`; it downloads `cwec_latest.xml.zip`, extracts, parses, and writes both `CweTaxonomy.sarif` and `CweTaxonomy.brief.md` in place under `src/Sarif/Taxonomies/` with UTF-8 (no BOM) and LF line endings.
+* NEW: GHAzDO1021 (`ProvideShortBranchNameInVcp`) flags `run.versionControlProvenance[].branch` values that begin with a `refs/<class>/` prefix (e.g. `refs/heads/main`). The AdvSec Service silently drops VCP entries whose branch is not a short branch name; the rule recommends stripping the prefix.
 * BUG: Drop AI1015 (`ProvideRunDefaultSourceLanguage`); AI runs are no longer required to set `run.defaultSourceLanguage`.
 * BUG: `SARIF1012.MessageArgumentsMustBeConsistentWithRule` no longer throws `NullReferenceException` when `result.message.id` is set but `result.ruleId` does not resolve (no matching rule by id, ruleIndex, or hierarchical base).
 

--- a/src/Sarif.Multitool.Library/Rules/GHAzDO1021.ProvideShortBranchNameInVcp.cs
+++ b/src/Sarif.Multitool.Library/Rules/GHAzDO1021.ProvideShortBranchNameInVcp.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using Microsoft.Json.Pointer;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
+{
+    public class ProvideShortBranchNameInVcp
+        : SarifValidationSkimmerBase
+    {
+        private const string BranchPropertyName = "branch";
+
+        private static readonly Regex s_refsPrefixRegex = new Regex(
+            @"^refs/[^/]+/",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public override string Id => RuleId.GHAzDOProvideShortBranchNameInVcp;
+
+        public override MultiformatMessageString FullDescription => new MultiformatMessageString
+        {
+            Text = RuleResources.GHAzDO1021_ProvideShortBranchNameInVcp_FullDescription_Text
+        };
+
+        protected override ICollection<string> MessageResourceNames => new List<string>
+        {
+            nameof(RuleResources.GHAzDO1021_ProvideShortBranchNameInVcp_Error_Default_Text)
+        };
+
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.GHAzDO });
+
+        public ProvideShortBranchNameInVcp()
+        {
+            this.DefaultConfiguration.Level = FailureLevel.Error;
+        }
+
+        protected override void Analyze(VersionControlDetails versionControlDetails, string versionControlDetailsPointer)
+        {
+            string branch = versionControlDetails?.Branch;
+            if (branch == null || !s_refsPrefixRegex.IsMatch(branch))
+            {
+                return;
+            }
+
+            string shortBranchName = s_refsPrefixRegex.Replace(branch, string.Empty, 1);
+
+            LogResult(
+                versionControlDetailsPointer.AtProperty(BranchPropertyName),
+                nameof(RuleResources.GHAzDO1021_ProvideShortBranchNameInVcp_Error_Default_Text),
+                branch,
+                shortBranchName);
+        }
+    }
+}

--- a/src/Sarif.Multitool.Library/Rules/RuleId.cs
+++ b/src/Sarif.Multitool.Library/Rules/RuleId.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public const string GHAzDOProvideToolDriverProperties = "GHAzDO1018";
         public const string GHAzDOProvidePipelineProperties = "GHAzDO1019";
         public const string GHAzDOProvideAutomationDetailsIdFormat = "GHAzDO1020";
+        public const string GHAzDOProvideShortBranchNameInVcp = "GHAzDO1021";
         public const string GHAzDOProvideRequiredReportingDescriptorProperties = "GHAzDO2012";
 
         // TEMPLATE:

--- a/src/Sarif.Multitool.Library/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool.Library/Rules/RuleResources.Designer.cs
@@ -269,6 +269,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The AdvSec Service expects 'run.versionControlProvenance[].branch' to contain a short branch name. It silently drops VCP entries whose branch value starts with a 'refs/&lt;class&gt;/' prefix; strip the leading prefix so, for example, 'refs/heads/main' becomes 'main'..
+        /// </summary>
+        internal static string GHAzDO1021_ProvideShortBranchNameInVcp_FullDescription_Text {
+            get {
+                return ResourceManager.GetString("GHAzDO1021_ProvideShortBranchNameInVcp_FullDescription_Text", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: The 'versionControlProvenance[].branch' value '{1}' starts with a 'refs/&lt;class&gt;/' prefix. The AdvSec Service silently drops VCP entries whose branch value is not a short branch name; strip the leading prefix so this value becomes '{2}'..
+        /// </summary>
+        internal static string GHAzDO1021_ProvideShortBranchNameInVcp_Error_Default_Text {
+            get {
+                return ResourceManager.GetString("GHAzDO1021_ProvideShortBranchNameInVcp_Error_Default_Text", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Rule metadata should provide information that makes it easy to understand and fix the problem.
         ///rule.id
         ///

--- a/src/Sarif.Multitool.Library/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool.Library/Rules/RuleResources.resx
@@ -653,6 +653,12 @@ Required keys on 'run.automationDetails.properties':
   <data name="GHAzDO1020_ProvideAutomationDetailsIdFormat_Error_BadPrefix_Text" xml:space="preserve">
     <value>{0}: The 'automationDetails.id' value '{3}' does not start with the expected prefix '{2}'. The {1} service expects ids of the form '{2}&lt;org&gt;/&lt;project&gt;/&lt;buildDefId&gt;/&lt;phaseId&gt;/&lt;branch&gt;/&lt;buildId&gt;'.</value>
   </data>
+  <data name="GHAzDO1021_ProvideShortBranchNameInVcp_FullDescription_Text" xml:space="preserve">
+    <value>The AdvSec Service expects 'run.versionControlProvenance[].branch' to contain a short branch name. It silently drops VCP entries whose branch value starts with a 'refs/&lt;class&gt;/' prefix; strip the leading prefix so, for example, 'refs/heads/main' becomes 'main'.</value>
+  </data>
+  <data name="GHAzDO1021_ProvideShortBranchNameInVcp_Error_Default_Text" xml:space="preserve">
+    <value>{0}: The 'versionControlProvenance[].branch' value '{1}' starts with a 'refs/&lt;class&gt;/' prefix. The AdvSec Service silently drops VCP entries whose branch value is not a short branch name; strip the leading prefix so this value becomes '{2}'.</value>
+  </data>
   <data name="GH1011_ReferenceFinalSchema" xml:space="preserve">
     <value>The '$schema' property must refer to the final version of the SARIF 2.1.0 schema. This enables IDEs to provide Intellisense for SARIF log files.
 

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -461,6 +461,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public void GH1007_ProvideFullyFormattedMessageStrings_Invalid()
             => RunInvalidTestForRule(RuleId.ProvideFullyFormattedMessageStrings);
 
+        [Fact]
+        public void GHAzDO1021_ProvideShortBranchNameInVcp_Valid()
+            => RunValidTestForRule(RuleId.GHAzDOProvideShortBranchNameInVcp);
+
+        [Fact]
+        public void GHAzDO1021_ProvideShortBranchNameInVcp_Invalid()
+            => RunInvalidTestForRule(RuleId.GHAzDOProvideShortBranchNameInVcp);
+
         private void RunArrayLimitTest(string testFileNameSuffix)
         {
             // Some of the actual limits are impractically large for testing purposes,
@@ -551,7 +559,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 OutputFileOptions = new[] { FilePersistenceOptions.PrettyPrint, FilePersistenceOptions.Optimize },
                 Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None },
                 //RuleKindOption = AllRuleKinds
-                RuleKindOption = new List<RuleKind>() { RuleKind.Gh, RuleKind.Sarif, RuleKind.AI },
+                RuleKindOption = ruleUnderTest.StartsWith("GHAzDO")
+                    ? new List<RuleKind> { RuleKind.GHAzDO }
+                    : new List<RuleKind> { RuleKind.Gh, RuleKind.Sarif, RuleKind.AI },
             };
 
             var mockFileSystem = new Mock<IFileSystem>();

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/GHAzDO1021.ProvideShortBranchNameInVcp_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/GHAzDO1021.ProvideShortBranchNameInVcp_Invalid.sarif
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing",
+          "rules": [
+            {
+              "id": "GHAzDO1021",
+              "name": "ProvideShortBranchNameInVcp",
+              "fullDescription": {
+                "text": "The AdvSec Service expects 'run.versionControlProvenance[].branch' to contain a short branch name. It silently drops VCP entries whose branch value starts with a 'refs/<class>/' prefix; strip the leading prefix so, for example, 'refs/heads/main' becomes 'main'."
+              },
+              "messageStrings": {
+                "Error_Default": {
+                  "text": "{0}: The 'versionControlProvenance[].branch' value '{1}' starts with a 'refs/<class>/' prefix. The AdvSec Service silently drops VCP entries whose branch value is not a short branch name; strip the leading prefix so this value becomes '{2}'."
+                }
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html"
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/GHAzDO1021.ProvideShortBranchNameInVcp_Invalid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "GHAzDO1021",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_Default",
+            "arguments": [
+              "runs[0].versionControlProvenance[0].branch",
+              "refs/heads/main",
+              "main"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 28,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "GHAzDO1021",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_Default",
+            "arguments": [
+              "runs[0].versionControlProvenance[1].branch",
+              "refs/tags/v1.0.0",
+              "v1.0.0"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 33,
+                  "startColumn": 38
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "GHAzDO1021",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_Default",
+            "arguments": [
+              "runs[0].versionControlProvenance[2].branch",
+              "refs/pull/42/merge",
+              "42/merge"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 38,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/GHAzDO1021.ProvideShortBranchNameInVcp_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/GHAzDO1021.ProvideShortBranchNameInVcp_Valid.sarif
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SARIF Functional Testing"
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "FunctionalTestOutput.ValidateCommand/GHAzDO1021.ProvideShortBranchNameInVcp_Valid.sarif",
+            "uriBaseId": "TEST_DIR"
+          }
+        }
+      ],
+      "results": [],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GHAzDO1021.ProvideShortBranchNameInVcp_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GHAzDO1021.ProvideShortBranchNameInVcp_Invalid.sarif
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "version": "1.0",
+          "semanticVersion": "1.0.0",
+          "informationUri": "https://example.com/",
+          "rules": []
+        }
+      },
+      "automationDetails": {
+        "id": "azuredevops/pipeline/build/org/project/1/11111111-1111-1111-1111-111111111111/refs/heads/main/2",
+        "properties": {
+          "azuredevops/pipeline/build/buildDefinitionId": "1",
+          "azuredevops/pipeline/build/buildDefinitionName": "CodeScanner-CI",
+          "azuredevops/pipeline/build/phaseId": "11111111-1111-1111-1111-111111111111",
+          "azuredevops/pipeline/build/phaseName": "scan"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "1111111111111111111111111111111111111111",
+          "branch": "refs/heads/main"
+        },
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "2222222222222222222222222222222222222222",
+          "branch": "refs/tags/v1.0.0"
+        },
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "3333333333333333333333333333333333333333",
+          "branch": "refs/pull/42/merge"
+        }
+      ],
+      "results": [],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GHAzDO1021.ProvideShortBranchNameInVcp_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GHAzDO1021.ProvideShortBranchNameInVcp_Valid.sarif
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "version": "1.0",
+          "semanticVersion": "1.0.0",
+          "informationUri": "https://example.com/",
+          "rules": []
+        }
+      },
+      "automationDetails": {
+        "id": "azuredevops/pipeline/build/org/project/1/11111111-1111-1111-1111-111111111111/refs/heads/main/2",
+        "properties": {
+          "azuredevops/pipeline/build/buildDefinitionId": "1",
+          "azuredevops/pipeline/build/buildDefinitionName": "CodeScanner-CI",
+          "azuredevops/pipeline/build/phaseId": "11111111-1111-1111-1111-111111111111",
+          "azuredevops/pipeline/build/phaseName": "scan"
+        }
+      },
+      "versionControlProvenance": [
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "1111111111111111111111111111111111111111",
+          "branch": "main"
+        },
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "2222222222222222222222222222222222222222",
+          "branch": "feature/x"
+        },
+        {
+          "repositoryUri": "https://github.com/microsoft/sarif-sdk",
+          "revisionId": "3333333333333333333333333333333333333333",
+          "branch": "release-2024"
+        }
+      ],
+      "results": [],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #2954.

## Summary
- Adds GHAzDO1021 (`ProvideShortBranchNameInVcp`) for `run.versionControlProvenance[].branch` values that are full refs.
- Detects any `^refs/[^/]+/` prefix, covering `refs/heads/*`, `refs/tags/*`, `refs/pull/*`, and other ref classes.
- Recommends stripping the leading `refs/<class>/` prefix so `refs/heads/main` becomes `main`.
- Scopes the rule strictly to VCP branch values; it does not flag the full-ref branch segment in `run.automationDetails.id`, which remains part of the GHAzDO1020 automation-details contract.

## AdvSec Service context
Issue #2954 documents that the AdvSec Service can return HTTP 200 + alert id at queue time, then silently drop the VCP entry during async ingestion when `versionControlProvenance[].branch` is a full ref. The issue traces the failure to server-side branch resolution raising `BranchNotFoundException` / `SarifValidation_BranchNotFound` after the caller has already received the success response.

## Tests
- `dotnet build src\Sarif.Multitool.Library\Sarif.Multitool.Library.csproj --nologo --verbosity quiet`
- `dotnet test src\Test.FunctionalTests.Sarif\Test.FunctionalTests.Sarif.csproj --filter "FullyQualifiedName~GHAzDO1021" --nologo --verbosity quiet` (2 passed)
- `dotnet test src\Test.FunctionalTests.Sarif\Test.FunctionalTests.Sarif.csproj --filter "FullyQualifiedName~ValidateCommandTests" --nologo --verbosity quiet` (92 passed)