### PR TITLE
Exclude SARIF2006 reachability notes from CWE sample generation gate

### DIFF
--- a/src/Sarif/Taxonomies/CweGenerateSample.ps1
+++ b/src/Sarif/Taxonomies/CweGenerateSample.ps1
@@ -693,7 +693,11 @@ $json = $doc | ConvertTo-Json -Depth 64
 # ---------------------------------------------------------------------------
 # Validate. The fixture MUST pass with 0 errors, 0 warnings, and 0 notes under
 # its variant's rule-kinds (Sarif;AI;Ghas for the GHAS fixture, Sarif;AI;GHAzDO
-# for the GHAzDO fixture). The run carries ai/origin = "generated" so the
+# for the GHAzDO fixture), with one deliberate exception: SARIF2006
+# (UrisShouldBeReachable) issues live HTTP GET requests against the fixture's
+# real URIs, so its findings reflect transient network state on the build host
+# rather than a fixture defect and are treated as informational (see the
+# fatal-set logic below). The run carries ai/origin = "generated" so the
 # AI-aware style rules (SARIF2002, SARIF2009, SARIF2014, SARIF2015) self-
 # suppress; the fixture is also constructed to satisfy the remaining
 # correctness-class rules (snippets, hashes, provenance, descriptor text, etc.).
@@ -731,6 +735,12 @@ $errors   = @($reportResults | Where-Object { (Get-ResultLevel $_) -eq 'error' }
 $warnings = @($reportResults | Where-Object { (Get-ResultLevel $_) -eq 'warning' })
 $notes    = @($reportResults | Where-Object { (Get-ResultLevel $_) -eq 'note' })
 
+# SARIF2006 (UrisShouldBeReachable) probes the fixture's real URIs over the
+# network, so a note from it reflects transient host connectivity rather than a
+# fixture defect. Exclude it from the fatal set; every other note still fails.
+$reachabilityNotes = @($notes | Where-Object { $_.ruleId -eq 'SARIF2006' })
+$fatalNotes        = @($notes | Where-Object { $_.ruleId -ne 'SARIF2006' })
+
 Write-Host ""
 Write-Host "Validator summary: $($errors.Count) error(s), $($warnings.Count) warning(s), $($notes.Count) note(s)"
 if ($notes.Count -gt 0) {
@@ -739,11 +749,14 @@ if ($notes.Count -gt 0) {
         Write-Host ("  note: {0,-12} x{1}" -f $g.Name, $g.Count)
     }
 }
+if ($reachabilityNotes.Count -gt 0) {
+    Write-Host "  (SARIF2006 reachability notes are informational and do not fail generation.)"
+}
 
-if ($errors.Count -gt 0 -or $warnings.Count -gt 0 -or $notes.Count -gt 0) {
-    if ($errors.Count -gt 0)   { Write-Warning ("Error rules: "   + (($errors   | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
-    if ($warnings.Count -gt 0) { Write-Warning ("Warning rules: " + (($warnings | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
-    if ($notes.Count -gt 0)    { Write-Warning ("Note rules: "    + (($notes    | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
+if ($errors.Count -gt 0 -or $warnings.Count -gt 0 -or $fatalNotes.Count -gt 0) {
+    if ($errors.Count -gt 0)     { Write-Warning ("Error rules: "   + (($errors     | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
+    if ($warnings.Count -gt 0)   { Write-Warning ("Warning rules: " + (($warnings   | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
+    if ($fatalNotes.Count -gt 0) { Write-Warning ("Note rules: "    + (($fatalNotes | Group-Object ruleId | ForEach-Object { $_.Name }) -join ', ')) }
     Write-Warning "See '$validateReport' for details."
     exit 1
 }


### PR DESCRIPTION
## What

`CweGenerateSample.ps1` fails sample generation if the post-finalize
validation reports **any** error, warning, or note — a gate that keeps the
shipped `CweGhasSample.sarif` / `CweGHAzDoSample.sarif` fixtures pristine.

That gate is meant to be hermetic, but **SARIF2006 (`UrisShouldBeReachable`)
is not**: it issues live HTTP GET requests against the fixture's real URIs —
the CWE `helpUri` values (`cwe.mitre.org/...`) and the reconstructed
`versionControlProvenance.repositoryUri`. A SARIF2006 note therefore reflects
**transient connectivity on the build host** (timeout, rate limit, momentary
5xx), not a defect in the generated SARIF.

## Why

This showed up as an intermittent **Windows-only** failure of
`CweGenerateSample_DefaultMode_ReconstructsLiveProvenanceFromGit`:

```
Validator summary: 0 error(s), 0 warning(s), 1 note(s)
  note: SARIF2006    x1
```

→ the script's "0 notes" gate hit `exit 1`. The identical script run locally,
and on the Ubuntu/macOS legs, reported **0 notes** and exited 0. Nothing in
the fixture changed — a single live GET transiently failed on one runner.

## Fix

Partition the validator's notes into SARIF2006 reachability notes vs.
everything else:

- Reachability notes are **still printed** in the summary (with an explicit
  "informational; do not fail generation" line).
- They are **excluded from the fatal set**.
- Every **other** note, plus all warnings and errors, still fails generation
  exactly as before — the fixture-pristineness intent is preserved for every
  deterministic rule.

The header comment documents the deliberate carve-out.

## Verification

- Parse-checked the PS1; ran it default-mode end-to-end → `0 errors, 0
  warnings, 0 notes`, exit 0 (no regression on the happy path).
- Unit-tested the new gate predicate against synthetic reports:
  SARIF2006-only → pass; any other note → fail; 2006 + other note → fail;
  warning → fail; clean → pass. All five as expected.

No consumer-facing surface changes, so no `ReleaseHistory.md` entry (internal
sample-generation infra).
