### PR TITLE
Surface skill descriptions in get-skill --list

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.0.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.4)
+* NEW: `sarif get-skill --list` now prints each skill's frontmatter `description` beside its name.
+
 ## **v5.0.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.3)
 * BRK: `FileRegionsCache.PopulateTextRegionProperties` gains an `overwriteExistingData` parameter (default `false`) and `OptionallyEmittedData.OverwriteExistingData` now suppresses exceptions for divergence in pre-populated versus computed region properties.
 * BRK: Split `AI2011.DoNotPersistFingerprints` (Note) into `AI1007.DoNotPersistFingerprints` (Error; `result.fingerprints`) and `AI2011.DoNotPersistPartialFingerprints` (Warning; `result.partialFingerprints`).

--- a/skills/publish-to-ghazdo/SKILL.md
+++ b/skills/publish-to-ghazdo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-to-ghazdo
-description: Uploads a finalized SARIF file to GitHub Advanced Security for Azure DevOps (GHAzDO) using the Sarif.Multitool publish-to-ghazdo verb, with the bearer secret read strictly from an environment variable.
+description: Uploads a finalized SARIF file to GitHub Advanced Security for Azure DevOps (GHAzDO) using the Sarif.Multitool publish-to-ghazdo verb.
 metadata:
   author: sarif-sdk-maintainers
   version: "1.0.0"

--- a/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
+++ b/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
@@ -61,13 +61,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         // `description:` appearing in skill prose cannot leak into the catalog.
         private static readonly Regex s_frontmatterDescription = new Regex(
             @"^description:[ \t]*(?<value>.+?)[ \t]*$",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 
         // A bare YAML block-scalar header (">", "|", optionally with a chomping/indentation indicator)
         // means the value spills onto following lines; the terse catalog skips such a description.
         private static readonly Regex s_blockScalarHeader = new Regex(
             @"^[>|][0-9+\-]*$",
-            RegexOptions.Compiled);
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 
         public int Run(GetSkillOptions options, IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
+++ b/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
@@ -56,6 +56,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             @"\+(?<sha>[0-9a-fA-F]{7,64})",
             RegexOptions.Compiled);
 
+        // The frontmatter `description:` scalar surfaced beside each skill in the get-skill --list
+        // catalog. Matched only against lines inside the leading YAML frontmatter block, so a
+        // `description:` appearing in skill prose cannot leak into the catalog.
+        private static readonly Regex s_frontmatterDescription = new Regex(
+            @"^description:[ \t]*(?<value>.+?)[ \t]*$",
+            RegexOptions.Compiled);
+
+        // A bare YAML block-scalar header (">", "|", optionally with a chomping/indentation indicator)
+        // means the value spills onto following lines; the terse catalog skips such a description.
+        private static readonly Regex s_blockScalarHeader = new Regex(
+            @"^[>|][0-9+\-]*$",
+            RegexOptions.Compiled);
+
         public int Run(GetSkillOptions options, IFileSystem fileSystem = null)
         {
             fileSystem ??= Sarif.FileSystem.Instance;
@@ -264,8 +277,72 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private static string BuildSkillList()
         {
-            return "Available skills:" + Environment.NewLine
-                + string.Concat(SkillSourceDirectory.Keys.Select(name => "  " + name + Environment.NewLine)).TrimEnd();
+            int width = SkillSourceDirectory.Keys.Max(name => name.Length);
+
+            var builder = new StringBuilder("Available skills:");
+            foreach (string name in SkillSourceDirectory.Keys)
+            {
+                builder.Append(Environment.NewLine).Append("  ");
+
+                string description = TryGetSkillDescription(name);
+                if (string.IsNullOrEmpty(description))
+                {
+                    builder.Append(name);
+                }
+                else
+                {
+                    builder.Append(name.PadRight(width)).Append("  ").Append(description);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Returns the skill's frontmatter <c>description</c>, or <c>null</c> when the embedded resource
+        /// is missing or declares none. This is the single source of truth for the skill's one-line
+        /// summary — the same scalar a consumer reads from the emitted document's frontmatter.
+        /// </summary>
+        internal static string TryGetSkillDescription(string skillName)
+        {
+            byte[] bytes = ReadEmbeddedSkill(skillName);
+            return bytes == null ? null : ExtractFrontmatterDescription(DecodeUtf8(bytes));
+        }
+
+        /// <summary>
+        /// Extracts the <c>description</c> scalar from a skill document's leading YAML frontmatter block.
+        /// Returns <c>null</c> when the document opens no frontmatter, declares no description, or uses a
+        /// multi-line block scalar (which the terse catalog does not render).
+        /// </summary>
+        internal static string ExtractFrontmatterDescription(string document)
+        {
+            if (string.IsNullOrEmpty(document)) { return null; }
+
+            using (var reader = new StringReader(document))
+            {
+                if (reader.ReadLine()?.Trim() != "---") { return null; }
+
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line.Trim() == "---") { return null; }
+
+                    Match match = s_frontmatterDescription.Match(line);
+                    if (!match.Success) { continue; }
+
+                    string value = match.Groups["value"].Value;
+                    if (value.Length >= 2
+                        && (value[0] == '"' || value[0] == '\'')
+                        && value[value.Length - 1] == value[0])
+                    {
+                        value = value.Substring(1, value.Length - 2);
+                    }
+
+                    return s_blockScalarHeader.IsMatch(value) ? null : value;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Test.UnitTests.Sarif.Multitool.Library/GetSkill/GetSkillCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/GetSkill/GetSkillCommandTests.cs
@@ -189,26 +189,74 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Fact]
         public void GetSkill_List_EnumeratesExactlyTheCatalogSkills()
         {
-            string output;
-            TextWriter original = Console.Out;
-            try
-            {
-                using var writer = new StringWriter();
-                Console.SetOut(writer);
-                new GetSkillCommand().Run(new GetSkillOptions { List = true })
-                    .Should().Be(CommandBase.SUCCESS);
-                output = writer.ToString();
-            }
-            finally
-            {
-                Console.SetOut(original);
-            }
+            string output = RunListToString();
 
             foreach (string skill in GetSkillCommand.SkillSourceDirectory.Keys)
             {
                 output.Should().Contain(skill);
             }
         }
+
+        [Fact]
+        public void GetSkill_List_SurfacesEachSkillDescriptionBesideItsName()
+        {
+            string output = RunListToString();
+            string[] lines = output.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            var offenders = new List<string>();
+            foreach (string skill in GetSkillCommand.SkillSourceDirectory.Keys)
+            {
+                string description = GetSkillCommand.TryGetSkillDescription(skill);
+                if (string.IsNullOrEmpty(description))
+                {
+                    offenders.Add($"  [{skill}] declares no frontmatter description.");
+                    continue;
+                }
+
+                string line = lines.SingleOrDefault(l => l.IndexOf(description, StringComparison.Ordinal) >= 0);
+                if (line == null)
+                {
+                    offenders.Add($"  [{skill}] description is not present on exactly one --list line.");
+                    continue;
+                }
+
+                if (!line.TrimStart().StartsWith(skill, StringComparison.Ordinal))
+                {
+                    offenders.Add($"  [{skill}] description is not on the same line as its name.");
+                }
+            }
+
+            offenders.Should().BeEmpty(
+                "get-skill --list must surface each skill's frontmatter description beside its name:\n"
+                + string.Join("\n", offenders));
+        }
+
+        [Fact]
+        public void GetSkill_ExtractDescription_ReadsUnquotedSingleLineScalar()
+            => AssertExtractedDescription("---\nname: x\ndescription: Hello, world.\n---\nbody\n", "Hello, world.");
+
+        [Fact]
+        public void GetSkill_ExtractDescription_StripsSurroundingDoubleQuotes()
+            => AssertExtractedDescription("---\ndescription: \"Quoted value\"\n---\n", "Quoted value");
+
+        [Fact]
+        public void GetSkill_ExtractDescription_StripsSurroundingSingleQuotes()
+            => AssertExtractedDescription("---\ndescription: 'Quoted value'\n---\n", "Quoted value");
+
+        [Fact]
+        public void GetSkill_ExtractDescription_ReturnsNullWhenDocumentHasNoFrontmatter()
+            => AssertExtractedDescription("# Title\ndescription: not in frontmatter\n", null);
+
+        [Fact]
+        public void GetSkill_ExtractDescription_ReturnsNullForBlockScalarIndicator()
+            => AssertExtractedDescription("---\ndescription: >\n  folded text spilling to the next line\n---\n", null);
+
+        [Fact]
+        public void GetSkill_ExtractDescription_IgnoresDescriptionAfterFrontmatterCloses()
+            => AssertExtractedDescription("---\nname: x\n---\ndescription: body line\n", null);
+
+        private static void AssertExtractedDescription(string document, string expected)
+            => GetSkillCommand.ExtractFrontmatterDescription(document).Should().Be(expected);
 
         [Fact]
         public void GetSkill_UnknownSkill_Fails()
@@ -252,6 +300,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             .Should().Be(CommandBase.SUCCESS);
 
             return File.ReadAllText(outPath);
+        }
+
+        private static string RunListToString()
+        {
+            TextWriter original = Console.Out;
+            try
+            {
+                using var writer = new StringWriter();
+                Console.SetOut(writer);
+                new GetSkillCommand().Run(new GetSkillOptions { List = true })
+                    .Should().Be(CommandBase.SUCCESS);
+                return writer.ToString();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
         }
 
         private static string FindRepositoryRoot()

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,6 @@
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>5.0.4</VersionPrefix>
-    <PreviousVersionPrefix>5.0.3</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>

--- a/src/build.props
+++ b/src/build.props
@@ -13,8 +13,8 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.0.3</VersionPrefix>
-    <PreviousVersionPrefix>5.0.2</PreviousVersionPrefix>
+    <VersionPrefix>5.0.4</VersionPrefix>
+    <PreviousVersionPrefix>5.0.3</PreviousVersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## What

get-skill --list now prints each skill's frontmatter `description` beside its name in an aligned two-column layout:

```
Available skills:
  emit-sarif         Serialize AI-detected security findings as SARIF v2.1.0 conforming to the AI-generated-findings profile, using the Sarif.Multitool emit verbs.
  publish-to-ghazdo  Uploads a finalized SARIF file to GitHub Advanced Security for Azure DevOps (GHAzDO) using the Sarif.Multitool publish-to-ghazdo verb.
  validate-sarif     Validates SARIF files against the SARIF 2.1.0 schema and the AI-generated-findings profile rules shipped by Sarif.Multitool.
```

## Why

The catalog previously emitted bare names. Names are intentionally terse, so an agent consuming the catalog had to fetch every skill and parse its frontmatter just to triage relevance. Surfacing the description inline lets a consumer self-select from a single `--list` call.

## Design

- **Single source of truth.** The description is read from each embedded skill's YAML frontmatter `description:` scalar -- the same value a consumer already reads from the emitted document. Nothing new to author or keep in sync.
- **Graceful degradation.** A skill that opens no frontmatter, declares no description, or uses a multi-line block scalar falls back to name-only rather than emitting a dangling indicator.
- **Conciseness.** Trimmed the `publish-to-ghazdo` frontmatter description to one clause to match its siblings; the env-var bearer-secret detail is a how (covered in the skill body), not a selection signal.

## Tests

Added direct `ExtractFrontmatterDescription` unit facts (unquoted scalar, quote stripping, no-frontmatter, block-scalar, post-frontmatter `description:`) and an integration fact asserting each catalog skill's description is surfaced beside its name. Full GetSkill suite: 20/20 green. Release build clean (0/0).

## Versioning

Bump to **5.0.4**.
