### PR TITLE
Drop kind: \"fail\" from emit-sarif skill minimum-fields list

### DIFF
--- a/skills/emit-sarif/SKILL.md
+++ b/skills/emit-sarif/SKILL.md
@@ -116,7 +116,7 @@ dotnet dnx Sarif.Multitool --yes -- add-result "{{OUTPUT_PATH}}" --input result-
 Get-Content result-001.json | dotnet dnx Sarif.Multitool --yes -- add-result "{{OUTPUT_PATH}}"
 ```
 
-The result JSON must include at minimum: `ruleId` (with sub-ID per AI1012, e.g. `CWE-78/api-handler`), `kind: "fail"`, `level`, `message.text`, `message.markdown` (AI1005), at least one `locations[].physicalLocation` with a `region.startLine`, and any `ai/*` property bag entries required by the profile (`ai/exploitability`, `ai/attackerPosition`, `ai/evidence`).
+The result JSON must include at minimum: `ruleId` (with sub-ID per AI1012, e.g. `CWE-78/api-handler`), `level`, `message.text`, `message.markdown` (AI1005), at least one `locations[].physicalLocation` with a `region.startLine`, and any `ai/*` property bag entries required by the profile (`ai/exploitability`, `ai/attackerPosition`, `ai/evidence`).
 
 **Vocabulary discipline:** only the eight `ai/*` keys defined in the profile are valid. Do not invent additional `ai/*` keys; place tool-specific data under a tool-named namespace instead (e.g. `myscanner/confidence`).
 


### PR DESCRIPTION
## What

The `emit-sarif` skill (`skills/emit-sarif/SKILL.md`) listed `kind: "fail"` among the fields a result JSON `must include at minimum`. This drops it.

## Why it was wrong

- **It is the schema default.** SARIF 2.1.0 §3.27.9 defines `result.kind` as defaulting to `"fail"` when absent. A minimal failure result need not emit it — it is the one value you never have to supply.
- **No rule requires it.** Nothing in `src/Sarif.Multitool.Library/Rules` references `result.kind` (verified by grep). Neither the schema nor any Sarif/AI profile rule mandates an explicit `kind`.

So listing `kind: "fail"` as required-at-minimum is self-contradictory: the floor cannot include the one field that is the default.

## Scope

- One-line edit to the minimum-fields sentence in `SKILL.md`.
- Explicit `kind` stays valid for **non-default** kinds (`pass`, `notApplicable`, `review`, `open`, `informational`) — those still require the producer to supply it.
- Full examples in `docs/ai/generating-sarif.md` continue to show `kind: "fail"` explicitly. That is intentionally untouched: a full example may be more explicit than the minimum floor, and `rank is only meaningful when kind is "fail"` (§3.27.25) remains a correct statement there.

## Validation

- `get-skill` source-fidelity tests: 20/20 pass (embedded resource re-syncs from disk).
- Release build: 0 warnings.

No `ReleaseHistory.md` bullet — a skill-doc correction is neither a public-API surface change nor a behavior change (same rationale as #2980).