### PR TITLE
Check for successive null bytes in IsTextualData

### DIFF
--- a/src/Sarif/FileEncoding.cs
+++ b/src/Sarif/FileEncoding.cs
@@ -43,11 +43,22 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             Windows1252 ??= Encoding.GetEncoding(1252);
 
+            int successiveNulls = 0;
             bool containsControlCharacters = false;
 
             for (int i = 0; i < count; i++)
             {
-                containsControlCharacters |= bytes[i] < 0x20;
+                byte b = bytes[i];
+
+                if (b == 0)
+                {
+                    if (++successiveNulls > 3)
+                    {
+                        return false;
+                    }
+                }
+
+                containsControlCharacters |= b < 0x20;
             }
 
             if (!containsControlCharacters)


### PR DESCRIPTION
IsTextualData returns true for a lot of dlls, like Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.dll 5.300.26.7805.  
 
I've added a check for 4 successive number of null bytes and it seems to be much more robust. 