### PR TITLE
Make RuleKind a [Flags] enum and remove RuleKind.Gh

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **UNRELEASED**
+* BRK: `RuleKind` is now a `[Flags]` enum (`Sarif=1, Ghas=2, GHAzDO=4, AI=8`); `RuleKind.Gh` is removed and the GH#### rules report `RuleKind.Ghas`. Callers selecting `Gh` must use `Ghas`.
+
 ## **v5.0.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.4)
 * NEW: `sarif get-skill --list` now prints each skill's frontmatter `description` beside its name.
 * NEW: `sarif emit-finalize` now stamps each minted `originalUriBaseIds` entry with a `description` whose `text` is an embedded link (§3.11.6), `[<repo>@<short-sha>](<root-at-revision URL>)`, pinning the source to its commit. A producer-supplied description is preserved.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
-* BRK: `RuleKind` is now a `[Flags]` enum (`Sarif=1, Ghas=2, GHAzDO=4, AI=8`); `RuleKind.Gh` is removed and the GH#### rules report `RuleKind.Ghas`. Callers selecting `Gh` must use `Ghas`.
+* BRK: `RuleKind` is now a `[Flags]` enum (`Sarif=1, Ghas=2, GHAzDO=4, AI=8`); the GH#### rules report `RuleKind.Ghas`, and `RuleKind.Gh` is now an `[Obsolete]` alias of `Ghas`.
 
 ## **v5.0.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.4)
 * NEW: `sarif get-skill --list` now prints each skill's frontmatter `description` beside its name.

--- a/src/Sarif.Multitool.Library/Rules/GH1001.ProvideRequiredLocationProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1001.ProvideRequiredLocationProperties.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.ProvideRequiredLocationProperties;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         /// <summary>
         /// Each result location must provide the property 'physicalLocation.artifactLocation.uri'.

--- a/src/Sarif.Multitool.Library/Rules/GH1002.InlineThreadFlowLocations.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1002.InlineThreadFlowLocations.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.InlineThreadFlowLocations;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         /// <summary>
         /// Results that include codeFlows must specify each threadFlowLocation directly within

--- a/src/Sarif.Multitool.Library/Rules/GH1003.ProvideRequiredRegionProperties.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1003.ProvideRequiredRegionProperties.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.ProvideRequiredRegionProperties;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         // Every result must provide a 'region' that specifies its location with line and optional
         // column information. GitHub Advanced Security code scanning can display the correct

--- a/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1004.ReviewArraysThatExceedConfigurableDefaults.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.ReviewArraysThatExceedConfigurableDefaults;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         // GitHub Advanced Security code scanning limits the amount of information it displays. There
         // are limits on the number of runs per log file, rules per run, results per run, locations

--- a/src/Sarif.Multitool.Library/Rules/GH1005.LocationsMustBeRelativeUrisOrFilePaths.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1005.LocationsMustBeRelativeUrisOrFilePaths.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.LocationsMustBeRelativeUrisOrFilePaths;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         // GitHub Advanced Security code scanning only displays results whose locations are specified
         // by file paths, either as relative URIs or as absolute URIs that use the 'file' scheme.

--- a/src/Sarif.Multitool.Library/Rules/GH1006.ProvideCheckoutPath.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1006.ProvideCheckoutPath.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.ProvideCheckoutPath;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         // GitHub Advanced Security code scanning will reject a SARIF file that expresses
         // result locations as absolute 'file' scheme URIs unless GitHub can determine the URI

--- a/src/Sarif.Multitool.Library/Rules/GH1007.ProvideFullyFormattedMessageStrings.cs
+++ b/src/Sarif.Multitool.Library/Rules/GH1007.ProvideFullyFormattedMessageStrings.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.ProvideFullyFormattedMessageStrings;
 
-        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Gh });
+        public override HashSet<RuleKind> RuleKinds => new HashSet<RuleKind>(new[] { RuleKind.Ghas });
 
         public override MultiformatMessageString FullDescription => new MultiformatMessageString { Text = RuleResources.GH1007_ProvideFullyFormattedMessageStrings_FullDescription_Text };
 

--- a/src/Sarif/RuleKind.cs
+++ b/src/Sarif/RuleKind.cs
@@ -9,16 +9,17 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// Identifies the validator family that applies a SARIF reporting-descriptor rule.
     /// </summary>
     /// <remarks>
-    /// Not a <c>[Flags]</c> enum; combinations are expressed via <see cref="RuleKindSet"/>.
+    /// <c>[Flags]</c>: each kind is an independent bit. The active kinds for an
+    /// analysis are expressed as a <see cref="RuleKindSet"/>.
     /// </remarks>
+    [Flags]
     public enum RuleKind
     {
         None = 0,
         Sarif = 1,
-        Gh = 2,
-        Ghas = 3,
+        Ghas = 2,
         GHAzDO = 4,
-        AI = 5,
+        AI = 8,
 
         [Obsolete("Use RuleKind.GHAzDO instead.")]
         Ado = GHAzDO,

--- a/src/Sarif/RuleKind.cs
+++ b/src/Sarif/RuleKind.cs
@@ -8,10 +8,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// <summary>
     /// Identifies the validator family that applies a SARIF reporting-descriptor rule.
     /// </summary>
-    /// <remarks>
-    /// <c>[Flags]</c>: each kind is an independent bit. The active kinds for an
-    /// analysis are expressed as a <see cref="RuleKindSet"/>.
-    /// </remarks>
     [Flags]
     public enum RuleKind
     {
@@ -20,6 +16,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         Ghas = 2,
         GHAzDO = 4,
         AI = 8,
+
+        [Obsolete("Use RuleKind.Ghas instead.")]
+        Gh = Ghas,
 
         [Obsolete("Use RuleKind.GHAzDO instead.")]
         Ado = GHAzDO,

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 //RuleKindOption = AllRuleKinds
                 RuleKindOption = ruleUnderTest.StartsWith("GHAzDO")
                     ? new List<RuleKind> { RuleKind.GHAzDO }
-                    : new List<RuleKind> { RuleKind.Gh, RuleKind.Sarif, RuleKind.AI },
+                    : new List<RuleKind> { RuleKind.Ghas, RuleKind.Sarif, RuleKind.AI },
             };
 
             var mockFileSystem = new Mock<IFileSystem>();

--- a/src/Test.UnitTests.Sarif/RuleKindTests.cs
+++ b/src/Test.UnitTests.Sarif/RuleKindTests.cs
@@ -23,6 +23,15 @@ namespace Test.UnitTests.Sarif
         }
 
         [Fact]
+        public void RuleKind_GhAlias_SharesUnderlyingValueWithGhas()
+        {
+#pragma warning disable CS0618
+            ((int)RuleKind.Gh).Should().Be((int)RuleKind.Ghas);
+            RuleKind.Gh.Should().Be(RuleKind.Ghas);
+#pragma warning restore CS0618
+        }
+
+        [Fact]
         public void RuleKind_AdoAlias_ParsesCaseInsensitively()
         {
             AssertParsesToGHAzDO("Ado");

--- a/src/Test.UnitTests.Sarif/RuleKindTests.cs
+++ b/src/Test.UnitTests.Sarif/RuleKindTests.cs
@@ -30,6 +30,21 @@ namespace Test.UnitTests.Sarif
             AssertParsesToGHAzDO("ADO");
         }
 
+        [Fact]
+        public void RuleKind_IsFlags_WithDistinctSingleBitValues()
+        {
+            RuleKind[] kinds = { RuleKind.Sarif, RuleKind.Ghas, RuleKind.GHAzDO, RuleKind.AI };
+
+            int combined = 0;
+            foreach (RuleKind kind in kinds)
+            {
+                int value = (int)kind;
+                (value & (value - 1)).Should().Be(0, "each kind is a single-bit flag");
+                (combined & value).Should().Be(0, "kinds occupy non-overlapping bits");
+                combined |= value;
+            }
+        }
+
         private static void AssertParsesToGHAzDO(string input)
         {
             RuleKind parsed = (RuleKind)Enum.Parse(typeof(RuleKind), input, ignoreCase: true);

--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         private readonly bool _testProducesSarifCurrentVersion;
         private readonly TestAssetResourceExtractor _extractor;
 
-        protected readonly List<RuleKind> AllRuleKinds = new List<RuleKind>(new[] { RuleKind.Sarif, RuleKind.GHAzDO, RuleKind.Gh, RuleKind.Ghas });
+        protected readonly List<RuleKind> AllRuleKinds = new List<RuleKind>(new[] { RuleKind.Sarif, RuleKind.GHAzDO, RuleKind.Ghas });
 
         public FileDiffingUnitTests(ITestOutputHelper outputHelper, bool testProducesSarifCurrentVersion = true)
         {


### PR DESCRIPTION
## What

Cleans up the `RuleKind` enum:

- Makes it a `[Flags]` enum with single-bit values: `None=0, Sarif=1, Ghas=2, GHAzDO=4, AI=8`.
- Removes the stray `RuleKind.Gh`.
- Repoints the seven GH#### rules that used `Gh` (GH1001–GH1007) onto `RuleKind.Ghas`, so every GitHub Advanced Security validation rule now reports a single, consistent kind.

## Why

`Gh` and `Ghas` were two kinds for one family — `GH1001–GH1007` claimed `Gh` while `GH1011`/`GH1013–GH1018`/`GH2012` already claimed `Ghas`. Folding them onto `Ghas` lets a consumer (e.g. an AI validation rule, or `emit-finalize`) reason about "is GHAS in play" by testing for a single kind. Making the enum `[Flags]` gives the kinds clean, independent bit values.

## Compatibility

`BRK`. `RuleKind.Gh` is gone; callers that selected it must use `RuleKind.Ghas`. `GHAzDO` keeps value `4`, so the obsolete `RuleKind.Ado` alias and its case-insensitive `--rule-kind` parsing are unchanged. CLI `--rule-kind` parsing is by name, so the renumbering of `AI` (5→8) and `Ghas` (3→2) is not observable through the command line or any persisted artifact.

## Validation

- `RuleKindTests` 3/3 (Ado-alias value + parse, new single-bit `[Flags]` invariant guard).
- Functional `GH100*` validation tests 14/14 (GH1001–GH1007 still fire under `--rule-kind Ghas`).
- Release build with `EnforceCodeStyleInBuild=true` clean (0/0).
- `ReleaseHistory.md` `UNRELEASED` `BRK` bullet added.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
