### PR TITLE
docs: fix multitool convert options

### DIFF
--- a/docs/multitool-usage.md
+++ b/docs/multitool-usage.md
@@ -36,7 +36,7 @@ npx @microsoft/sarif-multitool <args>
 Sarif.Multitool @microsoft/sarif-multitool help
 
 : Convert a Fortify file to SARIF
-Sarif.Multitool convert Current.fpr -tool FortifyFpr -output Current.sarif
+Sarif.Multitool convert Current.fpr --tool FortifyFpr --output Current.sarif
 
 : Add file contents from analyzed files and snippets from result regions to SARIF
 Sarif.Multitool rewrite Current.sarif --insert TextFiles;RegionSnippets --log Inline


### PR DESCRIPTION
## Summary
- Update the Fortify conversion example to use the long `--tool` and `--output` options.
- This avoids parsing `-tool` as `-t ool` and `-output` as `-o utput`.

Fixes #2730.

## Testing
- `rg -n "Fortify|Current\.fpr|-tool|-output|--tool|--output" docs\multitool-usage.md`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.