### PR TITLE
Harden emit-run / add-invocation round-trip guardrails

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,6 +14,8 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
+* BUG: `sarif add-invocation` now accepts a `workingDirectory` anchored by `uriBaseId` alone (empty or absent `uri`), so an `emit-finalize`-rebased invocation round-trips back through the verb; a whitespace `uri` with no `uriBaseId` is still rejected.
+* NEW: `sarif emit-run` now warns to stderr when the supplied run header carries `results` or `invocations` (use `add-result`/`add-invocation`); these are dropped at replay, and the header is still written.
 
 ## **v5.0.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.5) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.5)
 * BRK: `RuleKind` is now a `[Flags]` enum (`Sarif=1, Ghas=2, GHAzDO=4, AI=8`); the GH#### rules report `RuleKind.Ghas`, and `RuleKind.Gh` is now an `[Obsolete]` alias of `Ghas`.

--- a/src/Sarif.Multitool.Library/Emit/AddInvocationCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/AddInvocationCommand.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
     /// </summary>
     /// <remarks>
     /// <para>The verb gates required AI invocation fields: <c>executionSuccessful</c>,
-    /// <c>commandLine</c>, <c>workingDirectory.uri</c>, and inline notification <c>timeUtc</c>
+    /// <c>commandLine</c>, an anchored <c>workingDirectory</c> (a <c>uri</c> and/or
+    /// <c>uriBaseId</c>), and inline notification <c>timeUtc</c>
     /// values. Full structural validation runs at <c>emit-finalize --validate</c>.</para>
     /// <para>The verb stamps <c>endTimeUtc</c> with the time of receipt when the producer leaves it unset.</para>
     /// </remarks>
@@ -95,15 +96,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
 
             JToken workingDirectory = payload["workingDirectory"];
-            JToken workingDirectoryUri = (workingDirectory as JObject)?["uri"];
-            if (workingDirectory == null
-                || workingDirectory.Type != JTokenType.Object
-                || workingDirectoryUri == null
-                || workingDirectoryUri.Type != JTokenType.String
-                || string.IsNullOrWhiteSpace(workingDirectoryUri.Value<string>()))
+            if (workingDirectory == null || workingDirectory.Type != JTokenType.Object)
             {
                 Console.Error.WriteLine(
-                    "Invalid invocation: 'workingDirectory' is required and must be an artifactLocation with a non-whitespace 'uri'.");
+                    "Invalid invocation: 'workingDirectory' is required and must be an artifactLocation.");
+                return false;
+            }
+
+            // A SARIF artifactLocation is addressable by 'uri' and/or 'uriBaseId'. emit-finalize
+            // rebases a repo-root workingDirectory to an empty 'uri' under a 'uriBaseId', so accept
+            // either anchor; only a workingDirectory carrying neither is unanchored and rejected.
+            var workingDirectoryObject = (JObject)workingDirectory;
+            JToken workingDirectoryUri = workingDirectoryObject["uri"];
+            JToken workingDirectoryUriBaseId = workingDirectoryObject["uriBaseId"];
+            bool hasUri = workingDirectoryUri?.Type == JTokenType.String
+                && !string.IsNullOrWhiteSpace(workingDirectoryUri.Value<string>());
+            bool hasUriBaseId = workingDirectoryUriBaseId?.Type == JTokenType.String
+                && !string.IsNullOrWhiteSpace(workingDirectoryUriBaseId.Value<string>());
+            if (!hasUri && !hasUriBaseId)
+            {
+                Console.Error.WriteLine(
+                    "Invalid invocation: 'workingDirectory' must be an artifactLocation with a non-whitespace 'uri' or 'uriBaseId'.");
                 return false;
             }
 

--- a/src/Sarif.Multitool.Library/Emit/EmitRunCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitRunCommand.cs
@@ -187,6 +187,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     fileSystem.DirectoryCreateDirectory(directory);
                 }
 
+                WarnOnIgnoredHeaderData(runObject);
+
                 using (var writer = new SarifEventLogWriter(wipPath))
                 {
                     writer.Append(SarifEventKinds.RunHeader, runObject);
@@ -221,6 +223,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
 
             return true;
+        }
+
+        // results and invocations on the run header are dropped when the event log is replayed
+        // (SarifEventReplayer); they belong in their own add-result / add-invocation events. Warn
+        // rather than reject so a producer that ships a fuller Run object is told what is lost.
+        private static void WarnOnIgnoredHeaderData(JObject runObject)
+        {
+            var dropped = new List<string>();
+            if (runObject["results"] is JArray results && results.Count > 0)
+            {
+                dropped.Add(string.Format(CultureInfo.CurrentCulture, "results[{0}]", results.Count));
+            }
+
+            if (runObject["invocations"] is JArray invocations && invocations.Count > 0)
+            {
+                dropped.Add(string.Format(CultureInfo.CurrentCulture, "invocations[{0}]", invocations.Count));
+            }
+
+            if (dropped.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "warning: the run header carries {0}; this data is ignored at replay (results belong in add-result, invocations in add-invocation) and will not appear in the finalized log.",
+                        string.Join(", ", dropped)));
+            }
         }
 
         private static bool TryValidateRunHeader(JObject runObject, IFileSystem fileSystem)

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/AddInvocationCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/AddInvocationCommandTests.cs
@@ -208,6 +208,46 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
+        public void Run_SucceedsWhenWorkingDirectoryAnchoredByUriBaseIdWithEmptyUri()
+        {
+            // emit-finalize rebases a repo-root workingDirectory to an empty 'uri' under a
+            // 'uriBaseId'; that shape is a valid artifactLocation and must round-trip back
+            // through add-invocation rather than tripping the receipt gate.
+            SeedRunHeader();
+            File.WriteAllText(
+                InputPath,
+                "{ \"executionSuccessful\": true, \"commandLine\": \"demo --scan src\", \"workingDirectory\": { \"uri\": \"\", \"uriBaseId\": \"SRCROOT\" } }");
+
+            int exit = new AddInvocationCommand().Run(new AddInvocationOptions
+            {
+                OutputFilePath = OutPath,
+                InputFilePath = InputPath,
+            });
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            File.ReadAllLines(WipPath).Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Run_SucceedsWhenWorkingDirectoryAnchoredByUriBaseIdAlone()
+        {
+            // A 'uriBaseId' with no 'uri' member is likewise anchored and accepted.
+            SeedRunHeader();
+            File.WriteAllText(
+                InputPath,
+                "{ \"executionSuccessful\": true, \"commandLine\": \"demo --scan src\", \"workingDirectory\": { \"uriBaseId\": \"SRCROOT\" } }");
+
+            int exit = new AddInvocationCommand().Run(new AddInvocationOptions
+            {
+                OutputFilePath = OutPath,
+                InputFilePath = InputPath,
+            });
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            File.ReadAllLines(WipPath).Should().HaveCount(2);
+        }
+
+        [Fact]
         public void Run_StampsEndTimeUtcWhenOmitted()
         {
             // The verb fills endTimeUtc at emit time when the producer left it unset, so the

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitRunCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitRunCommandTests.cs
@@ -516,6 +516,77 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             File.Exists(WipPath).Should().BeFalse();
         }
 
+        [Fact]
+        public void Run_WhenHeaderCarriesResults_WarnsToStderrButStillWritesHeader()
+        {
+            // results on the run header are dropped at replay (they belong in add-result), so the
+            // verb warns rather than silently discarding them; the header is still written.
+            JObject runObject = MinimalRun();
+            runObject["results"] = new JArray
+            {
+                new JObject { ["ruleId"] = "TEST0001", ["message"] = new JObject { ["text"] = "x" } },
+            };
+
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            int exit = RunWithInput(runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            errWriter.ToString().Should().Contain("results[1]");
+            File.Exists(WipPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Run_WhenHeaderCarriesInvocations_WarnsToStderrButStillWritesHeader()
+        {
+            // invocations on the run header are dropped at replay (they belong in add-invocation),
+            // so the verb warns rather than silently discarding them; the header is still written.
+            JObject runObject = MinimalRun();
+            runObject["invocations"] = new JArray
+            {
+                new JObject { ["executionSuccessful"] = true },
+                new JObject { ["executionSuccessful"] = false },
+            };
+
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            int exit = RunWithInput(runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            errWriter.ToString().Should().Contain("invocations[2]");
+            File.Exists(WipPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Run_WhenHeaderHasNoResultsOrInvocations_DoesNotWarn()
+        {
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            int exit = RunWithInput(MinimalRun());
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            errWriter.ToString().Should().NotContain("ignored at replay");
+        }
+
+        [Fact]
+        public void Run_WhenHeaderHasEmptyResultsArray_DoesNotWarn()
+        {
+            // An empty array carries no data, so it is not worth a warning.
+            JObject runObject = MinimalRun();
+            runObject["results"] = new JArray();
+
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            int exit = RunWithInput(runObject);
+
+            exit.Should().Be(CommandBase.SUCCESS);
+            errWriter.ToString().Should().NotContain("ignored at replay");
+        }
+
         private static FakeEnvironmentVariableGetter CompleteAdoEnv() => new FakeEnvironmentVariableGetter()
             .With(AdoPipelineContext.TfBuildEnvVar, "True")
             .With(AdoPipelineContext.CollectionUriEnvVar, "https://dev.azure.com/contoso/")


### PR DESCRIPTION
Two small emit-verb fixes that surfaced from AI-friend feedback on the `emit-run` → `add-invocation` → `emit-finalize` pipeline. Both target a round-trip that today either breaks or loses data silently. A third candidate (`get-schema emit-finalize`) is deferred — see below.

## 1. `add-invocation`: accept a `uriBaseId`-anchored `workingDirectory` (BUG)

`emit-finalize` rebases a repo-root `workingDirectory` to an **empty `uri` under a `uriBaseId`** (`EmitFinalizeRebaseVisitor`: `node.Uri = LocalRoot.MakeRelativeUri(abs)` is `""` when the working directory *is* the root, with `node.UriBaseId` set). That is a valid SARIF `artifactLocation`.

But `AddInvocationCommand.TryValidateInvocationReceipt` required a **non-whitespace `uri`** unconditionally — stricter than SARIF — so a finalized invocation could not be re-ingested through the verb that produced it.

Fix: the gate now accepts a `workingDirectory` anchored by `uri` **or** `uriBaseId`. A `workingDirectory` carrying neither (e.g. a whitespace `uri` with no `uriBaseId`) is still unanchored and rejected.

## 2. `emit-run`: warn when the run header carries `results` / `invocations` (NEW)

The run header written by `emit-run` has its `results` and `invocations` **dropped at replay** (they belong in `add-result` / `add-invocation`). The doc-comment said as much, but the verb discarded them with no signal. A producer that hands `emit-run` a fuller `Run` object now gets a one-line stderr warning naming what was dropped (`results[N]`, `invocations[M]`). The header is still written; this is advisory, not a failure.

## Tests (house style: multiple `[Fact]`, no `[Theory]`)

- `AddInvocationCommandTests`: `Run_SucceedsWhenWorkingDirectoryAnchoredByUriBaseIdWithEmptyUri`, `Run_SucceedsWhenWorkingDirectoryAnchoredByUriBaseIdAlone`. The existing `Run_FailsWhenWorkingDirectoryUriIsWhitespace` (whitespace `uri`, no `uriBaseId`) stays green, proving the relaxation only opens the `uriBaseId` path.
- `EmitRunCommandTests`: warns on `results`, warns on `invocations`, no warning when clean, no warning on an empty array.

Full multitool-library suite: 84 passed. ReleaseHistory style gate: 2 passed.

## Deferred (open design question)

`get-schema emit-finalize` returns a graceful "schema not yet available (issue #2970)" error. "Fixing" it means deciding what schema describes finalize's input — which is the accumulated `.wip.jsonl` **event log**, not a single SARIF document. Serving the base SARIF schema (the original suggestion) would misdescribe that contract. Left as-is pending a decision.
