### PR TITLE
Rewrite merge verb to coalesce inputs into one run per tool+version

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,6 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
+* BRK: `sarif merge` now coalesces inputs into one run per tool + version and no longer accepts `--merge-runs` or `--split`; partition the merged log with the `partition` verb to split by rule, run, or target. Artifacts, logical locations, rules, and invocations are remapped into each merged run and value-identical results are deduped.
 * BUG: `@microsoft/sarif-multitool-win32` ships `Sarif.Multitool.exe` again, restoring `npx @microsoft/sarif-multitool` on Windows; the `win-x64` publish drops `PublishReadyToRun` (a crossgen2 failure had emptied the package) and `BuildMultitoolForNpm.ps1` now fails on any missing platform payload.
 
 ## **v5.0.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.6)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
-* BRK: `sarif merge` now coalesces inputs into one run per tool + version and no longer accepts `--merge-runs` or `--split`; partition the merged log with the `partition` verb to split by rule, run, or target. Artifacts, logical locations, rules, and invocations are remapped into each merged run and value-identical results are deduped.
+* BRK: `sarif merge` now coalesces inputs into one run per tool + version and no longer accepts `--merge-runs` or `--split`; use the `partition` verb to split the merged log by rule, run, or target.
 * BUG: `@microsoft/sarif-multitool-win32` ships `Sarif.Multitool.exe` again, restoring `npx @microsoft/sarif-multitool` on Windows; the `win-x64` publish drops `PublishReadyToRun` (a crossgen2 failure had emptied the package) and `BuildMultitoolForNpm.ps1` now fails on any missing platform payload.
 
 ## **v5.0.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.6) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.6)

--- a/src/Sarif.Multitool.Library/MergeCommand.cs
+++ b/src/Sarif.Multitool.Library/MergeCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -25,17 +25,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         private long _filesToProcessCount;
         private Channel<string> _logLoadChannel;
         private Channel<SarifLog> _mergeLogsChannel;
-        private readonly Dictionary<string, Run> _ruleIdToRunsMap;
-        private readonly Dictionary<string, SarifLog> _idToSarifLogMap;
-        private readonly Dictionary<string, HashSet<Result>> _ruleIdToResultsMap;
-        private readonly Dictionary<string, RunMergingVisitor> _ruleIdToMergeVisitorsMap;
+
+        // Coalescing is keyed by tool name + version. Each distinct tool maps to a single
+        // RunMergingVisitor that absorbs every contributing run, deduping results and
+        // remapping descriptor, artifact, logical-location, and invocation indices into one
+        // merged run. _toolKeyOrder preserves first-seen order so the output is deterministic.
+        private readonly List<string> _toolKeyOrder;
+        private readonly Dictionary<string, Run> _toolKeyToMergedRun;
+        private readonly Dictionary<string, RunMergingVisitor> _toolKeyToVisitor;
+        private readonly Dictionary<string, HashSet<Result>> _toolKeyToResults;
 
         public MergeCommand(IFileSystem fileSystem = null) : base(fileSystem)
         {
-            _ruleIdToRunsMap = new Dictionary<string, Run>();
-            _idToSarifLogMap = new Dictionary<string, SarifLog>();
-            _ruleIdToResultsMap = new Dictionary<string, HashSet<Result>>();
-            _ruleIdToMergeVisitorsMap = new Dictionary<string, RunMergingVisitor>();
+            _toolKeyOrder = new List<string>();
+            _toolKeyToMergedRun = new Dictionary<string, Run>();
+            _toolKeyToVisitor = new Dictionary<string, RunMergingVisitor>();
+            _toolKeyToResults = new Dictionary<string, HashSet<Result>>();
         }
 
         public int Run(MergeOptions mergeOptions)
@@ -57,12 +62,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     return FAILURE;
                 }
 
-                if (_options.SplittingStrategy == 0)
+                if (!DriverUtilities.ReportWhetherOutputFileCanBeCreated(outputFilePath, _options.ForceOverwrite, FileSystem))
                 {
-                    if (!DriverUtilities.ReportWhetherOutputFileCanBeCreated(outputFilePath, _options.ForceOverwrite, FileSystem))
-                    {
-                        return FAILURE;
-                    }
+                    return FAILURE;
                 }
 
                 var logLoadOptions = new BoundedChannelOptions(1000)
@@ -102,27 +104,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 // waiting writer
                 writer.Wait();
 
-                foreach (string key in _idToSarifLogMap.Keys)
+                var mergedLog = new SarifLog { Runs = new List<Run>() };
+                foreach (string toolKey in _toolKeyOrder)
                 {
-                    SarifLog mergedLog = _idToSarifLogMap[key]
-                                            .InsertOptionalData(this._options.DataToInsert.ToFlags())
-                                            .RemoveOptionalData(this._options.DataToInsert.ToFlags());
-
-                    // If there were no input files, the Merge operation set combinedLog.Runs to null. Although
-                    // null is valid in certain error cases, it is not valid here. Here, the correct value is
-                    // an empty list. See the SARIF spec, §3.13.4, "runs property".
-                    mergedLog.Runs ??= new List<Run>();
-                    mergedLog.Version = SarifVersion.Current;
-                    mergedLog.SchemaUri = mergedLog.Version.ConvertToSchemaUri();
-
-                    // We must replace invalid file characters in the constructed output file name
-                    // that may appear in any rule ids incorporated into the file name candidate.
-                    FileSystem.DirectoryCreateDirectory(outputDirectory);
-                    outputFilePath = Path.Combine(
-                        outputDirectory,
-                        GetOutputFileName(_options, key).ReplaceInvalidCharInFileName("."));
-                    WriteSarifFile(FileSystem, mergedLog, outputFilePath, _options.Minify);
+                    Run mergedRun = _toolKeyToMergedRun[toolKey];
+                    _toolKeyToVisitor[toolKey].PopulateWithMerged(mergedRun);
+                    mergedLog.Runs.Add(mergedRun);
                 }
+
+                mergedLog = mergedLog
+                                .InsertOptionalData(this._options.DataToInsert.ToFlags())
+                                .RemoveOptionalData(this._options.DataToInsert.ToFlags());
+
+                mergedLog.Version = SarifVersion.Current;
+                mergedLog.SchemaUri = mergedLog.Version.ConvertToSchemaUri();
+
+                FileSystem.DirectoryCreateDirectory(outputDirectory);
+                WriteSarifFile(FileSystem, mergedLog, outputFilePath, _options.Minify);
             }
             catch (Exception ex)
             {
@@ -138,14 +136,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
         private async Task<bool> MergeSarifLogsAsync()
         {
-            if (_options.SplittingStrategy != SplittingStrategy.PerRule)
-            {
-                this._idToSarifLogMap[""] = new SarifLog()
-                {
-                    Runs = new List<Run>()
-                };
-            }
-
             ChannelReader<SarifLog> reader = _mergeLogsChannel.Reader;
 
             // Wait until there is work or the channel is closed.
@@ -154,57 +144,53 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 // Loop while there is work to do.
                 while (reader.TryRead(out SarifLog sarifLog))
                 {
+                    if (sarifLog.Runs == null)
+                    {
+                        continue;
+                    }
+
                     foreach (Run run in sarifLog.Runs)
                     {
-                        if (_options.SplittingStrategy == SplittingStrategy.PerRule || !_options.MergeEmptyLogs)
+                        bool hasResults = run.Results != null && run.Results.Count > 0;
+                        if (!hasResults && !_options.MergeEmptyLogs)
                         {
-                            if (run.Results == null || run.Results.Count == 0)
-                            {
-                                continue;
-                            }
+                            continue;
                         }
 
                         run.SetRunOnResults();
 
-                        if (run.Results != null)
+                        string toolKey = CreateToolKey(run);
+                        if (!_toolKeyToVisitor.TryGetValue(toolKey, out RunMergingVisitor visitor))
                         {
-                            foreach (Result result in run.Results)
+                            visitor = _toolKeyToVisitor[toolKey] = new RunMergingVisitor();
+                            _toolKeyToResults[toolKey] = new HashSet<Result>(Result.ValueComparer);
+                            _toolKeyOrder.Add(toolKey);
+
+                            // The first run of a given tool + version supplies the merged run's
+                            // header (tool metadata, automationDetails, columnKind, etc.). Its
+                            // result, artifact, and rule collections are replaced by the merged
+                            // sets in PopulateWithMerged once every contributing run is absorbed.
+                            _toolKeyToMergedRun[toolKey] = run.DeepClone();
+                        }
+
+                        if (run.Results == null)
+                        {
+                            continue;
+                        }
+
+                        HashSet<Result> seenResults = _toolKeyToResults[toolKey];
+                        foreach (Result result in run.Results)
+                        {
+                            // Drop results that are value-identical to one already merged for this
+                            // tool. A sharded scan can re-report the same finding in more than one
+                            // input log; the merged run should carry each finding exactly once.
+                            if (!seenResults.Add(result))
                             {
-                                string key = _options.SplittingStrategy == SplittingStrategy.PerRule
-                                    ? result.RuleId
-                                    : string.Empty;
-
-                                if (!_idToSarifLogMap.TryGetValue(key, out SarifLog splitLog))
-                                {
-                                    splitLog = _idToSarifLogMap[key] = new SarifLog()
-                                    {
-                                        Runs = new List<Run>()
-                                    };
-                                }
-
-                                string ruleId = _options.MergeRuns ? null : result.RuleId;
-                                key = CreateRuleKey(ruleId, run);
-
-                                if (!_ruleIdToRunsMap.TryGetValue(key, out Run splitRun))
-                                {
-                                    Run emptyRun = run.DeepClone();
-                                    emptyRun.Results.Clear();
-                                    splitRun = _ruleIdToRunsMap[key] = emptyRun;
-                                    splitLog.Runs.Add(splitRun);
-                                    _ruleIdToResultsMap[key] = new HashSet<Result>(Result.ValueComparer);
-                                    _ruleIdToMergeVisitorsMap[key] = new RunMergingVisitor();
-                                }
-
-                                if (!_ruleIdToResultsMap[key].Contains(result))
-                                {
-                                    _ruleIdToResultsMap[key].Add(result);
-
-                                    RunMergingVisitor currentVisitor = _ruleIdToMergeVisitorsMap[key];
-                                    currentVisitor.CurrentRun = result.Run;
-                                    currentVisitor.VisitResult(result.DeepClone());
-                                    currentVisitor.PopulateWithMerged(splitRun);
-                                }
+                                continue;
                             }
+
+                            visitor.CurrentRun = run;
+                            visitor.VisitResult(result.DeepClone());
                         }
                     }
                 }
@@ -212,10 +198,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return true;
         }
 
-        private static string CreateRuleKey(string ruleId, Run run)
+        private static string CreateToolKey(Run run)
         {
             return
-                (ruleId ?? "") +
                 (run.Tool.Driver.Name ?? "") +
                 (run.Tool.Driver.Version ?? "") +
                 (run.Tool.Driver.SemanticVersion ?? "") +
@@ -252,11 +237,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 FileSystem.FileReadAllText(filePath),
                 formatting: Formatting.None,
                 out string sarifText);
-
-            if (_options.MergeRuns)
-            {
-                new FixupVisitor().VisitSarifLog(sarifLog);
-            }
 
             _mergeLogsChannel.Writer.TryWrite(sarifLog);
             Interlocked.Decrement(ref _filesToProcessCount);
@@ -295,61 +275,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return true;
         }
 
-        internal static string GetOutputFileName(MergeOptions mergeOptions, string prefix = "")
+        internal static string GetOutputFileName(MergeOptions mergeOptions)
         {
-            return string.IsNullOrEmpty(mergeOptions.OutputFileName) == false
-                ? GetPrefix(prefix) + mergeOptions.OutputFileName
-                : GetPrefix("merged.sarif");
-        }
-
-        private static string GetPrefix(string prefix)
-        {
-            if (!string.IsNullOrWhiteSpace(prefix) && !prefix.EndsWith("_"))
-            {
-                prefix += "_";
-            }
-
-            return prefix ?? string.Empty;
-        }
-    }
-
-    internal class FixupVisitor : SarifRewritingVisitor
-    {
-        private Run _run;
-
-        public override Run VisitRun(Run node)
-        {
-            _run = node;
-            _run = base.VisitRun(node);
-
-            // Invocations are intentionally preserved: RunMergingVisitor aggregates
-            // them into the merged run and rebases each result's invocationIndex.
-            _run.Artifacts = null;
-            _run.Tool.Driver = new ToolComponent
-            {
-                Name = _run.Tool.Driver.Name,
-                Version = _run.Tool.Driver.Version,
-                SemanticVersion = _run.Tool.Driver.SemanticVersion,
-                DottedQuadFileVersion = _run.Tool.Driver.DottedQuadFileVersion
-            };
-
-            return _run;
-        }
-
-        public override Result VisitResult(Result node)
-        {
-            node.RuleIndex = -1;
-            return base.VisitResult(node);
-        }
-
-        public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
-        {
-            if (_run.Artifacts != null && node.Index > -1)
-            {
-                node = _run.Artifacts[node.Index].Location;
-            }
-            node.Index = -1;
-            return base.VisitArtifactLocation(node);
+            return string.IsNullOrEmpty(mergeOptions.OutputFileName)
+                ? "merged.sarif"
+                : mergeOptions.OutputFileName;
         }
     }
 }

--- a/src/Sarif.Multitool.Library/MergeOptions.cs
+++ b/src/Sarif.Multitool.Library/MergeOptions.cs
@@ -20,20 +20,5 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             "merge-empty-logs",
             HelpText = "Merge log files with no results into the final log.")]
         public bool MergeEmptyLogs { get; set; }
-
-        [Option(
-            "split",
-            HelpText = "Apply a splitting strategy to the merged file. " +
-                       "Must be one of None or PerRule. By default ('None'), " +
-                       "no splitting strategy is applied (i.e. all input " +
-                       "files will be merged into a single log).",
-            Default = SplittingStrategy.None)]
-        public SplittingStrategy SplittingStrategy { get; set; }
-
-        [Option(
-            "merge-runs",
-            HelpText = "Merge runs of the same tool + version combination (requires " +
-                       "eliding run-specific details such as invocations data.")]
-        public bool MergeRuns { get; set; }
     }
 }

--- a/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandUnitTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandUnitTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using FluentAssertions;
@@ -44,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 OutputDirectoryPath = testDirectory,
                 OutputFileName = "merged.sarif",
                 TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = true,
                 OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.Inline, FilePersistenceOptions.PrettyPrint },
             };
 
@@ -67,7 +67,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 OutputDirectoryPath = testDirectory,
                 OutputFileName = "merged.sarif",
                 TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = true,
             };
 
             var mergeCommand = new MergeCommand(fileSystem);
@@ -76,77 +75,54 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void MergeCommand_WhenMergeRunsOn_RunShouldAggregateByToolVersion_SingleToolVersion()
+        public void MergeCommand_CoalescesSameToolIntoSingleRun()
         {
-            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(3) } };
+            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(5, ruleIdPrefix: "ALPHA") } };
+            var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(6, ruleIdPrefix: "BETA") } };
+
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
+
+            // Every contributing run shares one tool + version, so the merge coalesces them
+            // into a single run that carries all (distinct) results.
+            mergedLog.Runs.Count.Should().Be(1);
+            mergedLog.Runs[0].Tool.Driver.Name.Should().Be("TestTool");
+            mergedLog.Runs[0].Results.Count.Should().Be(11);
+        }
+
+        [Fact]
+        public void MergeCommand_DedupsValueIdenticalResultsAcrossInputs()
+        {
+            // The same finding can be re-reported in more than one shard of a sharded scan.
+            // Coalescing collapses value-identical results so the merged run carries each once.
+            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(5) } };
             var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(6) } };
-            string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
-            string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
-            string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
-            string sarifLog2FilePath = Path.Combine(testDirectory, "SarifLog2.sarif");
-            string outputFilePath = Path.Combine(testDirectory, "merged.sarif");
-            var outputStringBuilder = new StringBuilder();
 
-            var mockFileSystem = new Mock<IFileSystem>();
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog1Json, sarifLog1FilePath);
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog2Json, sarifLog2FilePath);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath, outputStringBuilder);
-            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, new[] { sarifLog1FilePath, sarifLog2FilePath });
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
 
-            IFileSystem fileSystem = mockFileSystem.Object;
+            mergedLog.Runs.Count.Should().Be(1);
+            mergedLog.Runs[0].Results.Count.Should().Be(6);
+        }
 
-            var options = new MergeOptions
-            {
-                OutputDirectoryPath = testDirectory,
-                OutputFileName = "merged.sarif",
-                TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = true,
-                OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.PrettyPrint },
-            };
+        [Fact]
+        public void MergeCommand_CoalescesByToolVersion_SingleToolVersion()
+        {
+            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(3, ruleIdPrefix: "ALPHA") } };
+            var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(6, ruleIdPrefix: "BETA") } };
 
-            var mergeCommand = new MergeCommand(fileSystem);
-            int returnCode = mergeCommand.Run(options);
-            returnCode.Should().Be(0);
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
 
-            SarifLog mergedLog = JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder.ToString());
             mergedLog.Runs.Count.Should().Be(1);
             mergedLog.Runs[0].Results.Count.Should().Be(9);
         }
 
         [Fact]
-        public void MergeCommand_WhenMergeRunsOn_RunShouldAggregateByToolVersion_ThreeToolVersions()
+        public void MergeCommand_CoalescesByToolVersion_ThreeToolVersions()
         {
             var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(7, false, "Tool1"), CreateTestRun(4, false, "Tool2") } };
             var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(2, false, "Tool3") } };
-            string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
-            string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
-            string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
-            string sarifLog2FilePath = Path.Combine(testDirectory, "SarifLog2.sarif");
-            string outputFilePath = Path.Combine(testDirectory, "merged.sarif");
-            var outputStringBuilder = new StringBuilder();
 
-            var mockFileSystem = new Mock<IFileSystem>();
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog1Json, sarifLog1FilePath);
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog2Json, sarifLog2FilePath);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath, outputStringBuilder);
-            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, new[] { sarifLog1FilePath, sarifLog2FilePath });
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
 
-            IFileSystem fileSystem = mockFileSystem.Object;
-
-            var options = new MergeOptions
-            {
-                OutputDirectoryPath = testDirectory,
-                OutputFileName = "merged.sarif",
-                TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = true,
-                OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.PrettyPrint },
-            };
-
-            var mergeCommand = new MergeCommand(fileSystem);
-            int returnCode = mergeCommand.Run(options);
-            returnCode.Should().Be(0);
-
-            SarifLog mergedLog = JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder.ToString());
             mergedLog.Runs.Count.Should().Be(3);
             foreach (Run run in mergedLog.Runs)
             {
@@ -166,39 +142,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void MergeCommand_WhenMergeRunsOn_AggregatesInvocationsAndRebasesInvocationIndex()
+        public void MergeCommand_AggregatesInvocationsAndRebasesInvocationIndex()
         {
             var sarifLog1 = new SarifLog { Runs = new[] { CreateRunReferencingInvocations("cmd-1a", "cmd-1b") } };
             var sarifLog2 = new SarifLog { Runs = new[] { CreateRunReferencingInvocations("cmd-2a") } };
-            string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
-            string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
-            string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
-            string sarifLog2FilePath = Path.Combine(testDirectory, "SarifLog2.sarif");
-            string outputFilePath = Path.Combine(testDirectory, "merged.sarif");
-            var outputStringBuilder = new StringBuilder();
 
-            var mockFileSystem = new Mock<IFileSystem>();
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog1Json, sarifLog1FilePath);
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog2Json, sarifLog2FilePath);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath, outputStringBuilder);
-            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, new[] { sarifLog1FilePath, sarifLog2FilePath });
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
 
-            IFileSystem fileSystem = mockFileSystem.Object;
-
-            var options = new MergeOptions
-            {
-                OutputDirectoryPath = testDirectory,
-                OutputFileName = "merged.sarif",
-                TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = true,
-                OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.PrettyPrint },
-            };
-
-            var mergeCommand = new MergeCommand(fileSystem);
-            int returnCode = mergeCommand.Run(options);
-            returnCode.Should().Be(0);
-
-            SarifLog mergedLog = JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder.ToString());
             mergedLog.Runs.Count.Should().Be(1);
 
             Run merged = mergedLog.Runs[0];
@@ -220,10 +170,44 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
-        public void MergeCommand_WhenMergeRunsOff_RunShouldAggregateByRuleToolVersion_SingleToolVersion()
+        public void MergeCommand_PreservesDescriptorEnrichmentAndBaseRuleId()
         {
-            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(5) } };
-            var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(6) } };
+            // Two runs of the same tool+version, each carrying base CWE descriptors enriched
+            // with a security-severity property and help text, and results whose ruleId uses
+            // the hierarchical sub-id form ("CWE-79/<sub>"). The merge must collapse them into
+            // one run while preserving the descriptor enrichment and the base reportingDescriptor
+            // id, and keeping each result's full sub-id ruleId.
+            var sarifLog1 = new SarifLog { Runs = new[] { CreateEnrichedSubIdRun(tag: "log1") } };
+            var sarifLog2 = new SarifLog { Runs = new[] { CreateEnrichedSubIdRun(tag: "log2") } };
+
+            SarifLog mergedLog = RunMerge(sarifLog1, sarifLog2);
+
+            mergedLog.Runs.Count.Should().Be(1);
+            Run merged = mergedLog.Runs[0];
+
+            // Descriptors are deduped to their base id; the hierarchical sub-id never leaks into a
+            // reportingDescriptor.id.
+            List<string> ruleIds = merged.Tool.Driver.Rules.Select(r => r.Id).ToList();
+            ruleIds.Should().Contain("CWE-79");
+            ruleIds.Should().Contain("CWE-89");
+            ruleIds.Should().NotContain(id => id.Contains("/"));
+
+            // Descriptor enrichment (security-severity property + help) survives the merge.
+            ReportingDescriptor xss = merged.Tool.Driver.Rules.Single(r => r.Id == "CWE-79");
+            xss.GetProperty<string>("security-severity").Should().Be("7.8");
+            xss.Help.Text.Should().Be("XSS help");
+
+            // Every result keeps its full sub-id ruleId and resolves to the base descriptor.
+            merged.Results.Count.Should().Be(6);
+            foreach (Result result in merged.Results)
+            {
+                result.RuleId.Should().Contain("/");
+                result.GetRule(merged).Id.Should().Be(result.RuleId.Split('/')[0]);
+            }
+        }
+
+        private SarifLog RunMerge(SarifLog sarifLog1, SarifLog sarifLog2)
+        {
             string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
             string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
             string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
@@ -244,7 +228,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 OutputDirectoryPath = testDirectory,
                 OutputFileName = "merged.sarif",
                 TargetFileSpecifiers = new[] { "*.sarif" },
-                MergeRuns = false,
                 OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.PrettyPrint },
             };
 
@@ -252,81 +235,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             int returnCode = mergeCommand.Run(options);
             returnCode.Should().Be(0);
 
-            // merged log should have 6 runs grouped by rule id
-            SarifLog mergedLog = JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder.ToString());
-            mergedLog.Runs.Count.Should().Be(6);
-            for (int i = 1; i <= 6; i++)
-            {
-                mergedLog.Runs[i - 1].Tool.Driver.Name.Should().Be("TestTool");
-                mergedLog.Runs[i - 1].Results[0].RuleId.Should().Be($"TESTRULE00{i}");
-            }
-        }
-
-        [Fact]
-        public void MergeCommand_WhenSplitPerRule_LogShouldAggregateByRuleToolVersion()
-        {
-            var sarifLog1 = new SarifLog { Runs = new[] { CreateTestRun(6, true) } };
-            var sarifLog2 = new SarifLog { Runs = new[] { CreateTestRun(4, true) } };
-            string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
-            string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
-            string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
-            string sarifLog2FilePath = Path.Combine(testDirectory, "SarifLog2.sarif");
-
-            string outputFilePath1 = Path.Combine(testDirectory, "TESTRULE.001_merged.sarif");
-            var outputStringBuilder1 = new StringBuilder();
-            string outputFilePath2 = Path.Combine(testDirectory, "TESTRULE.002_merged.sarif");
-            var outputStringBuilder2 = new StringBuilder();
-            string outputFilePath3 = Path.Combine(testDirectory, "TESTRULE.003_merged.sarif");
-            var outputStringBuilder3 = new StringBuilder();
-            string outputFilePath4 = Path.Combine(testDirectory, "TESTRULE.004_merged.sarif");
-            var outputStringBuilder4 = new StringBuilder();
-            string outputFilePath5 = Path.Combine(testDirectory, "TESTRULE.005_merged.sarif");
-            var outputStringBuilder5 = new StringBuilder();
-            string outputFilePath6 = Path.Combine(testDirectory, "TESTRULE.006_merged.sarif");
-            var outputStringBuilder6 = new StringBuilder();
-
-            var mockFileSystem = new Mock<IFileSystem>();
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog1Json, sarifLog1FilePath);
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog2Json, sarifLog2FilePath);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath1, outputStringBuilder1);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath2, outputStringBuilder2);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath3, outputStringBuilder3);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath4, outputStringBuilder4);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath5, outputStringBuilder5);
-            ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath6, outputStringBuilder6);
-            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, new[] { sarifLog1FilePath, sarifLog2FilePath });
-
-            IFileSystem fileSystem = mockFileSystem.Object;
-
-            var options = new MergeOptions
-            {
-                OutputDirectoryPath = testDirectory,
-                OutputFileName = "merged.sarif",
-                TargetFileSpecifiers = new[] { "*.sarif" },
-                SplittingStrategy = SplittingStrategy.PerRule,
-                OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite, FilePersistenceOptions.PrettyPrint },
-            };
-
-            var mergeCommand = new MergeCommand(fileSystem);
-            int returnCode = mergeCommand.Run(options);
-            returnCode.Should().Be(0);
-
-            // should have 6 merged logs each log has result of 1 rule
-            var mergedLogs = new List<SarifLog>
-            {
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder1.ToString()),
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder2.ToString()),
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder3.ToString()),
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder4.ToString()),
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder5.ToString()),
-                JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder6.ToString()),
-            };
-
-            for (int i = 1; i <= 6; i++)
-            {
-                mergedLogs[i - 1].Runs[0].Tool.Driver.Name.Should().Be("TestTool");
-                mergedLogs[i - 1].Runs[0].Results[0].RuleId.Should().Be($"TESTRULE/00{i}");
-            }
+            return JsonConvert.DeserializeObject<SarifLog>(outputStringBuilder.ToString());
         }
 
         private static Run CreateRunReferencingInvocations(params string[] commandLines)
@@ -353,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             };
         }
 
-        private Run CreateTestRun(int numberOfResult, bool createSubRule = false, string toolName = null, string version = null, string semanticVersion = null)
+        private Run CreateTestRun(int numberOfResult, bool createSubRule = false, string toolName = null, string version = null, string semanticVersion = null, string ruleIdPrefix = "TESTRULE")
         {
             Run run = RandomSarifLogGenerator.GenerateRandomRun(this.random, 0);
             run.Tool.Driver.Name = toolName ?? "TestTool";
@@ -365,12 +274,36 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
             for (int i = 1; i <= numberOfResult; i++)
             {
-                string ruleId = createSubRule ? $"TESTRULE/00{i}" : $"TESTRULE00{i}";
+                string ruleId = createSubRule ? $"{ruleIdPrefix}/00{i}" : $"{ruleIdPrefix}00{i}";
                 run.Results.AddRange(
                     RandomSarifLogGenerator.GenerateFakeResults(this.random, new List<string> { ruleId }, new List<Uri> { artifactUri }, 1));
             }
 
             return run;
+        }
+
+        private static Run CreateEnrichedSubIdRun(string toolName = "TestTool", string version = "15.0.0.0", string tag = "")
+        {
+            var rules = new List<ReportingDescriptor>
+            {
+                new ReportingDescriptor { Id = "CWE-79", Name = "CrossSiteScripting", Help = new MultiformatMessageString { Text = "XSS help" } },
+                new ReportingDescriptor { Id = "CWE-89", Name = "SqlInjection", Help = new MultiformatMessageString { Text = "SQLi help" } },
+            };
+            rules[0].SetProperty("security-severity", "7.8");
+            rules[1].SetProperty("security-severity", "8.8");
+
+            var results = new List<Result>
+            {
+                new Result { RuleId = "CWE-79/unescaped-view-input", RuleIndex = 0, Message = new Message { Text = $"a-{tag}" } },
+                new Result { RuleId = "CWE-89/string-concat-query", RuleIndex = 1, Message = new Message { Text = $"b-{tag}" } },
+                new Result { RuleId = "CWE-79/dom-xss-via-sanitizer-bypass", RuleIndex = 0, Message = new Message { Text = $"c-{tag}" } },
+            };
+
+            return new Run
+            {
+                Tool = new Tool { Driver = new ToolComponent { Name = toolName, Version = version, SemanticVersion = version, Rules = rules } },
+                Results = results,
+            };
         }
 
         private static void ArrangeMockFileSystemRead(Mock<IFileSystem> mockFileSystem, string sarifLogJson, string sariflogFilePath)

--- a/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandUnitTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/MergeCommandUnitTests.cs
@@ -206,20 +206,48 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
         }
 
-        private SarifLog RunMerge(SarifLog sarifLog1, SarifLog sarifLog2)
+        [Fact]
+        public void MergeCommand_CoalescesMultipleSameToolRunsWithinASingleInputFile()
         {
-            string sarifLog1Json = JsonConvert.SerializeObject(sarifLog1);
-            string sarifLog2Json = JsonConvert.SerializeObject(sarifLog2);
-            string sarifLog1FilePath = Path.Combine(testDirectory, "SarifLog1.sarif");
-            string sarifLog2FilePath = Path.Combine(testDirectory, "SarifLog2.sarif");
+            // The customer hands us one SARIF file that already contains several runs, each
+            // produced by an identical tool + version (e.g. a sharded scan serialized as one
+            // file with one run per shard). Merge must coalesce those runs into a single run
+            // carrying every distinct result; source-file boundaries are irrelevant to keying.
+            var singleInput = new SarifLog
+            {
+                Runs = new[]
+                {
+                    CreateTestRun(4, ruleIdPrefix: "ALPHA"),
+                    CreateTestRun(5, ruleIdPrefix: "BETA"),
+                    CreateTestRun(6, ruleIdPrefix: "GAMMA"),
+                }
+            };
+
+            SarifLog mergedLog = RunMerge(singleInput);
+
+            mergedLog.Runs.Count.Should().Be(1);
+            mergedLog.Runs[0].Tool.Driver.Name.Should().Be("TestTool");
+            mergedLog.Runs[0].Results.Count.Should().Be(15);
+        }
+
+        private SarifLog RunMerge(params SarifLog[] inputLogs)
+        {
+            var mockFileSystem = new Mock<IFileSystem>();
+            var inputFilePaths = new List<string>();
+
+            for (int i = 0; i < inputLogs.Length; i++)
+            {
+                string inputJson = JsonConvert.SerializeObject(inputLogs[i]);
+                string inputFilePath = Path.Combine(testDirectory, $"SarifLog{i + 1}.sarif");
+                inputFilePaths.Add(inputFilePath);
+                ArrangeMockFileSystemRead(mockFileSystem, inputJson, inputFilePath);
+            }
+
             string outputFilePath = Path.Combine(testDirectory, "merged.sarif");
             var outputStringBuilder = new StringBuilder();
 
-            var mockFileSystem = new Mock<IFileSystem>();
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog1Json, sarifLog1FilePath);
-            ArrangeMockFileSystemRead(mockFileSystem, sarifLog2Json, sarifLog2FilePath);
             ArrangeMockFileSystemCreate(mockFileSystem, outputFilePath, outputStringBuilder);
-            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, new[] { sarifLog1FilePath, sarifLog2FilePath });
+            ArrangeMockFileSystemEnumerate(mockFileSystem, testDirectory, inputFilePaths);
 
             IFileSystem fileSystem = mockFileSystem.Object;
 

--- a/src/Test.UnitTests.Sarif.Multitool.Library/TestData/MergeCommand/ExpectedOutputs/FileNameOnlyWithoutPath.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/TestData/MergeCommand/ExpectedOutputs/FileNameOnlyWithoutPath.sarif
@@ -28,7 +28,29 @@
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2021-22945",
               "properties": {
-                "tags": [ "vulnerability", "CRITICAL", "libcurl" ],
+                "tags": ["vulnerability","CRITICAL","libcurl"],
+                "precision": "very-high"
+              }
+            },
+            {
+              "id": "docker.io/fluxcd/flux:1.24.1 (alpine 3.14.2): libcurl-7.78.0-r0 CVE-2021-22946",
+              "name": "OS Package Vulnerability (Alpine)",
+              "fullDescription": {
+                "text": "curl: Requirement to use TLS not properly enforced for IMAP, POP3, and FTP protocols."
+              },
+              "help": {
+                "text": "Vulnerability CVE-2021-22946\nSeverity: HIGH\nPackage: libcurl\nInstalled Version: 7.78.0-r0\nFixed Version: 7.79.0-r0\nLink: [CVE-2021-22946](https://avd.aquasec.com/nvd/cve-2021-22946)",
+                "markdown": "**Vulnerability CVE-2021-22946**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|HIGH|libcurl|7.78.0-r0|7.79.0-r0|[CVE-2021-22946](https://avd.aquasec.com/nvd/cve-2021-22946)|\n"
+              },
+              "shortDescription": {
+                "text": "CVE-2021-22946 Package: libcurl"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2021-22946",
+              "properties": {
+                "tags": ["vulnerability","HIGH","libcurl"],
                 "precision": "very-high"
               }
             }
@@ -58,52 +80,10 @@
               }
             }
           ]
-        }
-      ],
-      "columnKind": "utf16CodeUnits"
-    },
-    {
-      "tool": {
-        "driver": {
-          "name": "Trivy",
-          "fullName": "Trivy Vulnerability Scanner",
-          "version": "0.15.0",
-          "informationUri": "https://github.com/aquasecurity/trivy",
-          "rules": [
-            {
-              "id": "docker.io/fluxcd/flux:1.24.1 (alpine 3.14.2): libcurl-7.78.0-r0 CVE-2021-22946",
-              "name": "OS Package Vulnerability (Alpine)",
-              "fullDescription": {
-                "text": "curl: Requirement to use TLS not properly enforced for IMAP, POP3, and FTP protocols."
-              },
-              "help": {
-                "text": "Vulnerability CVE-2021-22946\nSeverity: HIGH\nPackage: libcurl\nInstalled Version: 7.78.0-r0\nFixed Version: 7.79.0-r0\nLink: [CVE-2021-22946](https://avd.aquasec.com/nvd/cve-2021-22946)",
-                "markdown": "**Vulnerability CVE-2021-22946**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|HIGH|libcurl|7.78.0-r0|7.79.0-r0|[CVE-2021-22946](https://avd.aquasec.com/nvd/cve-2021-22946)|\n"
-              },
-              "shortDescription": {
-                "text": "CVE-2021-22946 Package: libcurl"
-              },
-              "defaultConfiguration": {
-                "level": "error"
-              },
-              "helpUri": "https://avd.aquasec.com/nvd/cve-2021-22946",
-              "properties": {
-                "tags": [ "vulnerability", "HIGH", "libcurl" ],
-                "precision": "very-high"
-              }
-            }
-          ]
-        }
-      },
-      "originalUriBaseIds": {
-        "ROOTPATH": {
-          "uri": "file:///"
-        }
-      },
-      "results": [
+        },
         {
           "ruleId": "docker.io/fluxcd/flux:1.24.1 (alpine 3.14.2): libcurl-7.78.0-r0 CVE-2021-22946",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "level": "error",
           "message": {
             "text": "A user can tell curl &gt;= 7.20.0 and &lt;= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network."


### PR DESCRIPTION
## The mess

`merge` had drifted from "coalesce sharded logs" into a tangle of three jobs at once:

- a **per-rule run-sharding default** — a single tool run was shattered into one run *per rule* unless you opted out;
- a `--merge-runs` opt-out whose collapse path **dropped descriptor enrichment and corrupted descriptor ids**;
- a `--split` strategy that duplicated splitting logic the `partition` verb already owns.

The result was four parallel dictionaries keyed by `tool+version+ruleId`, a lossy `FixupVisitor` that nulled artifacts, and a default behavior almost nobody wants.

## The change

Collapse `merge` to its one real job: **given N input logs that shard one or more tool runs, coalesce them into one run per unique tool + version.** Splitting is no longer a merge concern — the workflow is now **`merge` → `partition`**.

- **Removed `--merge-runs` and `--split`** from `MergeOptions`. One `tool+version` bucket map with first-seen ordering yields deterministic output.
- **Reuse `RunMergingVisitor` as-is.** It already deep-clones and remaps artifacts, logical locations, and rules (deduped by resolved base id, with the sub-id `ruleId` preserved on the result), and aggregates invocations with rebased `provenance.invocationIndex`. This makes merge **strictly more correct** than the old `--merge-runs` path, which discarded artifacts and enrichment.
- **Deleted `FixupVisitor`** — its artifact-nulling was lossy and redundant with the visitor's correct remapping.
- **Result dedup retained** — value-identical results across shards collapse via `Result.ValueComparer`.

## Splitting still fully supported

Everything `--split` did lives in the `partition` verb (per rule, per run, per target, …). No capability is lost; it just moves to the verb that owns it.

## Tests

- Rewrote `MergeCommandUnitTests` around coalesce-by-default: single-tool coalescing, three-tool-version separation, invocation aggregation + index rebasing, descriptor-enrichment / base-rule-id preservation, and cross-shard result dedup.
- Pinned the **single-file multi-run** customer scenario: one input log carrying several runs of an identical tool + version coalesces to one run (keying is blind to source-file boundaries).
- Regenerated the `FileNameOnlyWithoutPath` functional baseline: a single Trivy run with two distinct findings now coalesces to **one** run (was split into two).
- Full `Sarif.Multitool` + both multitool test projects build clean in Release; merge suite green.

## Flag for review

Hard removal (not deprecation) of `--merge-runs` and `--split` is the intended call here — they encoded behavior that was either wrong (`--merge-runs` enrichment loss) or duplicative (`--split` vs `partition`). Shout if you'd rather soft-land either with an `[Obsolete]`/warning hop.
