### PR TITLE
Fix single-file validate/analyze crash resolving configuration file path

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.0.9** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.9) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.9) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.9) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.9) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.9)
+* BUG: `sarif validate` and `sarif analyze` no longer crash with `ArgumentNullException` on the single-file build; `DefaultConfigurationPath` and the `--config <name>` fallback derive the assembly directory from `AppContext.BaseDirectory` when `Assembly.Location` is empty.
+
 ## **v5.0.8** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.8) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.8) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.8) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.8) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.8)
 * BUG: `sarif validate` and `emit-finalize --validate` no longer crash on the single-file win32 build, where `Assembly.Location` is empty; `Tool.CreateFromAssemblyData` now sources `tool.driver` identity from the assembly's version attributes instead of the on-disk version resource.
 * NEW: `sarif emit-finalize` stamps GitHub Advanced Security tags on each AI security rule for GitHub-hosted runs: a CWE rule gets `["security", "external/cwe/cwe-<n>"]`, a `NOVEL-` rule gets `["security"]`. GHAS ignores `security-severity` without the `security` tag; Azure DevOps is unaffected.

--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -59,9 +59,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             get
             {
-                string currentDirectory = Path.GetDirectoryName(GetType().Assembly.Location);
+                string currentDirectory = ResolveAssemblyDirectory(GetType().Assembly.Location);
                 return Path.Combine(currentDirectory, "default.configuration.xml");
             }
+        }
+
+        internal static string ResolveAssemblyDirectory(string assemblyLocation)
+        {
+            // In a single-file published application Assembly.Location is empty, and
+            // Path.GetDirectoryName("") returns null, which crashes a subsequent
+            // Path.Combine. Fall back to the application base directory so that
+            // configuration-file probing remains functional in that layout.
+            string directory = string.IsNullOrEmpty(assemblyLocation)
+                ? null
+                : Path.GetDirectoryName(assemblyLocation);
+
+            return string.IsNullOrEmpty(directory) ? AppContext.BaseDirectory : directory;
         }
 
         public override int Run(TOptions options)
@@ -944,7 +957,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (!File.Exists(configurationFilePath))
             {
                 string fileName = Path.GetFileNameWithoutExtension(configurationFilePath);
-                string spamDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string spamDirectory = ResolveAssemblyDirectory(Assembly.GetExecutingAssembly().Location);
                 fileName = Path.Combine(spamDirectory, $"{fileName}.xml");
 
                 if (fileSystem.FileExists(fileName))

--- a/src/Test.UnitTests.Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBaseTests.cs
+++ b/src/Test.UnitTests.Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBaseTests.cs
@@ -41,6 +41,28 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         }
 
         [Fact]
+        public void ResolveAssemblyDirectory_EmptyLocationFallsBackToAppBaseDirectory()
+            => VerifyResolveAssemblyDirectory(string.Empty, AppContext.BaseDirectory);
+
+        [Fact]
+        public void ResolveAssemblyDirectory_NullLocationFallsBackToAppBaseDirectory()
+            => VerifyResolveAssemblyDirectory(null, AppContext.BaseDirectory);
+
+        [Fact]
+        public void ResolveAssemblyDirectory_PopulatedLocationReturnsContainingDirectory()
+        {
+            string directory = Path.Combine(Path.GetTempPath(), "sarif-resolve-assembly-directory");
+            string location = Path.Combine(directory, "Some.Assembly.dll");
+            VerifyResolveAssemblyDirectory(location, directory);
+        }
+
+        private static void VerifyResolveAssemblyDirectory(string location, string expected)
+        {
+            string actual = TestMultithreadedAnalyzeCommand.ResolveAssemblyDirectory(location);
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
         public void MultithreadedAnalyzeCommandBase_InvalidZipArchive()
         {
             var logger = new TestMessageLogger();

--- a/src/build.props
+++ b/src/build.props
@@ -13,7 +13,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.0.8</VersionPrefix>
+    <VersionPrefix>5.0.9</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## Symptom

On the single-file (npm) Multitool build, `sarif validate <file>` and `sarif analyze` crash before doing any work:

```
ArgumentNullException (Parameter 'path1')
  at MultithreadedAnalyzeCommandBase.get_DefaultConfigurationPath()
  → Path.Combine(null, ...)
```

`--config none` does not bypass it — it crashes at the `--config` fallback instead. The emit verbs (`emit-*`, `export`) are unaffected, which is why server-side ingestion and `export --sarif` work.

## Root cause

In a single-file published app `Assembly.Location` is an **empty string**, so `Path.GetDirectoryName("")` returns `null` and the following `Path.Combine(null, …)` throws. Two analyze-path sites in `MultithreadedAnalyzeCommandBase` hit this:

- `DefaultConfigurationPath` (default-configuration probe), line ~62
- `GetConfigurationFileName` `--config <name>` sibling-file fallback, line ~947

v5.0.8 fixed the analogous single-file crash in `Tool.CreateFromAssemblyData`, but not these.

## Fix

Introduce an internal `ResolveAssemblyDirectory(string assemblyLocation)` helper that falls back to `AppContext.BaseDirectory` when the location is empty/null (preserving the existing directory when it is populated), and route both sites through it.

## Tests

Three unit tests (empty / null / populated location). All 76 `MultithreadedAnalyzeCommandBase` tests pass.

> Note: full end-to-end proof requires republishing the single-file npm binary; the unit tests cover the helper contract and both call sites now share it.

Adds a v5.0.9 `BUG` release note and bumps `VersionPrefix` to 5.0.9.
