### PR TITLE
Fix empty npm win32 package by disabling fragile ReadyToRun (#3003)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
-* BUG: `npx @microsoft/sarif-multitool` works on Windows again — the `@microsoft/sarif-multitool-win32` package now ships `Sarif.Multitool.exe`. The self-contained `win-x64` publish no longer enables `PublishReadyToRun`, whose crossgen2 failure had silently produced an empty Windows package; `BuildMultitoolForNpm.ps1` now fails the build if any platform payload is missing.
+* BUG: `@microsoft/sarif-multitool-win32` ships `Sarif.Multitool.exe` again, restoring `npx @microsoft/sarif-multitool` on Windows; the `win-x64` publish drops `PublishReadyToRun` (a crossgen2 failure had emptied the package) and `BuildMultitoolForNpm.ps1` now fails on any missing platform payload.
 
 ## **v5.0.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.6)
 * BRK: `sarif emit-finalize` no longer derives `security-severity` from `result.rank`; it stamps a stable hand-curated per-CWE prior (new `CweSecuritySeverity` table) for both GHAS and GHAzDO. A producer value wins; a CWE with no prior (including `NOVEL-`) stays unstamped.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,6 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
+* BUG: `npx @microsoft/sarif-multitool` works on Windows again — the `@microsoft/sarif-multitool-win32` package now ships `Sarif.Multitool.exe`. The self-contained `win-x64` publish no longer enables `PublishReadyToRun`, whose crossgen2 failure had silently produced an empty Windows package; `BuildMultitoolForNpm.ps1` now fails the build if any platform payload is missing.
 
 ## **v5.0.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.6)
 * BRK: `sarif emit-finalize` no longer derives `security-severity` from `result.rank`; it stamps a stable hand-curated per-CWE prior (new `CweSecuritySeverity` table) for both GHAS and GHAzDO. A producer value wins; a CWE with no prior (including `NOVEL-`) stays unstamped.

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -39,6 +39,9 @@ if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
     foreach ($runtime in "win-x64", "linux-x64", "osx-x64") {
         dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f net8.0 -r $runtime --self-contained
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet publish failed for runtime '$runtime' (exit code $LASTEXITCODE). Aborting before any npm folder is populated."
+        }
     }
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
@@ -47,6 +50,20 @@ if (-not $SkipBuild) {
     Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\net8.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32\
     Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\net8.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux\
     Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\net8.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin\
+
+    # A silently-empty platform folder ships an npm package with no executable.
+    # Verify each one carries its multitool binary before the package is considered built.
+    $expectedBinaries = [ordered]@{
+        "sarif-multitool-win32"  = "Sarif.Multitool.exe"
+        "sarif-multitool-linux"  = "Sarif.Multitool"
+        "sarif-multitool-darwin" = "Sarif.Multitool"
+    }
+    foreach ($folder in $expectedBinaries.Keys) {
+        $binaryPath = Join-Path $npmBuildFolder "$folder\$($expectedBinaries[$folder])"
+        if (-not (Test-Path $binaryPath)) {
+            throw "Expected multitool binary not found: $binaryPath. The npm package would ship without an executable."
+        }
+    }
 }
 
 # Match SARIF SDK version (from 2.2.1 forward).

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -17,8 +17,10 @@
     <!-- Seeing assembly load failures with trimmed exe, but not without. On some machines, for some commands. :/ -->
     <!-- <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed> -->
 
-    <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
-    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>
+    <!-- ReadyToRun is left off: crossgen2 aborts the self-contained win-x64 publish
+         (NETSDK1096) under the SDK the build host runs, which is the only RID that
+         enables it. The startup gain does not justify a publish that fails. -->
+    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">false</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Label="AssemblyAttributes">


### PR DESCRIPTION
Fixes #3003.

## Symptom

`npx @microsoft/sarif-multitool` is non-functional on Windows. The
`@microsoft/sarif-multitool-win32` package contains no `Sarif.Multitool.exe`
at any 5.0.x version — the win32 tarball is ~1.3 KB of template files, while
linux and darwin ship ~107 MB / 39 files each.

## Root cause (reproduced)

`Sarif.Multitool.csproj` enabled `PublishReadyToRun` for the `win-x64` RID
only:

```xml
<PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>
```

That self-contained publish aborts in crossgen2:

```
error NETSDK1096: Optimizing assemblies for performance failed.
You can either exclude the failing assemblies from being optimized,
or set the PublishReadyToRun property to false.
EXITCODE=1
```

`BuildMultitoolForNpm.ps1` never checked `$LASTEXITCODE` after
`dotnet publish`, and `$ErrorActionPreference = "Stop"` does **not** trap a
native non-zero exit. So the loop continued to the linux and osx publishes
(no R2R → success), the win-x64 copy found no payload and contributed
nothing, and the win32 package shipped with only its template files. Because
R2R fails every time, the package has been broken for the entire 5.0.x line.

## Fix

- **Disable `PublishReadyToRun`** for the self-contained publishes. It is a
  startup optimization, and it has been failing — shipping nothing — the
  whole 5.0.x line, so there is no working behavior to lose.
- **Harden `BuildMultitoolForNpm.ps1`:** `throw` on a non-zero
  `dotnet publish` exit *before* any npm folder is populated, and verify each
  platform folder carries its multitool binary (`Sarif.Multitool.exe` /
  `Sarif.Multitool`) after the copy. A silently-empty payload can no longer
  ship.

## Verification (end to end)

Ran the full script (`-NoPostClean`); all three RIDs publish, the
binary-presence gate passes, and `sarif-multitool-win32` now contains a
97 MB `Sarif.Multitool.exe` alongside `index.js` / `bin.js` / `package.json`.

```
BuildMultitoolForNpm SUCCEEDED.
Sarif.Multitool.exe   97370171
```

## Release notes

`BUG:` bullet added under `## UNRELEASED`.

## Note for the release owner

This is a release-pipeline fix. The broken win32 packages already published
to npm are immutable; the corrected payload reaches consumers only when the
next version is published from this branch's state.
