### PR TITLE
Derive portable artifact roots from versionControlProvenance at emit-finalize

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -21,6 +21,10 @@ Entries are terse by design: one line per change, present-tense behavior, comple
 * BRK: `multitool add-invocation` now requires `executionSuccessful`, a non-whitespace `commandLine`, a `workingDirectory` with a non-whitespace `uri`, and a producer-supplied `timeUtc` on every inline notification; it auto-stamps only `endTimeUtc` when omitted.
 * BRK: Rename `multitool emit-init-run` to `emit-run`.
 * BRK: `emit-run` now rejects a `file:` `originalUriBaseIds["SRCROOT"]` whose path does not resolve to an existing directory on disk at receipt.
+* BRK: Remove the `--srcroot` flag from `multitool emit-finalize`; the verb now derives portable artifact roots from `run.versionControlProvenance` rather than a caller-supplied root.
+* BRK: `multitool emit-finalize` now requires each run to carry at least one `versionControlProvenance` entry whose `mappedTo.uriBaseId` names a declared `originalUriBaseIds` root; only `github.com` repository URIs yield permalinks in this release.
+* NEW: `multitool emit-finalize` rebases absolute local artifact paths to portable `github.com/<owner>/<repo>/blob/<revisionId>/` permalinks — one repository binds to `SRCROOT`, multiple to `SRCROOT_<REPO>` — and warns without failing on absolute paths no root resolves.
+* NEW: `multitool emit-run` stamps `versionControlProvenance[0].mappedTo.uriBaseId = "SRCROOT"` when it auto-fills a single source-repo entry and the run declares an `originalUriBaseIds["SRCROOT"]` root.
 * BRK: Split `multitool add-reporting-descriptor` into `add-notification-reporting-descriptor` and `add-rule-reporting-descriptor`, removing the `--rules` flag.
 * BUG: `AddFileReferencesVisitor` no longer promotes an invocation's `workingDirectory` into `run.artifacts`; a bare location with no hashes, contents, or length adds nothing to the table.
 * BUG: `FileRegionsCache.GetHashData` returns null (rather than the sha-256 of the empty string) for a path that resolves to a directory or missing file with no cached text.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -22,8 +22,9 @@ Entries are terse by design: one line per change, present-tense behavior, comple
 * BRK: Rename `multitool emit-init-run` to `emit-run`.
 * BRK: `emit-run` now rejects a `file:` `originalUriBaseIds["SRCROOT"]` whose path does not resolve to an existing directory on disk at receipt.
 * BRK: Remove the `--srcroot` flag from `multitool emit-finalize`; the verb now derives portable artifact roots from `run.versionControlProvenance` rather than a caller-supplied root.
-* BRK: `multitool emit-finalize` now requires each run to carry at least one `versionControlProvenance` entry whose `mappedTo.uriBaseId` names a declared `originalUriBaseIds` root; only `github.com` repository URIs yield permalinks in this release.
-* NEW: `multitool emit-finalize` rebases absolute local artifact paths to portable `github.com/<owner>/<repo>/blob/<revisionId>/` permalinks — one repository binds to `SRCROOT`, multiple to `SRCROOT_<REPO>` — and warns without failing on absolute paths no root resolves.
+* BRK: `multitool emit-finalize` now requires each run to carry at least one `versionControlProvenance` entry whose `mappedTo.uriBaseId` names a declared `originalUriBaseIds` root; `github.com` and `dev.azure.com` repository URIs are supported in this release.
+* NEW: `multitool emit-finalize` rebases absolute local artifact paths to portable per-repository roots derived from `versionControlProvenance`, binding one repository to `SRCROOT` and multiple to `SRCROOT_<REPO>`; it fails closed on any local path no root resolves.
+* NEW: `multitool emit-finalize` derives portable roots for `dev.azure.com` repositories — the commit-less `dev.azure.com/<org>/<project>/_git/<repo>/` root, with commit pinning carried on `versionControlProvenance.revisionId` — alongside `github.com` blob permalinks.
 * NEW: `multitool emit-run` stamps `versionControlProvenance[0].mappedTo.uriBaseId = "SRCROOT"` when it auto-fills a single source-repo entry and the run declares an `originalUriBaseIds["SRCROOT"]` root.
 * BRK: Split `multitool add-reporting-descriptor` into `add-notification-reporting-descriptor` and `add-rule-reporting-descriptor`, removing the `--rules` flag.
 * BUG: `AddFileReferencesVisitor` no longer promotes an invocation's `workingDirectory` into `run.artifacts`; a bare location with no hashes, contents, or length adds nothing to the table.

--- a/src/Sarif.Multitool.Library/Emit/EmitFinalizeCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitFinalizeCommand.cs
@@ -36,12 +36,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     out string wipPath);
                 if (code != SUCCESS) { return code; }
 
-                if (!EmitEventLogHelpers.TryValidateUri(options.SrcRoot, "--srcroot", EmitEventLogHelpers.BaseUriSchemes, out string srcRootError))
-                {
-                    Console.Error.WriteLine(srcRootError);
-                    return FAILURE;
-                }
-
                 string outputPath = Path.GetFullPath(options.OutputFilePath);
 
                 SarifLog log = SarifEventReplayer.Replay(wipPath);
@@ -104,31 +98,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     }
                 }
 
-                // After enrichment, optionally rewrite originalUriBaseIds["SRCROOT"].uri.
-                // Producers commonly emit with a local file:// SRCROOT so the visitor above
-                // can read sources for snippets/hashes/contextRegion, then ship the SARIF
-                // with a canonical, host-independent URI (e.g. a GitHub blob URL). Doing
-                // the swap here — after the visitor, before serialization — keeps both
-                // contracts intact: enrichment uses real files; the artifact ships portable.
-                if (!string.IsNullOrWhiteSpace(options.SrcRoot) && log?.Runs != null)
+                // After enrichment reads sources from the local file:// bases, deconstruct every
+                // absolute local path into a relative URI plus a portable, per-repository uriBaseId
+                // derived from versionControlProvenance, so the shipped SARIF anchors at stable,
+                // host-independent permalinks and carries no machine-specific path.
+                if (log?.Runs != null)
                 {
-                    var finalSrcRoot = new Uri(options.SrcRoot, UriKind.Absolute);
+                    var rebaseVisitor = new EmitFinalizeRebaseVisitor();
                     foreach (Run run in log.Runs)
                     {
-                        if (run == null) { continue; }
+                        if (run != null) { rebaseVisitor.VisitRun(run); }
+                    }
 
-                        run.OriginalUriBaseIds ??= new Dictionary<string, ArtifactLocation>();
-                        if (run.OriginalUriBaseIds.TryGetValue(EmitRunCommand.SourceRootBaseId, out ArtifactLocation existing) && existing != null)
+                    if (!rebaseVisitor.Success)
+                    {
+                        foreach (string rebaseError in rebaseVisitor.Errors)
                         {
-                            existing.Uri = finalSrcRoot;
+                            Console.Error.WriteLine(rebaseError);
                         }
-                        else
-                        {
-                            run.OriginalUriBaseIds[EmitRunCommand.SourceRootBaseId] = new ArtifactLocation
-                            {
-                                Uri = finalSrcRoot,
-                            };
-                        }
+
+                        return FAILURE;
                     }
                 }
 

--- a/src/Sarif.Multitool.Library/Emit/EmitFinalizeOptions.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitFinalizeOptions.cs
@@ -38,11 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public bool Minify { get; set; }
 
         [Option(
-            "srcroot",
-            HelpText = "Rewrite originalUriBaseIds[\"SRCROOT\"].uri to this value AFTER enrichment runs. Use a local file:// SRCROOT on emit-run so InsertOptionalDataVisitor can read sources for snippets/hashes, then pass the canonical portable URI here (e.g. https://github.com/<org>/<repo>/blob/<branch>/) so the shipped SARIF anchors at a stable, host-independent location.")]
-        public string SrcRoot { get; set; }
-
-        [Option(
             "embed-text-files",
             HelpText = "Embed the textual content of every text-file artifact referenced by the run (run.artifacts[].contents.text). Use for self-contained AI fixtures and to clear SARIF2013.",
             Default = false)]

--- a/src/Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitor.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitor.cs
@@ -7,18 +7,17 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-using Microsoft.CodeAnalysis.Sarif.Visitors;
-
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     /// <summary>
     /// Rewrites absolute local file paths in a run into relative URIs plus portable, per-repository
-    /// <c>uriBaseId</c>s anchored at GitHub blob permalinks derived from
-    /// <c>versionControlProvenance</c>. Each artifact location is resolved against the run's input
-    /// <c>originalUriBaseIds</c>, attributed to the owning repository by longest-prefix match on the
-    /// mapped local root, and re-expressed relative to that repository's minted output base. The
-    /// rebuilt <c>originalUriBaseIds</c> anchor each base at the portable URL, so the finalized SARIF
-    /// carries no machine-specific path.
+    /// <c>uriBaseId</c>s derived from <c>versionControlProvenance</c>. Each artifact location is
+    /// resolved against the run's input <c>originalUriBaseIds</c>, attributed to the owning
+    /// repository by longest-prefix match on the mapped local root, and re-expressed relative to
+    /// that repository's minted output base. The rebuilt <c>originalUriBaseIds</c> anchor each base
+    /// at a portable root — a github.com blob permalink (commit-pinned in the URL) or an Azure
+    /// DevOps repository root (commit pinning carried by <c>versionControlProvenance.revisionId</c>)
+    /// — so the finalized SARIF carries no machine-specific path.
     /// </summary>
     /// <remarks>
     /// One repository collapses to the bare <c>SRCROOT</c> base. Multiple repositories each receive
@@ -208,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 if (string.IsNullOrEmpty(vcd.RevisionId))
                 {
-                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.revisionId must be a non-empty commit identifier so a portable permalink can be derived.", where));
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.revisionId must be a non-empty commit identifier so a portable root can be derived.", where));
                     return false;
                 }
 
@@ -282,49 +281,159 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             leaf = null;
             error = null;
 
-            if (!string.Equals(repositoryUri.Host, "github.com", StringComparison.OrdinalIgnoreCase)
-                || !repositoryUri.IsDefaultPort)
+            // A shipped repositoryUri must be a clean repository identity. Azure DevOps' own clone
+            // URL carries a benign org as userinfo (org@dev.azure.com), which is tolerated; a colon
+            // in userinfo means user:password, and a query/fragment means a browser URL rather than
+            // a repository root — either would leak or misidentify the repository, so both fail
+            // closed. Error text is sanitized so credentials can never surface.
+            string display = SanitizeForDisplay(repositoryUri);
+
+            if (!repositoryUri.IsDefaultPort)
             {
-                error = string.Format(CultureInfo.InvariantCulture, "portable permalink derivation currently supports only github.com repositories; '{0}' is not supported (other hosts are a planned follow-up).", repositoryUri.AbsoluteUri);
+                error = string.Format(CultureInfo.InvariantCulture, "repositoryUri '{0}' must use the host's default port.", display);
                 return false;
             }
+
+            if (!string.IsNullOrEmpty(repositoryUri.Query) || !string.IsNullOrEmpty(repositoryUri.Fragment))
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "repositoryUri '{0}' must be a bare repository URL with no query or fragment.", display);
+                return false;
+            }
+
+            if (repositoryUri.UserInfo.IndexOf(':') >= 0)
+            {
+                error = "a repositoryUri carrying credentials (user:password@) cannot be used to derive a portable root.";
+                return false;
+            }
+
+            if (string.Equals(repositoryUri.Host, "github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return TryDeriveGitHubRoot(repositoryUri, revisionId, display, out portableRoot, out leaf, out error);
+            }
+
+            if (string.Equals(repositoryUri.Host, "dev.azure.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return TryDeriveAzureDevOpsRoot(repositoryUri, display, out portableRoot, out leaf, out error);
+            }
+
+            error = string.Format(CultureInfo.InvariantCulture, "portable root derivation currently supports github.com and dev.azure.com repositories; '{0}' is not supported (other hosts are a planned follow-up).", display);
+            return false;
+        }
+
+        private static bool TryDeriveGitHubRoot(Uri repositoryUri, string revisionId, string display, out Uri portableRoot, out string leaf, out string error)
+        {
+            portableRoot = null;
+            leaf = null;
+            error = null;
 
             string[] segments = repositoryUri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length != 2)
             {
-                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri must take the form https://github.com/<owner>/<repo>; '{0}' did not.", repositoryUri.AbsoluteUri);
+                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri must take the form https://github.com/<owner>/<repo>; '{0}' did not.", display);
                 return false;
             }
 
-            string owner = segments[0];
-            string repo = segments[1];
-            if (repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            if (!TryNormalizeRepoSegment(segments[1], out string repo, out leaf, out string leafError))
             {
-                repo = repo.Substring(0, repo.Length - 4);
-            }
-
-            if (repo.Length == 0)
-            {
-                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri '{0}' has an empty repository name.", repositoryUri.AbsoluteUri);
+                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri '{0}': {1}", display, leafError);
                 return false;
             }
-
-            leaf = Uri.UnescapeDataString(repo);
 
             string composed = string.Format(
                 CultureInfo.InvariantCulture,
                 "https://github.com/{0}/{1}/blob/{2}/",
-                owner,
+                segments[0],
                 repo,
                 Uri.EscapeDataString(revisionId));
 
             if (!Uri.TryCreate(composed, UriKind.Absolute, out portableRoot))
             {
-                error = string.Format(CultureInfo.InvariantCulture, "could not compose a portable URL from repositoryUri '{0}' and revisionId '{1}'.", repositoryUri.AbsoluteUri, revisionId);
+                error = string.Format(CultureInfo.InvariantCulture, "could not compose a portable permalink from repositoryUri '{0}' and revisionId '{1}'.", display, revisionId);
                 return false;
             }
 
             return true;
+        }
+
+        private static bool TryDeriveAzureDevOpsRoot(Uri repositoryUri, string display, out Uri portableRoot, out string leaf, out string error)
+        {
+            portableRoot = null;
+            leaf = null;
+            error = null;
+
+            // Azure DevOps cloud repositories take the form
+            // https://dev.azure.com/<org>/<project>/_git/<repo>. Collection / virtual-directory and
+            // legacy <org>.visualstudio.com shapes are a planned follow-up; anything that is not
+            // exactly that four-segment form is rejected so a malformed URL cannot mint a bogus root.
+            string[] segments = repositoryUri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length != 4
+                || !string.Equals(segments[2], "_git", StringComparison.OrdinalIgnoreCase))
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "azure devops repositoryUri must take the form https://dev.azure.com/<org>/<project>/_git/<repo>; '{0}' did not.", display);
+                return false;
+            }
+
+            if (!TryNormalizeRepoSegment(segments[3], out string repo, out leaf, out string leafError))
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "azure devops repositoryUri '{0}': {1}", display, leafError);
+                return false;
+            }
+
+            // ADO's per-file web URL is query-based (?path=...&version=GC<sha>), which cannot serve
+            // as a SARIF uriBaseId prefix: RFC 3986 relative resolution against a base that has a
+            // query drops the query. The portable root is therefore the repository root, and commit
+            // pinning lives on versionControlProvenance.revisionId, which finalize preserves. The
+            // org/project segments are reproduced in their original percent-encoded form so that
+            // names containing spaces (%20) round-trip unchanged.
+            string composed = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://dev.azure.com/{0}/{1}/_git/{2}/",
+                segments[0],
+                segments[1],
+                repo);
+
+            if (!Uri.TryCreate(composed, UriKind.Absolute, out portableRoot))
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "could not compose a portable root from repositoryUri '{0}'.", display);
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryNormalizeRepoSegment(string rawSegment, out string repoForUrl, out string leaf, out string error)
+        {
+            repoForUrl = null;
+            leaf = null;
+            error = null;
+
+            string repo = rawSegment;
+            if (repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                repo = repo.Substring(0, repo.Length - 4);
+            }
+
+            string decoded = Uri.UnescapeDataString(repo);
+            if (decoded.Length == 0
+                || decoded == "."
+                || decoded == ".."
+                || decoded.IndexOf('/') >= 0
+                || decoded.IndexOf('\\') >= 0)
+            {
+                error = "the repository name is empty or is not a single valid path segment.";
+                return false;
+            }
+
+            repoForUrl = repo;
+            leaf = decoded;
+            return true;
+        }
+
+        private static string SanitizeForDisplay(Uri uri)
+        {
+            // Never echo credentials (or browser query/fragment) in diagnostics: keep only
+            // scheme, host, optional port, and path.
+            return uri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped);
         }
 
         private RepoRoot LongestPrefixOwner(Uri abs)

--- a/src/Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitor.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitor.cs
@@ -1,0 +1,520 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using Microsoft.CodeAnalysis.Sarif.Visitors;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    /// <summary>
+    /// Rewrites absolute local file paths in a run into relative URIs plus portable, per-repository
+    /// <c>uriBaseId</c>s anchored at GitHub blob permalinks derived from
+    /// <c>versionControlProvenance</c>. Each artifact location is resolved against the run's input
+    /// <c>originalUriBaseIds</c>, attributed to the owning repository by longest-prefix match on the
+    /// mapped local root, and re-expressed relative to that repository's minted output base. The
+    /// rebuilt <c>originalUriBaseIds</c> anchor each base at the portable URL, so the finalized SARIF
+    /// carries no machine-specific path.
+    /// </summary>
+    /// <remarks>
+    /// One repository collapses to the bare <c>SRCROOT</c> base. Multiple repositories each receive
+    /// <c>SRCROOT_&lt;REPO-LEAF&gt;</c>, disambiguated by an ordinal suffix on collision. A result URI
+    /// that resolves to a local file path under no declared repository root fails finalize (it would
+    /// leak); an unmatched URI under a portable scheme is inlined as an absolute reference.
+    /// </remarks>
+    internal sealed class EmitFinalizeRebaseVisitor : SarifRewritingVisitor
+    {
+        private const int MaxBaseChainDepth = 64;
+
+        private readonly List<string> _errors = new List<string>();
+        private readonly HashSet<string> _referencedBaseIds = new HashSet<string>(StringComparer.Ordinal);
+        private readonly List<string> _leakUris = new List<string>();
+
+        private List<RepoRoot> _plan;
+        private IDictionary<string, ArtifactLocation> _inputBases;
+        private Dictionary<string, string> _sourceToOutputBaseId;
+
+        internal IReadOnlyList<string> Errors => _errors;
+
+        internal bool Success => _errors.Count == 0;
+
+        public override Run VisitRun(Run node)
+        {
+            if (node == null) { return null; }
+
+            _plan = null;
+            _inputBases = null;
+            _sourceToOutputBaseId = null;
+            _referencedBaseIds.Clear();
+            _leakUris.Clear();
+
+            if (!TryBuildPlan(node, out _plan))
+            {
+                // Planning recorded the failure(s); the run is left untouched so finalize fails
+                // before any partial rewrite can ship a half-rebased payload.
+                return node;
+            }
+
+            _sourceToOutputBaseId = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (RepoRoot root in _plan)
+            {
+                _sourceToOutputBaseId[root.SourceBaseId] = root.OutputBaseId;
+            }
+
+            // Resolve every artifact location against a private copy of the input bases so that
+            // mutating live locations during the pass cannot corrupt resolution, then detach the
+            // dictionary so the base traversal in the rewriting visitor does not touch the base
+            // definitions (they are rebuilt from the plan below).
+            _inputBases = SnapshotBases(node.OriginalUriBaseIds);
+            node.OriginalUriBaseIds = null;
+
+            Run rewritten = base.VisitRun(node);
+
+            rewritten.OriginalUriBaseIds = BuildOutputBases(_plan);
+
+            VerifyNoLeak(rewritten);
+
+            return rewritten;
+        }
+
+        public override VersionControlDetails VisitVersionControlDetails(VersionControlDetails node)
+        {
+            // mappedTo records the local root, which the minted output base now represents; bind it
+            // to that base directly rather than letting the generic rebase touch it.
+            RepoRoot root = _plan?.FirstOrDefault(r => ReferenceEquals(r.Vcd, node));
+            if (root != null)
+            {
+                node.MappedTo = new ArtifactLocation { UriBaseId = root.OutputBaseId };
+                _referencedBaseIds.Add(root.OutputBaseId);
+            }
+
+            return node;
+        }
+
+        public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
+        {
+            if (node == null)
+            {
+                return node;
+            }
+
+            if (node.Uri == null)
+            {
+                // A base-only reference (the artifact is a repository root / directory). Its input
+                // uriBaseId is being retired; remap it to the minted output base so it does not
+                // dangle. An unmapped base id is recorded so the final assertion rejects it.
+                if (!string.IsNullOrEmpty(node.UriBaseId))
+                {
+                    if (_sourceToOutputBaseId != null
+                        && _sourceToOutputBaseId.TryGetValue(node.UriBaseId, out string outputBaseId))
+                    {
+                        node.UriBaseId = outputBaseId;
+                        _referencedBaseIds.Add(outputBaseId);
+                    }
+                    else
+                    {
+                        _referencedBaseIds.Add(node.UriBaseId);
+                    }
+                }
+
+                return node;
+            }
+
+            if (!node.TryReconstructAbsoluteUri(_inputBases, out Uri abs))
+            {
+                // A relative reference we cannot resolve through a declared base. A bare relative URI
+                // ships as-is; a rooted local-path shape is a leak the final assertion will reject.
+                if (!string.IsNullOrEmpty(node.UriBaseId)) { _referencedBaseIds.Add(node.UriBaseId); }
+                if (IsRootedLocalShape(node.Uri)) { _leakUris.Add(node.Uri.OriginalString); }
+                return node;
+            }
+
+            RepoRoot owner = LongestPrefixOwner(abs);
+            if (owner != null)
+            {
+                node.Uri = owner.LocalRoot.MakeRelativeUri(abs);
+                node.UriBaseId = owner.OutputBaseId;
+                _referencedBaseIds.Add(owner.OutputBaseId);
+                return node;
+            }
+
+            if (abs.IsAbsoluteUri && abs.Scheme == Uri.UriSchemeFile)
+            {
+                _leakUris.Add(abs.OriginalString);
+                return node;
+            }
+
+            // Already portable (https and friends): inline the absolute reference with no base so the
+            // rebuilt originalUriBaseIds cannot leave it dangling.
+            node.Uri = abs;
+            node.UriBaseId = null;
+            return node;
+        }
+
+        private bool TryBuildPlan(Run run, out List<RepoRoot> plan)
+        {
+            plan = null;
+
+            IList<VersionControlDetails> vcp = run.VersionControlProvenance;
+            if (vcp == null || vcp.Count == 0)
+            {
+                _errors.Add("emit-finalize requires run.versionControlProvenance to declare at least one repository, each carrying mappedTo, repositoryUri, and revisionId.");
+                return false;
+            }
+
+            if (!TryValidateNoBaseCycles(run.OriginalUriBaseIds, out string cycleError))
+            {
+                _errors.Add(cycleError);
+                return false;
+            }
+
+            var roots = new List<RepoRoot>(vcp.Count);
+            var seenLocalRoots = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < vcp.Count; i++)
+            {
+                VersionControlDetails vcd = vcp[i];
+                string where = string.Format(CultureInfo.InvariantCulture, "versionControlProvenance[{0}]", i);
+
+                if (vcd == null)
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0} must be a version-control-details object.", where));
+                    return false;
+                }
+
+                if (vcd.MappedTo == null || string.IsNullOrEmpty(vcd.MappedTo.UriBaseId))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.mappedTo must declare a uriBaseId that binds the repository root to an originalUriBaseIds entry.", where));
+                    return false;
+                }
+
+                if (vcd.MappedTo.Uri != null)
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.mappedTo must carry only a uriBaseId; the repository root's local path is declared on the named originalUriBaseIds entry, not inline on mappedTo.", where));
+                    return false;
+                }
+
+                if (vcd.RepositoryUri == null
+                    || !vcd.RepositoryUri.IsAbsoluteUri
+                    || (vcd.RepositoryUri.Scheme != Uri.UriSchemeHttp && vcd.RepositoryUri.Scheme != Uri.UriSchemeHttps))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.repositoryUri must be an absolute http(s) URI.", where));
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(vcd.RevisionId))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.revisionId must be a non-empty commit identifier so a portable permalink can be derived.", where));
+                    return false;
+                }
+
+                if (!TryResolveLocalRoot(run.OriginalUriBaseIds, vcd.MappedTo, out Uri localRoot)
+                    || !localRoot.IsAbsoluteUri
+                    || localRoot.Scheme != Uri.UriSchemeFile)
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.mappedTo (uriBaseId '{1}') must resolve to an absolute local file:// path through originalUriBaseIds.", where, vcd.MappedTo.UriBaseId));
+                    return false;
+                }
+
+                localRoot = EnsureTrailingSlash(localRoot);
+
+                string localKey = localRoot.AbsoluteUri;
+                if (seenLocalRoots.TryGetValue(localKey, out int previous))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}.mappedTo resolves to the same local root as versionControlProvenance[{1}]; each repository must map to a distinct root.", where, previous));
+                    return false;
+                }
+
+                seenLocalRoots[localKey] = i;
+
+                if (!TryDerivePortableRoot(vcd.RepositoryUri, vcd.RevisionId, out Uri portableRoot, out string leaf, out string deriveError))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "{0}: {1}", where, deriveError));
+                    return false;
+                }
+
+                roots.Add(new RepoRoot
+                {
+                    Vcd = vcd,
+                    SourceBaseId = vcd.MappedTo.UriBaseId,
+                    LocalRoot = localRoot,
+                    PortableRoot = portableRoot,
+                    Leaf = leaf,
+                });
+            }
+
+            AssignOutputBaseIds(roots);
+            plan = roots;
+            return true;
+        }
+
+        private static void AssignOutputBaseIds(List<RepoRoot> roots)
+        {
+            if (roots.Count == 1)
+            {
+                roots[0].OutputBaseId = EmitRunCommand.SourceRootBaseId;
+                return;
+            }
+
+            var used = new HashSet<string>(StringComparer.Ordinal);
+            foreach (RepoRoot root in roots)
+            {
+                string baseId = EmitRunCommand.SourceRootBaseId + "_" + UpperSnake(root.Leaf);
+                string candidate = baseId;
+                int n = 2;
+                while (!used.Add(candidate))
+                {
+                    candidate = baseId + "_" + n.ToString(CultureInfo.InvariantCulture);
+                    n++;
+                }
+
+                root.OutputBaseId = candidate;
+            }
+        }
+
+        private static bool TryDerivePortableRoot(Uri repositoryUri, string revisionId, out Uri portableRoot, out string leaf, out string error)
+        {
+            portableRoot = null;
+            leaf = null;
+            error = null;
+
+            if (!string.Equals(repositoryUri.Host, "github.com", StringComparison.OrdinalIgnoreCase)
+                || !repositoryUri.IsDefaultPort)
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "portable permalink derivation currently supports only github.com repositories; '{0}' is not supported (other hosts are a planned follow-up).", repositoryUri.AbsoluteUri);
+                return false;
+            }
+
+            string[] segments = repositoryUri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length != 2)
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri must take the form https://github.com/<owner>/<repo>; '{0}' did not.", repositoryUri.AbsoluteUri);
+                return false;
+            }
+
+            string owner = segments[0];
+            string repo = segments[1];
+            if (repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                repo = repo.Substring(0, repo.Length - 4);
+            }
+
+            if (repo.Length == 0)
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "github repositoryUri '{0}' has an empty repository name.", repositoryUri.AbsoluteUri);
+                return false;
+            }
+
+            leaf = Uri.UnescapeDataString(repo);
+
+            string composed = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://github.com/{0}/{1}/blob/{2}/",
+                owner,
+                repo,
+                Uri.EscapeDataString(revisionId));
+
+            if (!Uri.TryCreate(composed, UriKind.Absolute, out portableRoot))
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "could not compose a portable URL from repositoryUri '{0}' and revisionId '{1}'.", repositoryUri.AbsoluteUri, revisionId);
+                return false;
+            }
+
+            return true;
+        }
+
+        private RepoRoot LongestPrefixOwner(Uri abs)
+        {
+            RepoRoot best = null;
+            int bestLength = -1;
+
+            foreach (RepoRoot root in _plan)
+            {
+                if (root.LocalRoot.IsBaseOf(abs))
+                {
+                    int length = root.LocalRoot.AbsoluteUri.Length;
+                    if (length > bestLength)
+                    {
+                        best = root;
+                        bestLength = length;
+                    }
+                }
+            }
+
+            return best;
+        }
+
+        private IDictionary<string, ArtifactLocation> BuildOutputBases(List<RepoRoot> roots)
+        {
+            var bases = new Dictionary<string, ArtifactLocation>(StringComparer.Ordinal);
+            foreach (RepoRoot root in roots)
+            {
+                ArtifactLocation baseEntry =
+                    _inputBases != null
+                    && _inputBases.TryGetValue(root.SourceBaseId, out ArtifactLocation source)
+                    && source != null
+                        ? source
+                        : new ArtifactLocation();
+
+                baseEntry.Uri = root.PortableRoot;
+                baseEntry.UriBaseId = null;
+                bases[root.OutputBaseId] = baseEntry;
+            }
+
+            return bases;
+        }
+
+        private void VerifyNoLeak(Run run)
+        {
+            foreach (string baseId in _referencedBaseIds)
+            {
+                if (run.OriginalUriBaseIds == null || !run.OriginalUriBaseIds.ContainsKey(baseId))
+                {
+                    _errors.Add(string.Format(CultureInfo.InvariantCulture, "After rebasing, a location still references undefined uriBaseId '{0}'.", baseId));
+                }
+            }
+
+            foreach (string leak in _leakUris)
+            {
+                _errors.Add(string.Format(CultureInfo.InvariantCulture, "Local file path '{0}' could not be attributed to a declared repository root; finalize will not ship a machine-specific path.", leak));
+            }
+
+            if (run.OriginalUriBaseIds != null)
+            {
+                foreach (KeyValuePair<string, ArtifactLocation> kv in run.OriginalUriBaseIds)
+                {
+                    if (kv.Value?.Uri != null && kv.Value.Uri.IsAbsoluteUri && kv.Value.Uri.Scheme == Uri.UriSchemeFile)
+                    {
+                        _errors.Add(string.Format(CultureInfo.InvariantCulture, "originalUriBaseIds['{0}'] still anchors at a local path '{1}'.", kv.Key, kv.Value.Uri.OriginalString));
+                    }
+                }
+            }
+        }
+
+        private static IDictionary<string, ArtifactLocation> SnapshotBases(IDictionary<string, ArtifactLocation> bases)
+        {
+            var copy = new Dictionary<string, ArtifactLocation>(StringComparer.Ordinal);
+            if (bases != null)
+            {
+                foreach (KeyValuePair<string, ArtifactLocation> kv in bases)
+                {
+                    copy[kv.Key] = kv.Value?.DeepClone();
+                }
+            }
+
+            return copy;
+        }
+
+        private static bool TryValidateNoBaseCycles(IDictionary<string, ArtifactLocation> bases, out string error)
+        {
+            error = null;
+            if (bases == null) { return true; }
+
+            foreach (string startKey in bases.Keys)
+            {
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                string key = startKey;
+                int depth = 0;
+
+                while (key != null)
+                {
+                    if (!seen.Add(key))
+                    {
+                        error = string.Format(CultureInfo.InvariantCulture, "originalUriBaseIds contains a cyclic uriBaseId chain involving '{0}'.", key);
+                        return false;
+                    }
+
+                    if (++depth > MaxBaseChainDepth)
+                    {
+                        error = "originalUriBaseIds uriBaseId chain exceeds the maximum supported depth.";
+                        return false;
+                    }
+
+                    if (!bases.TryGetValue(key, out ArtifactLocation al) || al == null) { break; }
+
+                    key = al.UriBaseId;
+                }
+            }
+
+            return true;
+        }
+
+        // mappedTo carries only a uriBaseId (enforced in TryBuildPlan); the repository's absolute
+        // local root is the resolution of the matching originalUriBaseIds entry.
+        private static bool TryResolveLocalRoot(IDictionary<string, ArtifactLocation> bases, ArtifactLocation mappedTo, out Uri localRoot)
+        {
+            localRoot = null;
+
+            return bases != null
+                && !string.IsNullOrEmpty(mappedTo.UriBaseId)
+                && bases.TryGetValue(mappedTo.UriBaseId, out ArtifactLocation baseEntry)
+                && baseEntry != null
+                && baseEntry.TryReconstructAbsoluteUri(bases, out localRoot);
+        }
+
+        private static Uri EnsureTrailingSlash(Uri uri)
+        {
+            string text = uri.AbsoluteUri;
+            return text.EndsWith("/", StringComparison.Ordinal)
+                ? uri
+                : new Uri(text + "/", UriKind.Absolute);
+        }
+
+        private static bool IsRootedLocalShape(Uri uri)
+        {
+            if (uri.IsAbsoluteUri)
+            {
+                return uri.Scheme == Uri.UriSchemeFile;
+            }
+
+            string text = uri.OriginalString ?? string.Empty;
+            if (text.Length == 0) { return false; }
+
+            if (text[0] == '/' || text[0] == '\\') { return true; }
+
+            return text.Length >= 2 && text[1] == ':' && char.IsLetter(text[0]);
+        }
+
+        private static string UpperSnake(string value)
+        {
+            var sb = new StringBuilder(value.Length);
+            bool lastUnderscore = false;
+
+            foreach (char c in value)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    sb.Append(char.ToUpperInvariant(c));
+                    lastUnderscore = false;
+                }
+                else if (!lastUnderscore && sb.Length > 0)
+                {
+                    sb.Append('_');
+                    lastUnderscore = true;
+                }
+            }
+
+            string result = sb.ToString().TrimEnd('_');
+            return result.Length == 0 ? "REPO" : result;
+        }
+
+        private sealed class RepoRoot
+        {
+            public VersionControlDetails Vcd { get; set; }
+
+            public string SourceBaseId { get; set; }
+
+            public Uri LocalRoot { get; set; }
+
+            public Uri PortableRoot { get; set; }
+
+            public string Leaf { get; set; }
+
+            public string OutputBaseId { get; set; }
+        }
+    }
+}

--- a/src/Sarif.Multitool.Library/Emit/EmitRunCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitRunCommand.cs
@@ -643,6 +643,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     entry[kv.Key] = kv.Value;
                 }
 
+                StampMappedToIfAbsent(entry, runObject);
+
                 if (vcpArray == null)
                 {
                     runObject["versionControlProvenance"] = new JArray { entry };
@@ -704,7 +706,30 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 }
             }
 
+            StampMappedToIfAbsent(existing, runObject);
+
             return true;
+        }
+
+        // The auto-stamped source-repo entry binds to the local source root via mappedTo so
+        // emit-finalize can deconstruct local paths into portable permalinks. Only stamp when the
+        // run declares originalUriBaseIds.SRCROOT (otherwise the binding could not resolve) and the
+        // caller has not already supplied its own mappedTo.
+        private static void StampMappedToIfAbsent(JObject vcpEntry, JObject runObject)
+        {
+            JToken sourceRoot = runObject["originalUriBaseIds"]?[SourceRootBaseId];
+            if (sourceRoot == null || sourceRoot.Type != JTokenType.Object)
+            {
+                return;
+            }
+
+            JToken existingMappedTo = vcpEntry["mappedTo"];
+            if (existingMappedTo != null && existingMappedTo.Type != JTokenType.Null)
+            {
+                return;
+            }
+
+            vcpEntry["mappedTo"] = new JObject { ["uriBaseId"] = SourceRootBaseId };
         }
 
         /// <summary>

--- a/src/Sarif/Taxonomies/CweGHAzDoSample.sarif
+++ b/src/Sarif/Taxonomies/CweGHAzDoSample.sarif
@@ -140,7 +140,7 @@
       "versionControlProvenance": [
         {
           "repositoryUri": "https://github.com/microsoft/sarif-sdk",
-          "revisionId": "0000000000000000000000000000000000000000",
+          "revisionId": "84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7",
           "branch": "refs/heads/main",
           "mappedTo": {
             "uriBaseId": "SRCROOT"
@@ -149,7 +149,7 @@
       ],
       "originalUriBaseIds": {
         "SRCROOT": {
-          "uri": "https://github.com/microsoft/sarif-sdk/blob/main/"
+          "uri": "https://github.com/microsoft/sarif-sdk/blob/84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7/"
         }
       },
       "artifacts": [

--- a/src/Sarif/Taxonomies/CweGenerateSample.ps1
+++ b/src/Sarif/Taxonomies/CweGenerateSample.ps1
@@ -128,9 +128,11 @@
     -Branch when HEAD is detached. Ignored under -Deterministic.
 
 .PARAMETER Branch
-    Overrides the live-derived branch (git rev-parse --abbrev-ref HEAD)
-    in default mode; a bare name is normalized to refs/heads/<name>.
-    Ignored under -Deterministic.
+    Overrides the live-derived branch in default mode; a bare name is
+    normalized to refs/heads/<name>. When omitted, the branch resolves
+    from git (git rev-parse --abbrev-ref HEAD) or, on a detached-HEAD CI
+    checkout, from BUILD_SOURCEBRANCH / GITHUB_REF. Ignored under
+    -Deterministic.
 
 .EXAMPLE
     pwsh src/Sarif/Taxonomies/CweGenerateSample.ps1
@@ -319,10 +321,28 @@ else {
         else {
             $abbrev = $null
             try { $abbrev = (& git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch { }
-            if (-not $abbrev -or $abbrev -eq 'HEAD') {
-                throw "Detached HEAD at '$repoRoot' has no branch to record. Pass -Branch <name>, or pass -Deterministic."
+            if ($abbrev -and $abbrev -ne 'HEAD') {
+                $vcpBranch = ConvertTo-RefsHeads $abbrev
             }
-            $vcpBranch = ConvertTo-RefsHeads $abbrev
+            else {
+                # Detached HEAD — the normal state of a CI / pipeline checkout.
+                # git cannot name the branch, but the CI system does, via an
+                # environment ref that describes this very checkout (the same
+                # commit HEAD points at, so still coherent live provenance — not
+                # the canonical-pin mixing this resolver otherwise forbids). Read
+                # it so default-mode reconstruction works unattended in a
+                # GitHub Actions or Azure DevOps pipeline rather than demanding
+                # -Branch. These vars are read before Set-AdoEnv scrubs them for
+                # the multitool subprocess, so the parent value is intact.
+                $ciRef = $env:BUILD_SOURCEBRANCH
+                if (-not $ciRef) { $ciRef = $env:GITHUB_REF }
+                if ($ciRef -and $ciRef.Trim()) {
+                    $vcpBranch = ConvertTo-RefsHeads $ciRef.Trim()
+                }
+                else {
+                    throw "Detached HEAD at '$repoRoot' and no CI branch ref (BUILD_SOURCEBRANCH / GITHUB_REF) to record. Pass -Branch <name>, or pass -Deterministic."
+                }
+            }
         }
     }
     else {

--- a/src/Sarif/Taxonomies/CweGenerateSample.ps1
+++ b/src/Sarif/Taxonomies/CweGenerateSample.ps1
@@ -60,10 +60,12 @@
          contextRegion, charOffset). --embed-text-files inlines
          SampleCode.cs into run.artifacts[].contents.text so the fixture
          is self-contained (clears SARIF2013). emit-finalize then
-         deconstructs the local SRCROOT into a portable github.com
-         blob permalink derived from versionControlProvenance
-         (repositoryUri + revisionId) AFTER enrichment, so the shipped
-         artifact anchors at a stable, host-independent URL.
+         deconstructs the local SRCROOT into a portable repository root
+         derived from versionControlProvenance AFTER enrichment: a
+         github.com/<owner>/<repo>/blob/<revisionId>/ commit permalink,
+         or — for an Azure DevOps repositoryUri — the commit-less
+         dev.azure.com/<org>/<project>/_git/<repo>/ repository root. The
+         shipped artifact anchors at a stable, host-independent URL.
 
       5. Post-finalize JSON patches that the multitool emit verbs do not
          currently model as first-class flags:
@@ -88,6 +90,13 @@
         across Windows / Linux / macOS checkouts.
       * automationDetails GUIDs, ai/handoff text, and notification.timeUtc
         are all fixed constants (no Guid.NewGuid, no DateTime.UtcNow).
+      * versionControlProvenance (repositoryUri, revisionId, branch) is
+        resolved as a coherent unit: from the live git working tree by
+        default (full reconstruction when this taxonomy is copied into
+        another repo and run there), or pinned to the canonical fixture
+        triple under -Deterministic. The two are never mixed — a live
+        repositoryUri paired with a pinned commit would name a commit that
+        does not exist in that repository.
       * The CWE IDs span CweTaxonomy.DefaultStatuses (Stable, Draft,
         Incomplete) so the fixture doubles as a smoke test that the
         default loadout covers real-world ruleset surface area. See
@@ -105,18 +114,46 @@
     Sarif;AI;GHAzDO. Default (switch absent) preserves the original
     CweSample.sarif emission unchanged.
 
+.PARAMETER Deterministic
+    Pins versionControlProvenance to the canonical fixture triple
+    (repositoryUri https://github.com/microsoft/sarif-sdk, the frozen
+    v4.5.0 revisionId, branch refs/heads/main) so the checked-in
+    CweSample.sarif / CweGHAzDoSample.sarif regenerate byte-identically
+    on any machine, commit, or fork. The byte-gate test passes this.
+    Mutually exclusive with -RevisionId / -Branch.
+
+.PARAMETER RevisionId
+    Overrides the live-derived commit (git rev-parse HEAD) in default
+    mode — e.g. to anchor provenance at a specific commit. Pair with
+    -Branch when HEAD is detached. Ignored under -Deterministic.
+
+.PARAMETER Branch
+    Overrides the live-derived branch (git rev-parse --abbrev-ref HEAD)
+    in default mode; a bare name is normalized to refs/heads/<name>.
+    Ignored under -Deterministic.
+
 .EXAMPLE
     pwsh src/Sarif/Taxonomies/CweGenerateSample.ps1
 
 .EXAMPLE
     pwsh src/Sarif/Taxonomies/CweGenerateSample.ps1 -GHAzDO
+
+.EXAMPLE
+    # Reproduce the checked-in fixtures byte-for-byte (what CI runs):
+    pwsh src/Sarif/Taxonomies/CweGenerateSample.ps1 -Deterministic
 #>
 [CmdletBinding()]
 param(
     [ValidateSet('Release', 'Debug')]
     [string]$Configuration = 'Release',
 
-    [switch]$GHAzDO
+    [switch]$GHAzDO,
+
+    [switch]$Deterministic,
+
+    [string]$RevisionId = '',
+
+    [string]$Branch = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -163,14 +200,11 @@ $adoEnv = [ordered]@{
     'SYSTEM_JOBID'         = '00000000-0000-0000-0000-000000000002'
     'SYSTEM_PHASENAME'     = 'Build'
     'SYSTEM_JOBNAME'       = 'Build'
-    'BUILD_SOURCEBRANCH'   = 'refs/heads/main'
-    # The two optional VCP-augmenting vars (BUILD_REPOSITORY_URI /
-    # BUILD_SOURCEVERSION). BUILD_REPOSITORY_URI is set below once
-    # $vcpRepoUri is resolved; BUILD_SOURCEVERSION mirrors the supplied
-    # VCP entry's frozen revisionId. AdoPipelineContext detects both and
-    # verifies field-by-field agreement against the supplied VCP entry;
-    # mismatch would fail emit-run.
-    'BUILD_SOURCEVERSION'  = '84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7'
+    # The three VCP-augmenting vars (BUILD_REPOSITORY_URI,
+    # BUILD_SOURCEVERSION, BUILD_SOURCEBRANCH) are assigned post-resolution
+    # from the resolved provenance triple, below — AdoPipelineContext reads
+    # them and verifies field-by-field agreement against the supplied VCP
+    # entry; any mismatch fails emit-run.
     # GitHub Actions gate + identity vars. Cleared in every script
     # invocation so that GitHubActionsContext.TryDetect returns None: this
     # script supplies a deterministic VCP and stamps ADO identity
@@ -211,29 +245,113 @@ foreach ($name in $adoEnv.Keys) {
     $adoEnvCleared[$name] = $null
 }
 
-# Resolve the repository's canonical URL via git porcelain. The clone we run
-# inside is the source of truth for run.versionControlProvenance.repositoryUri
-# (GHAzDO ingestion validates this against repositories visible to the calling
-# identity). emit-finalize pairs it with revisionId to derive the portable
-# artifact permalinks. Falls back to the canonical GitHub URL if the working
-# tree has no origin (e.g. when running against an extracted source tarball
-# with no .git).
-$gitRemoteUrl = $null
-try {
-    $gitRemoteUrl = (& git -C $repoRoot remote get-url origin 2>$null).Trim()
-} catch { }
-if (-not $gitRemoteUrl) { $gitRemoteUrl = 'https://github.com/microsoft/sarif-sdk' }
-$vcpRepoUri = $gitRemoteUrl -replace '\.git$',''
+# Resolve the versionControlProvenance triple (repositoryUri, revisionId,
+# branch) ATOMICALLY: either every field comes from the live git working tree
+# (full reconstruction — what a consumer who copies this taxonomy into their
+# own repo and runs it gets) or every field comes from the canonical pin (the
+# checked-in fixture's frozen contract). The two are never mixed — a live
+# repositoryUri paired with a canonical commit would name a commit that does
+# not exist in that repository.
+#
+# emit-run (for the -GHAzDO variant) stamps BUILD_REPOSITORY_URI /
+# BUILD_SOURCEVERSION / BUILD_SOURCEBRANCH from these same resolved values;
+# AdoPipelineContext verifies them field-by-field against the supplied VCP
+# entry and fails emit-run on any disagreement, so all three must agree.
+# emit-finalize binds the local SRCROOT to a portable root derived from this
+# triple (github blob permalink, or the commit-less ADO repository root).
 
-# Inject the now-resolved repository URL as the deterministic
-# BUILD_REPOSITORY_URI. The supplied VCP entry below sets the same
-# value, so AdoPipelineContext's enrichment is a no-op (no conflict);
-# the env var still gets stamped on so detection reports Complete and
-# the GHAzDO-variant fixture exercises the full ADO env shape.
+# The canonical pin — a coherent triple anchored on a real, immutable
+# sarif-sdk commit (the v4.5.0 release). The checked-in fixtures are frozen
+# to these values so the byte-gate regenerates identically on any machine,
+# commit, or fork; -Deterministic selects it. The revisionId must resolve to
+# a real blob on github.com for the default fixture's SRCROOT permalink to be
+# clickable; when the sample source (SampleCode.cs) changes, advance this pin
+# to a commit that carries the new content.
+$canonicalRepositoryUri = 'https://github.com/microsoft/sarif-sdk'
+$canonicalRevisionId    = '84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7'
+$canonicalBranch        = 'refs/heads/main'
+
+function ConvertTo-RefsHeads {
+    param([string]$name)
+    $n = $name.Trim()
+    if ($n -like 'refs/*') { return $n }
+    return "refs/heads/$n"
+}
+
+if ($Deterministic) {
+    if ($RevisionId -or $Branch) {
+        throw "-Deterministic pins the canonical provenance triple and cannot be combined with -RevisionId/-Branch. Drop -Deterministic to override individual live-derived fields."
+    }
+    $vcpRepoUri = $canonicalRepositoryUri
+    $revisionId = $canonicalRevisionId
+    $vcpBranch  = $canonicalBranch
+}
+else {
+    $insideGit = $false
+    try { $insideGit = ((& git -C $repoRoot rev-parse --is-inside-work-tree 2>$null) -eq 'true') } catch { }
+
+    if ($insideGit) {
+        # Full live reconstruction. Every field resolves from this one git
+        # context; we never backfill a missing field from the canonical pin
+        # (that is exactly the incoherent-provenance bug this guards against),
+        # we fail with an actionable message instead.
+        $originUrl = $null
+        try { $originUrl = (& git -C $repoRoot remote get-url origin 2>$null).Trim() } catch { }
+        if (-not $originUrl) {
+            throw "The git repository at '$repoRoot' has no 'origin' remote, so repositoryUri cannot be resolved. Add an origin remote, or pass -Deterministic to emit the checked-in fixture."
+        }
+        $vcpRepoUri = ($originUrl -replace '\.git$','').TrimEnd('/')
+
+        if ($RevisionId) {
+            $revisionId = $RevisionId.Trim()
+        }
+        else {
+            $revisionId = $null
+            try { $revisionId = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim() } catch { }
+            if (-not $revisionId) {
+                throw "Could not resolve HEAD at '$repoRoot' (an unborn branch has no commit). Commit at least once, pass -RevisionId <sha>, or pass -Deterministic."
+            }
+        }
+
+        if ($Branch) {
+            $vcpBranch = ConvertTo-RefsHeads $Branch
+        }
+        else {
+            $abbrev = $null
+            try { $abbrev = (& git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch { }
+            if (-not $abbrev -or $abbrev -eq 'HEAD') {
+                throw "Detached HEAD at '$repoRoot' has no branch to record. Pass -Branch <name>, or pass -Deterministic."
+            }
+            $vcpBranch = ConvertTo-RefsHeads $abbrev
+        }
+    }
+    else {
+        # No git context (e.g. an extracted source tarball). Fall back to the
+        # canonical pin WHOLESALE so the triple stays coherent; explicit
+        # overrides still layer onto it for callers who know their target.
+        $vcpRepoUri = $canonicalRepositoryUri
+        $revisionId = if ($RevisionId) { $RevisionId.Trim() } else { $canonicalRevisionId }
+        $vcpBranch  = if ($Branch) { ConvertTo-RefsHeads $Branch } else { $canonicalBranch }
+    }
+}
+
+# A bare run inside the canonical sarif-sdk repo (no -Deterministic) stamps
+# the developer's live HEAD and would dirty the checked-in fixture. That is
+# intentional for consumers copying this taxonomy elsewhere, but surprising
+# in-repo — guide the developer to the deterministic path.
+if (-not $Deterministic -and $vcpRepoUri -eq $canonicalRepositoryUri -and $revisionId -ne $canonicalRevisionId) {
+    Write-Warning "Generating with live provenance (revisionId $revisionId). To reproduce the checked-in fixture byte-for-byte, re-run with -Deterministic."
+}
+
+# Stamp the three VCP-augmenting ADO env vars from the resolved triple so the
+# -GHAzDO variant's AdoPipelineContext agreement check passes (it compares
+# these against the supplied VCP entry and fails emit-run on mismatch).
 $adoEnv['BUILD_REPOSITORY_URI'] = $vcpRepoUri
+$adoEnv['BUILD_SOURCEVERSION']  = $revisionId
+$adoEnv['BUILD_SOURCEBRANCH']   = $vcpBranch
 
 # Local SRCROOT for enrichment; emit-finalize deconstructs it into the portable
-# GitHub permalink (derived from versionControlProvenance) after enrichment.
+# repository root (derived from versionControlProvenance) after enrichment.
 # Cross-platform file:// construction: [System.Uri]$path returns a relative
 # Uri on Linux/macOS (Unix paths lack a scheme), and .AbsoluteUri on a
 # relative Uri yields $null — which then null-refs on .EndsWith. Build the
@@ -243,8 +361,10 @@ if (-not $repoRootSlash.StartsWith('/')) { $repoRootSlash = "/$repoRootSlash" }
 if (-not $repoRootSlash.EndsWith('/'))   { $repoRootSlash = "$repoRootSlash/" }
 $localSrcRootUri = "file://$repoRootSlash"
 
-# Repo-relative artifact path; emit-finalize binds it to the SRCROOT base, which
-# resolves to a clickable github.com/<owner>/<repo>/blob/<sha>/ permalink.
+# Repo-relative artifact path; emit-finalize binds it to the SRCROOT base,
+# which resolves to a github.com/<owner>/<repo>/blob/<sha>/ commit permalink
+# or, for an Azure DevOps repositoryUri, the dev.azure.com/<org>/<project>/
+# _git/<repo>/ repository root.
 $sampleFileRepoRelative = 'src/Sarif/Taxonomies/SampleCode.cs'
 $sampleFileOnDisk       = Join-Path $PSScriptRoot 'SampleCode.cs'
 
@@ -252,12 +372,6 @@ $sampleFileOnDisk       = Join-Path $PSScriptRoot 'SampleCode.cs'
 # constantly dirty the working tree.
 $automationGuid            = 'a7ad9ab8-1234-5678-9abc-def012345678'
 $automationCorrelationGuid = '660f3001-34a8-46c5-8ad5-14b9682470ba'
-
-# A real, immutable sarif-sdk commit (the v4.5.0 release tag). emit-finalize
-# derives the portable artifact permalink as
-# https://github.com/<owner>/<repo>/blob/<revisionId>/<path>, so the revisionId
-# must resolve to a real blob on github.com for the sample's links to work.
-$frozenRevisionId = '84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7'
 
 Write-Host "[1/6] Opening run -> $outPath"
 
@@ -279,8 +393,8 @@ $runHeader = [ordered]@{
     versionControlProvenance = @(
         [ordered]@{
             repositoryUri = $vcpRepoUri
-            revisionId    = $frozenRevisionId
-            branch        = 'refs/heads/main'
+            revisionId    = $revisionId
+            branch        = $vcpBranch
             mappedTo      = [ordered]@{ uriBaseId = 'SRCROOT' }
         }
     )

--- a/src/Sarif/Taxonomies/CweGenerateSample.ps1
+++ b/src/Sarif/Taxonomies/CweGenerateSample.ps1
@@ -55,14 +55,15 @@
          bytes are stable across re-runs. (SARIF has no run-level notifications
          array, so notifications ride inside the invocation that owns them.)
 
-      4. emit-finalize --embed-text-files --srcroot https://github.com/microsoft/sarif-sdk/blob/main/
+      4. emit-finalize --embed-text-files
          Enrichment runs against the local SRCROOT (snippets, hashes,
          contextRegion, charOffset). --embed-text-files inlines
          SampleCode.cs into run.artifacts[].contents.text so the fixture
-         is self-contained (clears SARIF2013). --srcroot rewrites
-         originalUriBaseIds.SRCROOT.uri to the canonical GitHub URL
-         AFTER enrichment so the shipped artifact anchors at a stable,
-         host-independent URL.
+         is self-contained (clears SARIF2013). emit-finalize then
+         deconstructs the local SRCROOT into a portable github.com
+         blob permalink derived from versionControlProvenance
+         (repositoryUri + revisionId) AFTER enrichment, so the shipped
+         artifact anchors at a stable, host-independent URL.
 
       5. Post-finalize JSON patches that the multitool emit verbs do not
          currently model as first-class flags:
@@ -165,11 +166,11 @@ $adoEnv = [ordered]@{
     'BUILD_SOURCEBRANCH'   = 'refs/heads/main'
     # The two optional VCP-augmenting vars (BUILD_REPOSITORY_URI /
     # BUILD_SOURCEVERSION). BUILD_REPOSITORY_URI is set below once
-    # $vcpRepoUri is resolved; BUILD_SOURCEVERSION is the deterministic
-    # zero-SHA matching the hardcoded VCP placeholder. AdoPipelineContext
-    # detects both and verifies field-by-field agreement against the
-    # supplied VCP entry; mismatch would fail emit-run.
-    'BUILD_SOURCEVERSION'  = '0000000000000000000000000000000000000000'
+    # $vcpRepoUri is resolved; BUILD_SOURCEVERSION mirrors the supplied
+    # VCP entry's frozen revisionId. AdoPipelineContext detects both and
+    # verifies field-by-field agreement against the supplied VCP entry;
+    # mismatch would fail emit-run.
+    'BUILD_SOURCEVERSION'  = '84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7'
     # GitHub Actions gate + identity vars. Cleared in every script
     # invocation so that GitHubActionsContext.TryDetect returns None: this
     # script supplies a deterministic VCP and stamps ADO identity
@@ -211,13 +212,12 @@ foreach ($name in $adoEnv.Keys) {
 }
 
 # Resolve the repository's canonical URL via git porcelain. The clone we run
-# inside is the source of truth for both:
-#   - run.versionControlProvenance.repositoryUri (GHAzDO ingestion validates
-#     this against repositories visible to the calling identity), and
-#   - the SRCROOT base used by emit-finalize --srcroot rewriting (best-effort
-#     "blob view" form for clickable artifact URIs).
-# Falls back to the canonical GitHub URL if the working tree has no origin
-# (e.g. when running against an extracted source tarball with no .git).
+# inside is the source of truth for run.versionControlProvenance.repositoryUri
+# (GHAzDO ingestion validates this against repositories visible to the calling
+# identity). emit-finalize pairs it with revisionId to derive the portable
+# artifact permalinks. Falls back to the canonical GitHub URL if the working
+# tree has no origin (e.g. when running against an extracted source tarball
+# with no .git).
 $gitRemoteUrl = $null
 try {
     $gitRemoteUrl = (& git -C $repoRoot remote get-url origin 2>$null).Trim()
@@ -232,21 +232,8 @@ $vcpRepoUri = $gitRemoteUrl -replace '\.git$',''
 # the GHAzDO-variant fixture exercises the full ADO env shape.
 $adoEnv['BUILD_REPOSITORY_URI'] = $vcpRepoUri
 
-# GitHub has a clean `<repo>/blob/<branch>/<path>` viewer URL. ADO uses
-# query-string addressing (`?path=&version=GB<branch>`) so there is no clean
-# prefix that concatenates with a relative artifact path; we use the bare
-# repo URL with a trailing slash. GHAzDO ingestion validates the VCP
-# repositoryUri but not the SRCROOT base, so the latter is best-effort UX,
-# not a correctness gate.
-$finalSrcRootUri = if ($vcpRepoUri -match '^https?://github\.com/[^/]+/[^/]+$') {
-    "$vcpRepoUri/blob/main/"
-} elseif ($vcpRepoUri.EndsWith('/')) {
-    $vcpRepoUri
-} else {
-    "$vcpRepoUri/"
-}
-
-# Local SRCROOT for enrichment; rewritten to $finalSrcRootUri at finalize.
+# Local SRCROOT for enrichment; emit-finalize deconstructs it into the portable
+# GitHub permalink (derived from versionControlProvenance) after enrichment.
 # Cross-platform file:// construction: [System.Uri]$path returns a relative
 # Uri on Linux/macOS (Unix paths lack a scheme), and .AbsoluteUri on a
 # relative Uri yields $null — which then null-refs on .EndsWith. Build the
@@ -256,9 +243,8 @@ if (-not $repoRootSlash.StartsWith('/')) { $repoRootSlash = "/$repoRootSlash" }
 if (-not $repoRootSlash.EndsWith('/'))   { $repoRootSlash = "$repoRootSlash/" }
 $localSrcRootUri = "file://$repoRootSlash"
 
-# Repo-relative artifact path; with --srcroot above this becomes a clickable
-# permalink under $finalSrcRootUri (GitHub) or a host-specific reference
-# (ADO / others).
+# Repo-relative artifact path; emit-finalize binds it to the SRCROOT base, which
+# resolves to a clickable github.com/<owner>/<repo>/blob/<sha>/ permalink.
 $sampleFileRepoRelative = 'src/Sarif/Taxonomies/SampleCode.cs'
 $sampleFileOnDisk       = Join-Path $PSScriptRoot 'SampleCode.cs'
 
@@ -266,6 +252,12 @@ $sampleFileOnDisk       = Join-Path $PSScriptRoot 'SampleCode.cs'
 # constantly dirty the working tree.
 $automationGuid            = 'a7ad9ab8-1234-5678-9abc-def012345678'
 $automationCorrelationGuid = '660f3001-34a8-46c5-8ad5-14b9682470ba'
+
+# A real, immutable sarif-sdk commit (the v4.5.0 release tag). emit-finalize
+# derives the portable artifact permalink as
+# https://github.com/<owner>/<repo>/blob/<revisionId>/<path>, so the revisionId
+# must resolve to a real blob on github.com for the sample's links to work.
+$frozenRevisionId = '84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7'
 
 Write-Host "[1/6] Opening run -> $outPath"
 
@@ -287,7 +279,7 @@ $runHeader = [ordered]@{
     versionControlProvenance = @(
         [ordered]@{
             repositoryUri = $vcpRepoUri
-            revisionId    = '0000000000000000000000000000000000000000'
+            revisionId    = $frozenRevisionId
             branch        = 'refs/heads/main'
             mappedTo      = [ordered]@{ uriBaseId = 'SRCROOT' }
         }
@@ -413,10 +405,9 @@ $invocationJson = $invocationPayload | ConvertTo-Json -Compress -Depth 8
 $invocationJson | & dotnet $multitool add-invocation $outPath | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "add-invocation failed (exit $LASTEXITCODE)." }
 
-Write-Host "[3/6] Finalizing (--srcroot $finalSrcRootUri --embed-text-files)"
+Write-Host "[3/6] Finalizing (--embed-text-files)"
 $finalizeArgs = @(
     $multitool, 'emit-finalize', $outPath,
-    '--srcroot',          $finalSrcRootUri,
     '--embed-text-files'
 )
 & dotnet @finalizeArgs | Out-Host

--- a/src/Sarif/Taxonomies/CweSample.sarif
+++ b/src/Sarif/Taxonomies/CweSample.sarif
@@ -139,7 +139,7 @@
       "versionControlProvenance": [
         {
           "repositoryUri": "https://github.com/microsoft/sarif-sdk",
-          "revisionId": "0000000000000000000000000000000000000000",
+          "revisionId": "84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7",
           "branch": "refs/heads/main",
           "mappedTo": {
             "uriBaseId": "SRCROOT"
@@ -148,7 +148,7 @@
       ],
       "originalUriBaseIds": {
         "SRCROOT": {
-          "uri": "https://github.com/microsoft/sarif-sdk/blob/main/"
+          "uri": "https://github.com/microsoft/sarif-sdk/blob/84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7/"
         }
       },
       "artifacts": [

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeCommandTests.cs
@@ -46,11 +46,35 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return JsonSerializer.CreateDefault().Deserialize<SarifLog>(jr);
         }
 
+        private const string FrozenSha = "1234567890abcdef1234567890abcdef12345678";
+
+        // emit-finalize now requires every run to declare versionControlProvenance with a
+        // mappedTo-bound local root so it can deconstruct local paths into portable permalinks.
+        private static Run RunHeader()
+            => new Run
+            {
+                Tool = new Tool { Driver = new ToolComponent { Name = "demo" } },
+                VersionControlProvenance = new[]
+                {
+                    new VersionControlDetails
+                    {
+                        RepositoryUri = new Uri("https://github.com/microsoft/sarif-sdk", UriKind.Absolute),
+                        RevisionId = FrozenSha,
+                        Branch = "refs/heads/main",
+                        MappedTo = new ArtifactLocation { UriBaseId = "SRCROOT" },
+                    },
+                },
+                OriginalUriBaseIds = new System.Collections.Generic.Dictionary<string, ArtifactLocation>
+                {
+                    ["SRCROOT"] = new ArtifactLocation { Uri = new Uri("file:///d:/repo/", UriKind.Absolute) },
+                },
+            };
+
         [Fact]
         public void Run_HappyPath_WritesSarifWithEnrichedCweDescriptorsAndRemovesWip()
         {
             SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }),
+                (SarifEventKinds.RunHeader, RunHeader()),
                 (SarifEventKinds.Result, new Result { RuleId = "CWE-79/template-xss", Message = new Message { Text = "xss" } }),
                 (SarifEventKinds.Result, new Result { RuleId = "NOVEL-custom", Message = new Message { Text = "n/a" } }));
 
@@ -81,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public void Run_WithNoCweEnrichment_LeavesCweDescriptorBare()
         {
             SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }),
+                (SarifEventKinds.RunHeader, RunHeader()),
                 (SarifEventKinds.Result, new Result { RuleId = "CWE-79/template-xss", Message = new Message { Text = "xss" } }));
 
             int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
@@ -102,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public void Run_WithKeepWip_RetainsWipAfterSuccess()
         {
             SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }));
+                (SarifEventKinds.RunHeader, RunHeader()));
 
             int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
             {
@@ -122,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             File.WriteAllText(OutPath, "{ \"stale\": true }");
 
             SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }),
+                (SarifEventKinds.RunHeader, RunHeader()),
                 (SarifEventKinds.Result, new Result { RuleId = "NOVEL-rule-1", Message = new Message { Text = "x" } }));
 
             int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions { OutputFilePath = OutPath });
@@ -164,64 +188,56 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void Run_WithSrcRoot_RewritesExistingSrcRootUriAfterEnrichment()
+        public void Run_RebasesSrcRootToPortableGitHubPermalink()
         {
             // Producer emits with a local file:// SRCROOT so InsertOptionalDataVisitor can
-            // resolve sources, then asks finalize to rewrite the shipped URI to a portable
-            // canonical anchor. The shipped artifact must carry the post-rewrite value.
-            var initialRun = new Run
-            {
-                Tool = new Tool { Driver = new ToolComponent { Name = "demo" } },
-                OriginalUriBaseIds = new System.Collections.Generic.Dictionary<string, ArtifactLocation>
-                {
-                    ["SRCROOT"] = new ArtifactLocation { Uri = new Uri("file:///c:/repo/", UriKind.Absolute) },
-                },
-            };
+            // resolve sources; finalize deconstructs that local anchor into a portable GitHub
+            // blob permalink derived from versionControlProvenance. The shipped artifact must
+            // carry the post-rebase value and keep result URIs relative.
             SeedWip(
-                (SarifEventKinds.RunHeader, initialRun),
-                (SarifEventKinds.Result, new Result { RuleId = "NOVEL-test", Message = new Message { Text = "x" } }));
+                (SarifEventKinds.RunHeader, RunHeader()),
+                (SarifEventKinds.Result, new Result
+                {
+                    RuleId = "NOVEL-test",
+                    Message = new Message { Text = "x" },
+                    Locations = new[]
+                    {
+                        new Location
+                        {
+                            PhysicalLocation = new PhysicalLocation
+                            {
+                                ArtifactLocation = new ArtifactLocation
+                                {
+                                    Uri = new Uri("src/a.cs", UriKind.Relative),
+                                    UriBaseId = "SRCROOT",
+                                },
+                            },
+                        },
+                    },
+                }));
 
-            int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
-            {
-                OutputFilePath = OutPath,
-                SrcRoot = "https://github.com/microsoft/sarif-sdk/blob/main/",
-            });
+            int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions { OutputFilePath = OutPath });
 
             exit.Should().Be(CommandBase.SUCCESS);
             SarifLog log = LoadSarif();
             log.Runs[0].OriginalUriBaseIds.Should().ContainKey("SRCROOT");
             log.Runs[0].OriginalUriBaseIds["SRCROOT"].Uri
-                .Should().Be(new Uri("https://github.com/microsoft/sarif-sdk/blob/main/", UriKind.Absolute));
+                .Should().Be(new Uri($"https://github.com/microsoft/sarif-sdk/blob/{FrozenSha}/", UriKind.Absolute));
+
+            ArtifactLocation shipped = log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation;
+            shipped.Uri.OriginalString.Should().Be("src/a.cs");
+            shipped.UriBaseId.Should().Be("SRCROOT");
         }
 
         [Fact]
-        public void Run_WithSrcRoot_AddsSrcRootEntryWhenRunHadNoOriginalUriBaseIds()
+        public void Run_FailsWhenRunHasNoVersionControlProvenance()
         {
-            // Run header was emitted without --srcroot. Finalize --srcroot should still
-            // honor the producer's intent and populate the SRCROOT base id from scratch.
+            // The finalize contract requires versionControlProvenance so local paths can be
+            // rebased to portable permalinks; a run without it is refused before any file ships.
             SeedWip(
                 (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }),
                 (SarifEventKinds.Result, new Result { RuleId = "NOVEL-test", Message = new Message { Text = "x" } }));
 
-            int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
-            {
-                OutputFilePath = OutPath,
-                SrcRoot = "https://example.com/repo/",
-            });
-
-            exit.Should().Be(CommandBase.SUCCESS);
-            SarifLog log = LoadSarif();
-            log.Runs[0].OriginalUriBaseIds.Should().ContainKey("SRCROOT");
-            log.Runs[0].OriginalUriBaseIds["SRCROOT"].Uri
-                .Should().Be(new Uri("https://example.com/repo/", UriKind.Absolute));
-        }
-
-        [Fact]
-        public void Run_WithMalformedSrcRoot_FailsWithClearMessage()
-        {
-            SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }));
-
             string capturedStderr;
             int exit;
             using (var writer = new StringWriter())
@@ -230,11 +246,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 Console.SetError(writer);
                 try
                 {
-                    exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
-                    {
-                        OutputFilePath = OutPath,
-                        SrcRoot = "not a uri",
-                    });
+                    exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions { OutputFilePath = OutPath });
                 }
                 finally
                 {
@@ -245,56 +257,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
             exit.Should().Be(CommandBase.FAILURE);
             File.Exists(OutPath).Should().BeFalse();
-            capturedStderr.Should().Contain("--srcroot");
-            capturedStderr.Should().Contain("not a uri");
-        }
-
-        [Fact]
-        public void Run_WithDisallowedSrcRootScheme_FailsWithClearMessage()
-        {
-            // http:// is not in the base-URI allow-list (https + file only) so a typo
-            // surfaces here rather than silently shipping a clear-text base URI.
-            SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }));
-
-            string capturedStderr;
-            int exit;
-            using (var writer = new StringWriter())
-            {
-                TextWriter original = Console.Error;
-                Console.SetError(writer);
-                try
-                {
-                    exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
-                    {
-                        OutputFilePath = OutPath,
-                        SrcRoot = "http://example.com/repo/",
-                    });
-                }
-                finally
-                {
-                    Console.SetError(original);
-                }
-                capturedStderr = writer.ToString();
-            }
-
-            exit.Should().Be(CommandBase.FAILURE);
-            File.Exists(OutPath).Should().BeFalse();
-            capturedStderr.Should().Contain("--srcroot");
-            capturedStderr.Should().Contain("scheme 'http'");
+            capturedStderr.Should().Contain("versionControlProvenance");
         }
 
         [Fact]
         public void Run_WithValidateFlag_ReturnsFailureWhenErrorFindingsPresent()
         {
-            // A bare run with no AI-profile metadata fires several AI* error-level
-            // findings (AI1004 missing VCP, AI1006 missing ai/origin, etc.). The
-            // --validate gate should propagate this as a FAILURE exit code and
-            // leave the report file on disk for forensics. The clean-input
-            // success path is covered with higher fidelity by the
+            // A run that carries versionControlProvenance (so finalize can rebase) but is
+            // otherwise bare of AI-profile metadata fires several AI* error-level findings
+            // (AI1006 missing ai/origin, automationDetails, etc.). The --validate gate should
+            // propagate this as a FAILURE exit code and leave the report file on disk for
+            // forensics. The clean-input success path is covered with higher fidelity by the
             // CweGenerateSample.ps1 + CweSample.sarif integration fixture.
             SeedWip(
-                (SarifEventKinds.RunHeader, new Run { Tool = new Tool { Driver = new ToolComponent { Name = "demo" } } }));
+                (SarifEventKinds.RunHeader, RunHeader()));
 
             int exit = new EmitFinalizeCommand().Run(new EmitFinalizeOptions
             {

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitorTests.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    public class EmitFinalizeRebaseVisitorTests
+    {
+        private const string Sha = "1234567890abcdef1234567890abcdef12345678";
+
+        private static VersionControlDetails Vcd(string repositoryUri, string uriBaseId, string revisionId = Sha)
+            => new VersionControlDetails
+            {
+                RepositoryUri = new Uri(repositoryUri, UriKind.Absolute),
+                RevisionId = revisionId,
+                Branch = "refs/heads/main",
+                MappedTo = new ArtifactLocation { UriBaseId = uriBaseId },
+            };
+
+        private static IDictionary<string, ArtifactLocation> Bases(params (string id, string uri)[] entries)
+        {
+            var bases = new Dictionary<string, ArtifactLocation>(StringComparer.Ordinal);
+            foreach ((string id, string uri) in entries)
+            {
+                bases[id] = new ArtifactLocation { Uri = new Uri(uri, UriKind.Absolute) };
+            }
+
+            return bases;
+        }
+
+        private static Result ResultAt(string uri, string uriBaseId = null)
+            => new Result
+            {
+                RuleId = "NOVEL-x",
+                Message = new Message { Text = "x" },
+                Locations = new[]
+                {
+                    new Location
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri(uri, UriKind.RelativeOrAbsolute),
+                                UriBaseId = uriBaseId,
+                            },
+                        },
+                    },
+                },
+            };
+
+        private static ArtifactLocation FirstLocation(Run run)
+            => run.Results[0].Locations[0].PhysicalLocation.ArtifactLocation;
+
+        private static EmitFinalizeRebaseVisitor Visit(Run run)
+        {
+            var visitor = new EmitFinalizeRebaseVisitor();
+            visitor.VisitRun(run);
+            return visitor;
+        }
+
+        [Fact]
+        public void SingleRepo_AbsoluteFileLocation_BecomesRelativeUnderSrcRoot()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("file:///d:/src/sarif-sdk/src/Foo.cs") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            ArtifactLocation location = FirstLocation(run);
+            location.Uri.OriginalString.Should().Be("src/Foo.cs");
+            location.UriBaseId.Should().Be("SRCROOT");
+            run.OriginalUriBaseIds["SRCROOT"].Uri
+                .Should().Be(new Uri($"https://github.com/microsoft/sarif-sdk/blob/{Sha}/", UriKind.Absolute));
+        }
+
+        [Fact]
+        public void SingleRepo_RelativeLocationAlreadyUnderBase_KeepsRelativeForm()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("src/Foo.cs", "SRCROOT") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            ArtifactLocation location = FirstLocation(run);
+            location.Uri.OriginalString.Should().Be("src/Foo.cs");
+            location.UriBaseId.Should().Be("SRCROOT");
+        }
+
+        [Fact]
+        public void SingleRepo_RewritesMappedToToPortableBaseAndPreservesRevision()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("file:///d:/src/sarif-sdk/a.cs") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            VersionControlDetails vcd = run.VersionControlProvenance[0];
+            vcd.MappedTo.UriBaseId.Should().Be("SRCROOT");
+            vcd.MappedTo.Uri.Should().BeNull();
+            vcd.RepositoryUri.Should().Be(new Uri("https://github.com/microsoft/sarif-sdk", UriKind.Absolute));
+            vcd.RevisionId.Should().Be(Sha);
+        }
+
+        [Fact]
+        public void MultiRepo_NestedCheckouts_AttributeByLongestPrefix()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com/contoso/package", "PACKAGE_ROOT"),
+                    Vcd("https://github.com/contoso/plugin", "PLUGIN_ROOT"),
+                },
+                OriginalUriBaseIds = Bases(
+                    ("PACKAGE_ROOT", "file:///d:/pkg/"),
+                    ("PLUGIN_ROOT", "file:///d:/pkg/plugins/plugin/")),
+                Results = new[]
+                {
+                    ResultAt("file:///d:/pkg/src/a.cs"),
+                    ResultAt("file:///d:/pkg/plugins/plugin/b.cs"),
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+
+            ArtifactLocation a = run.Results[0].Locations[0].PhysicalLocation.ArtifactLocation;
+            a.Uri.OriginalString.Should().Be("src/a.cs");
+            a.UriBaseId.Should().Be("SRCROOT_PACKAGE");
+
+            ArtifactLocation b = run.Results[1].Locations[0].PhysicalLocation.ArtifactLocation;
+            b.Uri.OriginalString.Should().Be("b.cs");
+            b.UriBaseId.Should().Be("SRCROOT_PLUGIN");
+
+            run.OriginalUriBaseIds["SRCROOT_PACKAGE"].Uri
+                .Should().Be(new Uri($"https://github.com/contoso/package/blob/{Sha}/", UriKind.Absolute));
+            run.OriginalUriBaseIds["SRCROOT_PLUGIN"].Uri
+                .Should().Be(new Uri($"https://github.com/contoso/plugin/blob/{Sha}/", UriKind.Absolute));
+            run.OriginalUriBaseIds.Should().NotContainKey("PACKAGE_ROOT");
+            run.OriginalUriBaseIds.Should().NotContainKey("PLUGIN_ROOT");
+        }
+
+        [Fact]
+        public void MultiRepo_DuplicateLeafNames_GetOrdinalSuffix()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com/contoso/widgets", "A"),
+                    Vcd("https://github.com/fabrikam/widgets", "B"),
+                },
+                OriginalUriBaseIds = Bases(
+                    ("A", "file:///d:/a/"),
+                    ("B", "file:///d:/b/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            run.OriginalUriBaseIds.Should().ContainKey("SRCROOT_WIDGETS");
+            run.OriginalUriBaseIds.Should().ContainKey("SRCROOT_WIDGETS_2");
+        }
+
+        [Fact]
+        public void UnmatchedAbsoluteFilePath_FailsAsLeak()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("file:///e:/elsewhere/secret.cs") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("secret.cs");
+        }
+
+        [Fact]
+        public void UnmatchedPortableUri_IsInlinedAbsoluteWithNoBase()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("https://cdn.example.com/vendor/lib.js") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            ArtifactLocation location = FirstLocation(run);
+            location.Uri.Should().Be(new Uri("https://cdn.example.com/vendor/lib.js", UriKind.Absolute));
+            location.UriBaseId.Should().BeNull();
+        }
+
+        [Fact]
+        public void MissingVersionControlProvenance_Fails()
+        {
+            var run = new Run
+            {
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Results = new[] { ResultAt("file:///d:/src/sarif-sdk/a.cs") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("versionControlProvenance");
+        }
+
+        [Fact]
+        public void VcpMissingMappedTo_Fails()
+        {
+            var vcd = Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT");
+            vcd.MappedTo = null;
+
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { vcd },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("mappedTo");
+        }
+
+        [Fact]
+        public void NonGitHubHost_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/_git/widgets", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("github.com");
+        }
+
+        [Fact]
+        public void GitHubHostWithNonDefaultPort_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com:8443/microsoft/sarif-sdk", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("github.com");
+        }
+
+        [Fact]
+        public void MappedToCarryingInlineUri_Fails()
+        {
+            var vcd = Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT");
+            vcd.MappedTo = new ArtifactLocation
+            {
+                UriBaseId = "SRCROOT",
+                Uri = new Uri("file:///d:/src/sarif-sdk/", UriKind.Absolute),
+            };
+
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { vcd },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("mappedTo");
+        }
+
+        [Fact]
+        public void MissingRevisionId_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT", revisionId: null),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("revisionId");
+        }
+
+        [Fact]
+        public void CyclicBaseChain_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>(StringComparer.Ordinal)
+                {
+                    ["SRCROOT"] = new ArtifactLocation { UriBaseId = "OTHER" },
+                    ["OTHER"] = new ArtifactLocation { UriBaseId = "SRCROOT" },
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("cyclic");
+        }
+
+        [Fact]
+        public void BaseOnlyArtifactLocation_IsRemappedToOutputBase()
+        {
+            // A directory/repositoryRoot artifact references its repo by uriBaseId alone (no uri).
+            // The retired input base id must be remapped to the minted output base, not left dangling.
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com/contoso/package", "PACKAGE_ROOT"),
+                    Vcd("https://github.com/contoso/plugin", "PLUGIN_ROOT"),
+                },
+                OriginalUriBaseIds = Bases(
+                    ("PACKAGE_ROOT", "file:///d:/pkg/"),
+                    ("PLUGIN_ROOT", "file:///d:/pkg/plugins/plugin/")),
+                Artifacts = new[]
+                {
+                    new Artifact
+                    {
+                        Location = new ArtifactLocation { UriBaseId = "PLUGIN_ROOT" },
+                        Roles = ArtifactRoles.Directory,
+                    },
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            ArtifactLocation artifactLocation = run.Artifacts[0].Location;
+            artifactLocation.Uri.Should().BeNull();
+            artifactLocation.UriBaseId.Should().Be("SRCROOT_PLUGIN");
+            run.OriginalUriBaseIds.Should().ContainKey("SRCROOT_PLUGIN");
+        }
+
+        [Fact]
+        public void BaseOnlyArtifactLocation_WithUnmappedBaseId_FailsAsDangling()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Artifacts = new[]
+                {
+                    new Artifact
+                    {
+                        Location = new ArtifactLocation { UriBaseId = "UNDECLARED" },
+                    },
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("UNDECLARED");
+        }
+
+        [Fact]
+        public void NonResultSurfaces_AreRebased()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[] { Vcd("https://github.com/microsoft/sarif-sdk", "SRCROOT") },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/sarif-sdk/")),
+                Invocations = new[]
+                {
+                    new Invocation
+                    {
+                        WorkingDirectory = new ArtifactLocation { Uri = new Uri("file:///d:/src/sarif-sdk/src/", UriKind.Absolute) },
+                        ExecutionSuccessful = true,
+                    },
+                },
+                Results = new[]
+                {
+                    new Result
+                    {
+                        RuleId = "NOVEL-x",
+                        Message = new Message { Text = "x" },
+                        RelatedLocations = new[]
+                        {
+                            new Location
+                            {
+                                PhysicalLocation = new PhysicalLocation
+                                {
+                                    ArtifactLocation = new ArtifactLocation { Uri = new Uri("file:///d:/src/sarif-sdk/related/r.cs", UriKind.Absolute) },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            run.Invocations[0].WorkingDirectory.Uri.OriginalString.Should().Be("src/");
+            run.Invocations[0].WorkingDirectory.UriBaseId.Should().Be("SRCROOT");
+            ArtifactLocation related = run.Results[0].RelatedLocations[0].PhysicalLocation.ArtifactLocation;
+            related.Uri.OriginalString.Should().Be("related/r.cs");
+            related.UriBaseId.Should().Be("SRCROOT");
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitorTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using FluentAssertions;
 
@@ -254,7 +253,86 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void NonGitHubHost_Fails()
+        public void UnsupportedHost_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://gitlab.com/contoso/widgets", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("not supported");
+        }
+
+        [Fact]
+        public void AzureDevOps_SingleRepo_DerivesRepositoryRootBase()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/MyProject/_git/widgets", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+                Results = new[] { ResultAt("file:///d:/src/widgets/src/Foo.cs") },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            ArtifactLocation location = FirstLocation(run);
+            location.Uri.OriginalString.Should().Be("src/Foo.cs");
+            location.UriBaseId.Should().Be("SRCROOT");
+            run.OriginalUriBaseIds["SRCROOT"].Uri
+                .Should().Be(new Uri("https://dev.azure.com/contoso/MyProject/_git/widgets/", UriKind.Absolute));
+        }
+
+        [Fact]
+        public void AzureDevOps_ProjectAndRepoWithSpaces_PreserveEncodedSegments()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/My%20Project/_git/My%20Repo", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            run.OriginalUriBaseIds["SRCROOT"].Uri.OriginalString
+                .Should().Be("https://dev.azure.com/contoso/My%20Project/_git/My%20Repo/");
+        }
+
+        [Fact]
+        public void AzureDevOps_DotGitSuffix_IsStripped()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/proj/_git/widgets.git", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            run.OriginalUriBaseIds["SRCROOT"].Uri
+                .Should().Be(new Uri("https://dev.azure.com/contoso/proj/_git/widgets/", UriKind.Absolute));
+        }
+
+        [Fact]
+        public void AzureDevOps_MalformedPath_Fails()
         {
             var run = new Run
             {
@@ -268,7 +346,102 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             EmitFinalizeRebaseVisitor visitor = Visit(run);
 
             visitor.Success.Should().BeFalse();
-            string.Join(" ", visitor.Errors).Should().Contain("github.com");
+            string.Join(" ", visitor.Errors).Should().Contain("azure devops repositoryUri must take the form");
+        }
+
+        [Fact]
+        public void AzureDevOps_PreservesRevisionIdAndDoesNotEmbedItInRoot()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/proj/_git/widgets", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+            run.VersionControlProvenance[0].RevisionId.Should().Be(Sha);
+            run.OriginalUriBaseIds["SRCROOT"].Uri.AbsoluteUri.Should().NotContain(Sha);
+        }
+
+        [Fact]
+        public void RepositoryUriWithQuery_Fails()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://dev.azure.com/contoso/proj/_git/widgets?path=/x&version=GCabc", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string.Join(" ", visitor.Errors).Should().Contain("query or fragment");
+        }
+
+        [Fact]
+        public void RepositoryUriWithCredentials_FailsWithoutLeakingSecret()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://user:s3cr3t-token@github.com/contoso/widgets", "SRCROOT"),
+                },
+                OriginalUriBaseIds = Bases(("SRCROOT", "file:///d:/src/widgets/")),
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeFalse();
+            string joined = string.Join(" ", visitor.Errors);
+            joined.Should().Contain("credentials");
+            joined.Should().NotContain("s3cr3t-token");
+        }
+
+        [Fact]
+        public void MixedHosts_GitHubAndAzureDevOps_MintDistinctBases()
+        {
+            var run = new Run
+            {
+                VersionControlProvenance = new[]
+                {
+                    Vcd("https://github.com/contoso/widgets", "A"),
+                    Vcd("https://dev.azure.com/fabrikam/proj/_git/widgets", "B"),
+                },
+                OriginalUriBaseIds = Bases(
+                    ("A", "file:///d:/gh/"),
+                    ("B", "file:///d:/ado/")),
+                Results = new[]
+                {
+                    ResultAt("file:///d:/gh/a.cs"),
+                    ResultAt("file:///d:/ado/b.cs"),
+                },
+            };
+
+            EmitFinalizeRebaseVisitor visitor = Visit(run);
+
+            visitor.Success.Should().BeTrue();
+
+            ArtifactLocation a = run.Results[0].Locations[0].PhysicalLocation.ArtifactLocation;
+            a.Uri.OriginalString.Should().Be("a.cs");
+            a.UriBaseId.Should().Be("SRCROOT_WIDGETS");
+
+            ArtifactLocation b = run.Results[1].Locations[0].PhysicalLocation.ArtifactLocation;
+            b.Uri.OriginalString.Should().Be("b.cs");
+            b.UriBaseId.Should().Be("SRCROOT_WIDGETS_2");
+
+            run.OriginalUriBaseIds["SRCROOT_WIDGETS"].Uri
+                .Should().Be(new Uri($"https://github.com/contoso/widgets/blob/{Sha}/", UriKind.Absolute));
+            run.OriginalUriBaseIds["SRCROOT_WIDGETS_2"].Uri
+                .Should().Be(new Uri("https://dev.azure.com/fabrikam/proj/_git/widgets/", UriKind.Absolute));
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitRunCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitRunCommandTests.cs
@@ -733,6 +733,71 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
+        public void Run_WhenSrcRootDeclared_AndVcpSynthesized_BindsMappedToSourceRoot()
+        {
+            // The run names a local SRCROOT, so the auto-stamped source-repo entry binds to it via
+            // mappedTo. emit-finalize relies on this binding to deconstruct local paths.
+            JObject runObject = MinimalRun();
+            runObject["originalUriBaseIds"] = new JObject
+            {
+                ["SRCROOT"] = new JObject { ["uri"] = new Uri(_dir).AbsoluteUri },
+            };
+            runObject["versionControlProvenance"] = new JArray();
+
+            int exit = RunWithInput(CompleteAdoEnvWithVcp(), runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            var events = new SarifEventLogReader().Read(WipPath).ToList();
+            var vcp = (JArray)events[0].Payload["versionControlProvenance"];
+            vcp.Should().HaveCount(1);
+            vcp[0]["mappedTo"]["uriBaseId"].ToString().Should().Be(EmitRunCommand.SourceRootBaseId);
+        }
+
+        [Fact]
+        public void Run_WhenSrcRootDeclared_AndCallerSuppliesMappedTo_DoesNotOverride()
+        {
+            // A caller-authored mappedTo is authoritative; stamping fills missing fields but never
+            // rebinds the source root the producer already chose.
+            JObject runObject = MinimalRun();
+            runObject["originalUriBaseIds"] = new JObject
+            {
+                ["SRCROOT"] = new JObject { ["uri"] = new Uri(_dir).AbsoluteUri },
+            };
+            runObject["versionControlProvenance"] = new JArray
+            {
+                new JObject
+                {
+                    ["repositoryUri"] = AdoRepoUriValue,
+                    ["mappedTo"] = new JObject { ["uriBaseId"] = "REPO_ROOT" },
+                },
+            };
+
+            int exit = RunWithInput(CompleteAdoEnvWithVcp(), runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            var events = new SarifEventLogReader().Read(WipPath).ToList();
+            var vcp = (JArray)events[0].Payload["versionControlProvenance"];
+            vcp[0]["mappedTo"]["uriBaseId"].ToString().Should().Be("REPO_ROOT");
+        }
+
+        [Fact]
+        public void Run_WhenNoSrcRootDeclared_StampedVcpHasNoMappedTo()
+        {
+            // Without a declared SRCROOT there is nothing for mappedTo to resolve against, so the
+            // stamped entry carries no binding rather than a dangling one.
+            JObject runObject = MinimalRun();
+            runObject["versionControlProvenance"] = new JArray();
+
+            int exit = RunWithInput(CompleteAdoEnvWithVcp(), runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            var events = new SarifEventLogReader().Read(WipPath).ToList();
+            var vcp = (JArray)events[0].Payload["versionControlProvenance"];
+            vcp.Should().HaveCount(1);
+            vcp[0]["mappedTo"].Should().BeNull();
+        }
+
+        [Fact]
         public void Run_WhenAdoRepositoryUriHostCasingDiffers_IsNotConflict()
         {
             // URI equality treats scheme/host case-insensitively (per RFC 3986). The

--- a/src/Test.UnitTests.Sarif/Taxonomies/CweGeneratedSampleTests.cs
+++ b/src/Test.UnitTests.Sarif/Taxonomies/CweGeneratedSampleTests.cs
@@ -59,6 +59,96 @@ namespace Microsoft.CodeAnalysis.Sarif.Taxonomies
         }
 
         [Fact]
+        public void CweGenerateSample_DefaultMode_ReconstructsLiveProvenanceFromGit()
+        {
+            // The bug this guards: the script once hardcoded revisionId to a
+            // frozen github sha while resolving repositoryUri live from the
+            // origin remote, so copying the taxonomy into another repo (e.g.
+            // Azure DevOps) and running it produced an INCOHERENT
+            // versionControlProvenance — a repositoryUri for repo X paired
+            // with a commit that only exists in github sarif-sdk. Default mode
+            // must now reconstruct the whole triple from the live working
+            // tree. We assert the regenerated fixture carries this repo's real
+            // HEAD (not the frozen pin), then restore the checked-in bytes so
+            // the test leaves the working tree clean.
+            string pwsh = FindOnPath("pwsh") ?? FindOnPath("pwsh.exe");
+            if (pwsh == null)
+            {
+                _output.WriteLine("pwsh not found on PATH; skipping live-provenance test.");
+                return;
+            }
+
+            string testAssemblyDirectory = Path.GetDirectoryName(typeof(CweGeneratedSampleTests).Assembly.Location);
+            string repoRoot = FindRepoRoot(testAssemblyDirectory);
+            if (repoRoot == null)
+            {
+                _output.WriteLine($"Could not locate repo root from '{testAssemblyDirectory}'; skipping.");
+                return;
+            }
+
+            string multitoolPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testAssemblyDirectory) ?? string.Empty, "..", "Sarif.Multitool", "net8.0", "Sarif.Multitool.dll"));
+            if (!File.Exists(multitoolPath))
+            {
+                _output.WriteLine($"Sarif.Multitool.dll not found at '{multitoolPath}'; skipping.");
+                return;
+            }
+
+            string headSha = RunGit(repoRoot, "rev-parse HEAD");
+            if (string.IsNullOrWhiteSpace(headSha))
+            {
+                _output.WriteLine($"Could not resolve HEAD at '{repoRoot}' (no git context); skipping live-provenance test.");
+                return;
+            }
+            headSha = headSha.Trim();
+
+            string scriptPath = Path.Combine(repoRoot, ScriptRelativePath);
+            string fixturePath = Path.Combine(repoRoot, DefaultFixtureRelativePath);
+            File.Exists(scriptPath).Should().BeTrue($"the generator script must exist at '{scriptPath}'");
+            File.Exists(fixturePath).Should().BeTrue($"the checked-in fixture must exist at '{fixturePath}'");
+
+            string configuration = InferConfigurationFromAssemblyPath(testAssemblyDirectory) ?? "Release";
+
+            // Snapshot the checked-in fixture; default mode overwrites it in
+            // place with live provenance, so we restore it in the finally.
+            byte[] checkedInBytes = File.ReadAllBytes(fixturePath);
+            try
+            {
+                int exitCode = RunPwsh(
+                    pwsh,
+                    scriptPath,
+                    new[] { "-Configuration", configuration },
+                    out string stdout,
+                    out string stderr);
+
+                if (exitCode != 0)
+                {
+                    Assert.Fail(
+                        $"CweGenerateSample.ps1 (default mode) exited with code {exitCode}.{Environment.NewLine}" +
+                        $"stdout:{Environment.NewLine}{stdout}{Environment.NewLine}" +
+                        $"stderr:{Environment.NewLine}{stderr}");
+                }
+
+                string produced = File.ReadAllText(fixturePath);
+
+                produced.Should().Contain(
+                    headSha,
+                    "default mode must stamp the live HEAD commit into versionControlProvenance.revisionId (and, on the github host, the SRCROOT blob permalink)");
+
+                const string FrozenPin = "84f83c813bcf52ae2c0fd7ff2963e2fa2a2efac7";
+                if (!string.Equals(headSha, FrozenPin, StringComparison.OrdinalIgnoreCase))
+                {
+                    produced.Should().NotContain(
+                        FrozenPin,
+                        "default mode must reconstruct provenance from the live tree, not fall back to the hardcoded canonical sha");
+                }
+            }
+            finally
+            {
+                File.WriteAllBytes(fixturePath, checkedInBytes);
+            }
+        }
+
+        [Fact]
         public void CweGHAzDoSample_RegenerationSucceeds_WhenAmbientAdoFallbackEnvVarsConflict()
         {
             // Regression gate for the mseng pipeline break: a real ADO agent
@@ -170,7 +260,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Taxonomies
             byte[] expectedBytes = File.ReadAllBytes(fixturePath);
             string expectedHash = ComputeSha256(expectedBytes);
 
-            var scriptArgs = new List<string> { "-Configuration", configuration };
+            // -Deterministic pins versionControlProvenance to the canonical
+            // fixture triple (repositoryUri/revisionId/branch) so the
+            // regeneration is byte-identical regardless of the host machine's
+            // git HEAD, branch, or origin remote (fork PRs included). Without
+            // it the script reconstructs live provenance from the working
+            // tree, which is the run-anywhere consumer path, not the fixture.
+            var scriptArgs = new List<string> { "-Configuration", configuration, "-Deterministic" };
             scriptArgs.AddRange(extraScriptArgs);
 
             int exitCode = RunPwsh(
@@ -391,6 +487,33 @@ namespace Microsoft.CodeAnalysis.Sarif.Taxonomies
             stdout = stdoutBuilder.ToString();
             stderr = stderrBuilder.ToString();
             return process.ExitCode;
+        }
+
+        private static string RunGit(string workingDirectory, string arguments)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = arguments,
+                    WorkingDirectory = workingDirectory,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                };
+                using var process = new Process { StartInfo = psi };
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd();
+                process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                return process.ExitCode == 0 ? output : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private static string FindOnPath(string fileName)


### PR DESCRIPTION
## Summary

Replaces the caller-supplied `--srcroot` rewrite at `emit-finalize` with a VCP-driven rebasing visitor. At finalize, `EmitFinalizeRebaseVisitor` deconstructs absolute local file paths into relative URIs plus portable, per-repository `uriBaseId`s derived from `run.versionControlProvenance`. The shipped SARIF carries no machine-specific path.

Portable-root derivation supports **`github.com` and `dev.azure.com`** in this release:
- **github.com** → clickable commit permalink `https://github.com/<owner>/<repo>/blob/<revisionId>/`.
- **dev.azure.com** → commit-less repository root `https://dev.azure.com/<org>/<project>/_git/<repo>/`. ADO per-file web URLs are query-based (`?path=...&version=GC<sha>`) and cannot serve as a SARIF `uriBaseId` prefix (RFC 3986 relative resolution drops the query), so commit pinning rides on `versionControlProvenance.revisionId`, which finalize preserves and GHAzDO ingestion reads.

Follow-up to #2971 (get-schema + emit-run rename + receipt-time SRCROOT-exists check). Fast-follow scope tracked in #2972.

## Contract (hard-enforced at finalize; FAILURE before any file is written)

- Each run declares ≥1 `versionControlProvenance` entry whose `mappedTo` carries **only** a `uriBaseId`, binding a declared `originalUriBaseIds` root.
- `repositoryUri` must be an absolute http(s) URI at the host's default port; `revisionId` non-empty.
- A `repositoryUri` carrying credentials (`user:password@`), a query, or a fragment **fails closed**, and all diagnostics are sanitized so a secret can never surface in an error message.
- Host derivation: `github.com` (`<owner>/<repo>`) and `dev.azure.com` (`<org>/<project>/_git/<repo>`); a `.git` suffix is stripped and empty / dotted / multi-segment repo names are rejected through a single shared guard. Other hosts fail with a clear, planned-follow-up message.
- Base-id minting: one repo → bare `SRCROOT`; multiple → `SRCROOT_<REPO-LEAF>` with `_2`,`_3` collision suffix. Mixed github + ADO repos in one run each get a distinct base. Artifact locations attribute to the owning repo by longest-prefix match on the mapped local root.
- An absolute local path that no declared root resolves **fails closed** (warn-and-ship would leak the machine path) — confirmed with @michaelcfanning.

## emit-run stamping

`TryStampVcp` sets `versionControlProvenance[0].mappedTo.uriBaseId = "SRCROOT"` when (a) the run declares `originalUriBaseIds["SRCROOT"]` and (b) the entry has no caller-supplied `mappedTo`. Multi-entry provenance is left untouched; a caller-authored `mappedTo` is never overridden. emit-run stays host-agnostic.

## Generator reconstructs provenance (no hand-patching)

`CweGenerateSample.ps1` previously resolved `repositoryUri` live from the origin remote but **hardcoded** `revisionId`/`branch` to a frozen github sha. Copying the taxonomy into another repo (e.g. Azure DevOps) and running it produced an incoherent `versionControlProvenance` — a `repositoryUri` for repo X paired with a commit that exists only in github sarif-sdk — that had to be hand-patched before publishing.

The script now resolves the whole triple **atomically**, never per-field:
- **Default** → full live reconstruction from the git working tree (`origin` remote, `HEAD`, abbrev branch), with actionable failures for a missing remote, an unborn HEAD, or a detached HEAD.
- **`-Deterministic`** → the canonical fixture pin (the `v4.5.0` commit `84f83c81…`), so the checked-in fixtures regenerate byte-identically on any machine, commit, or fork. The byte-gate test passes this.
- **`-RevisionId` / `-Branch`** layer onto live mode (explicit anchoring / detached HEAD). The `-GHAzDO` variant stamps `BUILD_REPOSITORY_URI` / `BUILD_SOURCEVERSION` / `BUILD_SOURCEBRANCH` from the same resolved values so `AdoPipelineContext`'s field-by-field agreement check passes.

A new live-coherence `[Fact]` proves default mode stamps this repo's real `HEAD` (not the pin) and restores the fixture afterward, so the working tree stays clean.

## Genchi genbutsu (end-to-end proof)

Copied the `Taxonomies` directory into a live Azure DevOps repository and regenerated with **no patch**:
- `SRCROOT` anchored at the ADO repository root; `revisionId` **auto-resolved to the ADO HEAD**; `branch` `refs/heads/main`.
- Validation **0 errors / 0 warnings / 0 notes** for both variants; **0 machine-path leaks**.
- GHAzDO ingestion of the `-GHAzDO` variant returned **HTTP 200**.

## Validation

- Full `Test.UnitTests.Sarif.Multitool.Library` suite: **319 passed, 1 skipped** (incl. 8 new ADO / credential / mixed-host visitor `[Fact]`s).
- Cwe byte-identical fixture gate + live-coherence test: **green**.
- ReleaseHistory style test: **green**.
- Release build with `EnforceCodeStyleInBuild` (IDE0005-as-error, the CI gate): **clean**.

## Deferred to #2972

Receipt-time VCP/`mappedTo` validation at emit-run; non-cloud ADO shapes (`<org>.visualstudio.com`, collection/virtual-directory) and GHE; submodule / multi-repo collision-suffix determinism; SSH→HTTPS normalization; test-design smell review.