### PR TITLE
Lift the add-* emit pipeline into an in-memory RunEmitContext API

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.1.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.1.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.1.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.1.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.1.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.1.0)
+* NEW: `RunEmitContext` runs the `add-*` emit pipeline in-process over a pluggable `IEmitSink` (`FileEmitSink`/`InMemoryEmitSink`): `AddResults`/`AddInvocations`/`AddRuleDescriptors`/`AddNotificationDescriptors` validate atomically and return an `EmitReport`, with no process spawn per call.
+
 ## **v5.0.10** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.0.10) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.0.10) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.0.10) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.0.10) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.0.10)
 * BRK: Rename the `add-*` emit verbs to plural — `add-results`, `add-invocations`, `add-notification-reporting-descriptors`, `add-rule-reporting-descriptors` — reflecting that each now accepts one or many; `get-schema` verb keys follow.
 * NEW: The plural `add-*` verbs accept a single JSON object or an array and validate atomically — any rejected element appends nothing — reporting the appended count and rejected element indices on stdout; an id duplicated within a batch is rejected like a cross-log duplicate.

--- a/src/Sarif.Multitool.Library/Emit/AddInvocationsCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/AddInvocationsCommand.cs
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Emit;
-
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
@@ -36,109 +30,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 options?.OutputFilePath,
                 options?.InputFilePath,
                 payloadKind: "invocation",
-                eventKind: SarifEventKinds.Invocation,
                 fileSystem,
-                buildValidator: _ => ValidateInvocation);
-        }
-
-        private static BatchElementError ValidateInvocation(JObject invocation, int index, bool batched)
-        {
-            string message = ValidateInvocationReceipt(invocation);
-            if (message != null) { return new BatchElementError(index, message); }
-
-            JToken endTimeUtc = invocation["endTimeUtc"];
-            bool hasEndTimeUtc = endTimeUtc != null && endTimeUtc.Type != JTokenType.Null;
-            if (!hasEndTimeUtc)
-            {
-                if (batched)
-                {
-                    return new BatchElementError(
-                        index,
-                        "Invalid invocation: 'endTimeUtc' is required when submitting invocations as a batch. The receipt-time default applies only to single (one-object) submission, where the write is roughly coincident with the invocation's conclusion; a batch is assembled after the fact, so each invocation must carry its own 'endTimeUtc'.");
-                }
-
-                StampEndTimeUtc(invocation, DateTime.UtcNow);
-            }
-
-            return null;
-        }
-
-        // Receipt gate for the required fields of ai-invocation.schema.json; full structural
-        // validation runs at emit-finalize --validate. Returns null when the invocation is
-        // acceptable; otherwise a message describing the first violation.
-        private static string ValidateInvocationReceipt(JObject invocation)
-        {
-            JToken executionSuccessful = invocation["executionSuccessful"];
-            if (executionSuccessful == null || executionSuccessful.Type != JTokenType.Boolean)
-            {
-                return "Invalid invocation: 'executionSuccessful' is required and must be a boolean.";
-            }
-
-            JToken commandLine = invocation["commandLine"];
-            if (commandLine == null
-                || commandLine.Type != JTokenType.String
-                || string.IsNullOrWhiteSpace(commandLine.Value<string>()))
-            {
-                return "Invalid invocation: 'commandLine' is required and must be a non-whitespace string.";
-            }
-
-            JToken workingDirectory = invocation["workingDirectory"];
-            if (workingDirectory == null || workingDirectory.Type != JTokenType.Object)
-            {
-                return "Invalid invocation: 'workingDirectory' is required and must be an artifactLocation.";
-            }
-
-            // A SARIF artifactLocation is addressable by 'uri' and/or 'uriBaseId'. emit-finalize
-            // rebases a repo-root workingDirectory to an empty 'uri' under a 'uriBaseId', so accept
-            // either anchor; only a workingDirectory carrying neither is unanchored and rejected.
-            var workingDirectoryObject = (JObject)workingDirectory;
-            JToken workingDirectoryUri = workingDirectoryObject["uri"];
-            JToken workingDirectoryUriBaseId = workingDirectoryObject["uriBaseId"];
-            bool hasUri = workingDirectoryUri?.Type == JTokenType.String
-                && !string.IsNullOrWhiteSpace(workingDirectoryUri.Value<string>());
-            bool hasUriBaseId = workingDirectoryUriBaseId?.Type == JTokenType.String
-                && !string.IsNullOrWhiteSpace(workingDirectoryUriBaseId.Value<string>());
-            if (!hasUri && !hasUriBaseId)
-            {
-                return "Invalid invocation: 'workingDirectory' must be an artifactLocation with a non-whitespace 'uri' or 'uriBaseId'.";
-            }
-
-            // The AI profile requires timeUtc on every inline notification.
-            return ValidateNotificationTimes(invocation["toolExecutionNotifications"], "toolExecutionNotifications")
-                ?? ValidateNotificationTimes(invocation["toolConfigurationNotifications"], "toolConfigurationNotifications");
-        }
-
-        private static string ValidateNotificationTimes(JToken notifications, string arrayName)
-        {
-            if (notifications == null || notifications.Type == JTokenType.Null) { return null; }
-
-            if (notifications.Type != JTokenType.Array)
-            {
-                return string.Format(CultureInfo.CurrentCulture, "Invalid invocation: '{0}' must be an array.", arrayName);
-            }
-
-            foreach (JToken item in (JArray)notifications)
-            {
-                JToken timeUtc = (item as JObject)?["timeUtc"];
-                if (timeUtc == null
-                    || timeUtc.Type != JTokenType.String
-                    || string.IsNullOrWhiteSpace(timeUtc.Value<string>()))
-                {
-                    return string.Format(
-                        CultureInfo.CurrentCulture,
-                        "Invalid invocation: every '{0}' entry requires a non-whitespace 'timeUtc'.",
-                        arrayName);
-                }
-            }
-
-            return null;
-        }
-
-        private static void StampEndTimeUtc(JObject invocation, DateTime endTimeUtc)
-        {
-            invocation["endTimeUtc"] = endTimeUtc.ToString(
-                SarifUtilities.SarifDateTimeFormatMillisecondsPrecision,
-                CultureInfo.InvariantCulture);
+                apply: (context, payload) => context.AddInvocations(payload));
         }
     }
 }

--- a/src/Sarif.Multitool.Library/Emit/AddResultsCommand.cs
+++ b/src/Sarif.Multitool.Library/Emit/AddResultsCommand.cs
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Globalization;
-
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Emit;
-
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
@@ -29,46 +24,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 options?.OutputFilePath,
                 options?.InputFilePath,
                 payloadKind: "result",
-                eventKind: SarifEventKinds.Result,
                 fileSystem,
-                buildValidator: _ => ValidateResult);
-        }
-
-        private static BatchElementError ValidateResult(JObject result, int index, bool batched)
-        {
-            JToken ruleIdToken = result["ruleId"];
-            if (ruleIdToken != null
-                && ruleIdToken.Type != JTokenType.Null
-                && ruleIdToken.Type != JTokenType.String)
-            {
-                // ThrowIfUnacceptable(null) would surface this as "(empty ruleId)" — misleading when
-                // the producer supplied a value of the wrong JSON type. Emit a specific message in
-                // the AI1012 namespace so the orchestrator can detect and correct.
-                return new BatchElementError(
-                    index,
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        "result.ruleId must be a JSON string, but the payload supplied a JSON {0}. See docs/ai/generating-sarif.md#rule-id-convention.",
-                        ruleIdToken.Type.ToString().ToLowerInvariant()),
-                    AIRuleIdConventionException.ErrorCode);
-            }
-
-            string ruleId = ruleIdToken?.Type == JTokenType.String
-                ? ruleIdToken.Value<string>()
-                : null;
-
-            try
-            {
-                AIRuleIdConvention.ThrowIfUnacceptable(ruleId);
-            }
-            catch (AIRuleIdConventionException ex)
-            {
-                // The message is already shaped for AI consumption (see
-                // AIRuleIdConventionException.BuildMessage) — surface it verbatim.
-                return new BatchElementError(index, ex.Message, AIRuleIdConventionException.ErrorCode);
-            }
-
-            return null;
+                apply: (context, payload) => context.AddResults(payload));
         }
     }
 }

--- a/src/Sarif.Multitool.Library/Emit/EmitBatchProcessor.cs
+++ b/src/Sarif.Multitool.Library/Emit/EmitBatchProcessor.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
@@ -16,60 +14,26 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     /// <summary>
-    /// Describes a single batch element the verb refused to append, identified by its
-    /// position in the submitted payload.
+    /// CLI shell for the polymorphic <c>add-*</c> emit verbs. Resolves the staged event log path,
+    /// reads the caller-supplied JSON (file or stdin), drives a <see cref="RunEmitContext"/> over a
+    /// <see cref="FileEmitSink"/>, and renders the resulting <see cref="EmitReport"/>. The verb's
+    /// value — element validation and all-or-none append semantics — lives in
+    /// <see cref="RunEmitContext"/>; this shell owns only process I/O and exit-code mapping.
     /// </summary>
-    internal sealed class BatchElementError
-    {
-        internal BatchElementError(int index, string message, string errorCode = null)
-        {
-            Index = index;
-            Message = message;
-            ErrorCode = errorCode;
-        }
-
-        /// <summary>The element's zero-based position in the submitted array (0 for a lone object).</summary>
-        internal int Index { get; }
-
-        /// <summary>An optional machine-readable code (e.g. <c>AI1012</c>) for the rejection.</summary>
-        internal string ErrorCode { get; }
-
-        /// <summary>A human/AI-consumable description of why the element was rejected.</summary>
-        internal string Message { get; }
-    }
-
-    /// <summary>
-    /// Validates a single batch element and may mutate it in place (e.g. stamping a default).
-    /// Returns <c>null</c> when the element is acceptable; otherwise the error describing the
-    /// rejection.
-    /// </summary>
-    /// <param name="element">The element to validate.</param>
-    /// <param name="index">The element's zero-based position in the submitted payload.</param>
-    /// <param name="batched">
-    /// <c>true</c> when the payload arrived as a JSON array (batch submission); <c>false</c> when
-    /// it arrived as a lone JSON object. A validator that defaults a field from receipt time uses
-    /// this to refuse the default under batch submission, where one write instant cannot stand in
-    /// for many elements assembled after the fact.
-    /// </param>
-    internal delegate BatchElementError ValidateBatchElement(JObject element, int index, bool batched);
-
-    /// <summary>
-    /// Shared orchestration for the polymorphic <c>add-*</c> emit verbs. Each verb accepts a single
-    /// JSON object or an array of objects, validates every element atomically, and appends all or
-    /// none: if any element is rejected the staged event log is left untouched. The outcome is
-    /// reported as a structured JSON document on stdout
+    /// <remarks>
+    /// A whole-payload rejection (<see cref="EmitReport.PayloadError"/>) is written to stderr; per-
+    /// element rejections are rendered as a structured JSON document on stdout
     /// (<c>{ "appended": N, "rejected": [ { "index": i, "errorCode": "...", "message": "..." } ] }</c>),
     /// so an AI orchestrator can correct the offending elements and retry idempotently.
-    /// </summary>
+    /// </remarks>
     internal static class EmitBatchProcessor
     {
         internal static int Run(
             string outputFilePath,
             string inputFilePath,
             string payloadKind,
-            string eventKind,
             IFileSystem fileSystem,
-            Func<string, ValidateBatchElement> buildValidator)
+            Func<RunEmitContext, JToken, EmitReport> apply)
         {
             fileSystem ??= Sarif.FileSystem.Instance;
 
@@ -81,83 +45,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 code = EmitEventLogHelpers.TryReadJsonToken(inputFilePath, payloadKind, fileSystem, out JToken token);
                 if (code != CommandBase.SUCCESS) { return code; }
 
-                var elements = new List<JObject>();
-                var errors = new List<BatchElementError>();
-                bool batched;
-
-                if (token.Type == JTokenType.Object)
+                EmitReport report;
+                using (var sink = new FileEmitSink(wipPath))
                 {
-                    batched = false;
-                    elements.Add((JObject)token);
+                    report = apply(new RunEmitContext(sink), token);
                 }
-                else if (token.Type == JTokenType.Array)
-                {
-                    batched = true;
-                    int i = 0;
-                    foreach (JToken item in (JArray)token)
-                    {
-                        if (item.Type == JTokenType.Object)
-                        {
-                            elements.Add((JObject)item);
-                        }
-                        else
-                        {
-                            // Keep the index aligned so the report cites the submitted position.
-                            elements.Add(null);
-                            errors.Add(new BatchElementError(
-                                i,
-                                string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    "{0} batch element must be a JSON object, but element {1} was a JSON {2}.",
-                                    Capitalize(payloadKind),
-                                    i,
-                                    item.Type.ToString().ToLowerInvariant())));
-                        }
 
-                        i++;
-                    }
-                }
-                else
+                if (report.PayloadError != null)
                 {
-                    Console.Error.WriteLine(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "{0} JSON must be a JSON object or an array of objects, but the parsed payload was a {1}.",
-                            Capitalize(payloadKind),
-                            token.Type.ToString().ToLowerInvariant()));
+                    Console.Error.WriteLine(report.PayloadError);
                     return CommandBase.FAILURE;
                 }
 
-                ValidateBatchElement validate = buildValidator(wipPath);
-
-                for (int index = 0; index < elements.Count; index++)
-                {
-                    JObject element = elements[index];
-                    if (element == null) { continue; } // already captured as a structural error
-
-                    BatchElementError error = validate(element, index, batched);
-                    if (error != null) { errors.Add(error); }
-                }
-
-                // Atomic: any rejection appends nothing, so a retry of the corrected payload never
-                // double-appends the elements that were already valid.
-                if (errors.Count > 0)
-                {
-                    WriteReport(appended: 0, errors);
-                    return CommandBase.FAILURE;
-                }
-
-                if (elements.Count > 0)
-                {
-                    using var writer = new SarifEventLogWriter(wipPath);
-                    foreach (JObject element in elements)
-                    {
-                        writer.Append(eventKind, element);
-                    }
-                }
-
-                WriteReport(elements.Count, errors);
-                return CommandBase.SUCCESS;
+                WriteReport(report);
+                return report.Rejected.Count > 0 ? CommandBase.FAILURE : CommandBase.SUCCESS;
             }
             catch (Exception ex) when (!Debugger.IsAttached)
             {
@@ -166,11 +67,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
         }
 
-        private static void WriteReport(int appended, List<BatchElementError> errors)
+        private static void WriteReport(EmitReport report)
         {
             var rejected = new JArray(
-                errors
-                    .OrderBy(e => e.Index)
+                report.Rejected
                     .Select(e =>
                     {
                         var entry = new JObject { ["index"] = e.Index };
@@ -180,19 +80,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     })
                     .Cast<JToken>());
 
-            var report = new JObject
+            var document = new JObject
             {
-                ["appended"] = appended,
+                ["appended"] = report.Appended,
                 ["rejected"] = rejected,
             };
 
-            Console.Out.WriteLine(report.ToString(Formatting.Indented));
-        }
-
-        private static string Capitalize(string s)
-        {
-            if (string.IsNullOrEmpty(s)) { return s; }
-            return char.ToUpperInvariant(s[0]) + s.Substring(1);
+            Console.Out.WriteLine(document.ToString(Formatting.Indented));
         }
     }
 }

--- a/src/Sarif.Multitool.Library/Emit/ReportingDescriptorEmitter.cs
+++ b/src/Sarif.Multitool.Library/Emit/ReportingDescriptorEmitter.cs
@@ -1,20 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-
-using Microsoft.CodeAnalysis.Sarif.Emit;
-
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     /// <summary>
-    /// Shared implementation behind <c>add-notification-reporting-descriptors</c> and
-    /// <c>add-rule-reporting-descriptors</c>: validates one or more SARIF reportingDescriptor
-    /// objects and appends an event per element to <c>&lt;output&gt;.wip.jsonl</c>.
+    /// Shared entry point behind <c>add-notification-reporting-descriptors</c> and
+    /// <c>add-rule-reporting-descriptors</c>: drives a <see cref="Sarif.Emit.RunEmitContext"/> to
+    /// validate one or more SARIF reportingDescriptor objects and append an event per element to
+    /// <c>&lt;output&gt;.wip.jsonl</c>.
     /// </summary>
     /// <remarks>
     /// Notifications append to <c>run.tool.driver.notifications[]</c>; rules append to
@@ -31,143 +24,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             IFileSystem fileSystem = null)
         {
             string payloadKind = isRules ? "rule descriptor" : "notification descriptor";
-            string eventKind = isRules
-                ? SarifEventKinds.RuleDescriptor
-                : SarifEventKinds.NotificationDescriptor;
 
             return EmitBatchProcessor.Run(
                 outputFilePath,
                 inputFilePath,
                 payloadKind,
-                eventKind,
                 fileSystem,
-                buildValidator: wipPath => BuildValidator(wipPath, isRules, payloadKind));
-        }
-
-        private static ValidateBatchElement BuildValidator(string wipPath, bool isRules, string payloadKind)
-        {
-            string targetArray = isRules ? "rules" : "notifications";
-            string eventKind = isRules
-                ? SarifEventKinds.RuleDescriptor
-                : SarifEventKinds.NotificationDescriptor;
-
-            // Read the existing-log ids once (O(events)) so a batch does not re-scan the log per
-            // element. Track ids seen earlier in this batch so two same-id elements are rejected.
-            HashSet<string> existingIds = ReadExistingDescriptorIds(wipPath, eventKind, targetArray);
-            var batchIds = new HashSet<string>(StringComparer.Ordinal);
-
-            return (descriptor, index, batched) =>
-            {
-                // SARIF §3.49.3 requires a non-empty reportingDescriptor.id string.
-                JToken idToken = descriptor["id"];
-                if (idToken == null || idToken.Type != JTokenType.String)
-                {
-                    return new BatchElementError(
-                        index,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "{0} JSON must include a non-empty 'id' string (SARIF §3.49.3). {1}.",
-                            Capitalize(payloadKind),
-                            idToken == null
-                                ? "The payload had no 'id' field"
-                                : string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    "The payload supplied 'id' as JSON {0}",
-                                    idToken.Type.ToString().ToLowerInvariant())));
-                }
-
-                string id = idToken.Value<string>();
-                if (string.IsNullOrEmpty(id))
-                {
-                    return new BatchElementError(
-                        index,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "{0} JSON 'id' must be a non-empty string (SARIF §3.49.3).",
-                            Capitalize(payloadKind)));
-                }
-
-                // Rule descriptors are accepted only for flat NOVEL- ids.
-                if (isRules && !(AIRuleIdConvention.IsNovel(id) && AIRuleIdConvention.IsAcceptable(id)))
-                {
-                    return new BatchElementError(
-                        index,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "rule descriptor id '{0}' is not a well-formed NOVEL- id. The add-rule-reporting-descriptors verb is reserved for novel-finding descriptors that have no taxonomy entry; descriptors for taxonomy-mapped rules (e.g., 'CWE-89') come from the taxonomy enricher, not from this verb. Use a NOVEL- escape-hatch id: 'NOVEL-' followed by a lowercase-alphanumeric kebab sub-id (single hyphens, no slash, no trailing hyphen), e.g., 'NOVEL-prompt-injection-via-system-message'. See docs/ai/generating-sarif.md#rule-id-convention.",
-                            id),
-                        AIRuleIdConventionException.ErrorCode);
-                }
-
-                if (existingIds.Contains(id))
-                {
-                    return new BatchElementError(
-                        index,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "a {0} with id '{1}' is already present in the event log under tool.driver.{2}. Each id may appear at most once per event log. (--force is not yet supported.)",
-                            payloadKind,
-                            id,
-                            targetArray));
-                }
-
-                if (!batchIds.Add(id))
-                {
-                    return new BatchElementError(
-                        index,
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            "a {0} with id '{1}' appears more than once in this batch. Each id may appear at most once per event log. (--force is not yet supported.)",
-                            payloadKind,
-                            id));
-                }
-
-                return null;
-            };
-        }
-
-        /// <summary>
-        /// Collects every descriptor id already targeting <paramref name="targetArray"/> in the
-        /// staged event log, counting both run-header pre-populated descriptors and prior descriptor
-        /// events.
-        /// </summary>
-        private static HashSet<string> ReadExistingDescriptorIds(string wipPath, string targetKind, string targetArray)
-        {
-            var ids = new HashSet<string>(StringComparer.Ordinal);
-
-            var reader = new SarifEventLogReader();
-            foreach (SarifEvent evt in reader.Read(wipPath))
-            {
-                if (string.Equals(evt.Kind, SarifEventKinds.RunHeader, StringComparison.Ordinal))
-                {
-                    JToken driverArray = evt.Payload?["tool"]?["driver"]?[targetArray];
-                    if (driverArray is JArray descriptors)
-                    {
-                        foreach (JToken descriptor in descriptors)
-                        {
-                            if (descriptor?["id"]?.Type == JTokenType.String)
-                            {
-                                ids.Add(descriptor["id"].Value<string>());
-                            }
-                        }
-                    }
-                }
-                else if (string.Equals(evt.Kind, targetKind, StringComparison.Ordinal))
-                {
-                    if (evt.Payload?["id"]?.Type == JTokenType.String)
-                    {
-                        ids.Add(evt.Payload["id"].Value<string>());
-                    }
-                }
-            }
-
-            return ids;
-        }
-
-        private static string Capitalize(string s)
-        {
-            if (string.IsNullOrEmpty(s)) { return s; }
-            return char.ToUpperInvariant(s[0]) + s.Substring(1);
+                apply: (context, payload) => isRules
+                    ? context.AddRuleDescriptors(payload)
+                    : context.AddNotificationDescriptors(payload));
         }
     }
 }

--- a/src/Sarif/Emit/EmitElementError.cs
+++ b/src/Sarif/Emit/EmitElementError.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// Describes a single emit element that was refused, identified by its position in the submitted
+    /// payload. A lone object is index 0; an array element carries its zero-based position so a
+    /// producer can correct the offender and retry the corrected payload idempotently.
+    /// </summary>
+    public sealed class EmitElementError
+    {
+        public EmitElementError(int index, string message, string errorCode = null)
+        {
+            Index = index;
+            Message = message;
+            ErrorCode = errorCode;
+        }
+
+        /// <summary>The element's zero-based position in the submitted payload (0 for a lone object).</summary>
+        public int Index { get; }
+
+        /// <summary>An optional machine-readable code (e.g. <c>AI1012</c>) for the rejection.</summary>
+        public string ErrorCode { get; }
+
+        /// <summary>A human/AI-consumable description of why the element was rejected.</summary>
+        public string Message { get; }
+    }
+}

--- a/src/Sarif/Emit/EmitReport.cs
+++ b/src/Sarif/Emit/EmitReport.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// The outcome of an atomic emit append: how many events were appended (all-or-none) and, on
+    /// rejection, why. The append is atomic — if any element is rejected, <see cref="Appended"/> is
+    /// zero and nothing reaches the sink — so a retry of the corrected payload never double-appends
+    /// the elements that were already valid.
+    /// </summary>
+    /// <remarks>
+    /// Two rejection shapes are distinguished. A per-element rejection populates <see cref="Rejected"/>
+    /// (the payload was a well-formed object or array, but one or more elements failed validation). A
+    /// <see cref="PayloadError"/> is a whole-payload rejection: the payload itself was neither a JSON
+    /// object nor an array, so there were no elements to validate. A CLI shell routes
+    /// <see cref="PayloadError"/> to stderr and <see cref="Rejected"/> to its structured stdout report.
+    /// </remarks>
+    public sealed class EmitReport
+    {
+        public EmitReport(int appended, IReadOnlyList<EmitElementError> rejected, string payloadError = null)
+        {
+            Appended = appended;
+            Rejected = rejected ?? Array.Empty<EmitElementError>();
+            PayloadError = payloadError;
+        }
+
+        /// <summary>The number of events appended to the sink (0 on any rejection).</summary>
+        public int Appended { get; }
+
+        /// <summary>The per-element rejections, ordered by submitted index. Empty on success.</summary>
+        public IReadOnlyList<EmitElementError> Rejected { get; }
+
+        /// <summary>
+        /// Non-null when the whole payload was rejected before any element could be considered (the
+        /// payload was neither a JSON object nor an array).
+        /// </summary>
+        public string PayloadError { get; }
+
+        /// <summary>True when nothing was rejected and the append committed.</summary>
+        public bool Succeeded => PayloadError == null && Rejected.Count == 0;
+    }
+}

--- a/src/Sarif/Emit/FileEmitSink.cs
+++ b/src/Sarif/Emit/FileEmitSink.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// An <see cref="IEmitSink"/> backed by a SARIF event-log file (<c>*.wip.jsonl</c>). Appends go
+    /// through a single lazily-opened <see cref="SarifEventLogWriter"/>; <see cref="ReadAll"/> opens
+    /// a fresh forward-only reader each call. This is the durable, crash-safe, resumable sink and the
+    /// shape the CLI emit verbs use.
+    /// </summary>
+    public sealed class FileEmitSink : IEmitSink
+    {
+        private readonly string _path;
+        private SarifEventLogWriter _writer;
+
+        public FileEmitSink(string path)
+        {
+            _path = path;
+        }
+
+        public void Append(string kind, JToken payload)
+        {
+            // Open on first append so a read-only context (e.g. a duplicate scan that never appends)
+            // never takes the exclusive append handle.
+            _writer ??= new SarifEventLogWriter(_path);
+            _writer.Append(kind, payload);
+        }
+
+        public IEnumerable<SarifEvent> ReadAll() => new SarifEventLogReader().Read(_path);
+
+        public void Dispose() => _writer?.Dispose();
+    }
+}

--- a/src/Sarif/Emit/IEmitSink.cs
+++ b/src/Sarif/Emit/IEmitSink.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// Append-only destination for the SARIF event stream that backs incremental authoring. A sink
+    /// hides where events live — a <c>*.wip.jsonl</c> file on disk, an in-memory list, or a per-run
+    /// shard — so a <see cref="RunEmitContext"/> can validate-and-append without owning that policy.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ReadAll"/> returns every event appended so far in append order; it backs the
+    /// descriptor duplicate scan and run resolution. Implementations that stream from disk MUST
+    /// tolerate being read while the sink is still open for append.
+    /// </remarks>
+    public interface IEmitSink : IDisposable
+    {
+        /// <summary>Appends one event of the given kind with the given payload.</summary>
+        void Append(string kind, JToken payload);
+
+        /// <summary>Enumerates every event appended to the sink so far, in append order.</summary>
+        IEnumerable<SarifEvent> ReadAll();
+    }
+}

--- a/src/Sarif/Emit/InMemoryEmitSink.cs
+++ b/src/Sarif/Emit/InMemoryEmitSink.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// An <see cref="IEmitSink"/> that accumulates events in memory. Lets a .NET producer drive a
+    /// <see cref="RunEmitContext"/> with no file handle and no process spawn; the accumulated events
+    /// are resolved into a <see cref="SarifLog"/> at finalize. Trades the file sink's crash-safety
+    /// and resumability for speed on small/short runs.
+    /// </summary>
+    public sealed class InMemoryEmitSink : IEmitSink
+    {
+        private readonly List<SarifEvent> _events = new List<SarifEvent>();
+
+        /// <summary>The events appended so far, in append order.</summary>
+        public IReadOnlyList<SarifEvent> Events => _events;
+
+        public void Append(string kind, JToken payload)
+        {
+            _events.Add(new SarifEvent
+            {
+                Version = SarifEventKinds.CurrentSchemaVersion,
+                Kind = kind,
+                Payload = payload ?? new JObject(),
+            });
+        }
+
+        public IEnumerable<SarifEvent> ReadAll() => _events;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Sarif/Emit/RunEmitContext.cs
+++ b/src/Sarif/Emit/RunEmitContext.cs
@@ -1,0 +1,440 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Emit
+{
+    /// <summary>
+    /// Validates a single emit element and may mutate it in place (e.g. stamping a default). Returns
+    /// <c>null</c> when the element is acceptable; otherwise the error describing the rejection.
+    /// </summary>
+    /// <param name="element">The element to validate.</param>
+    /// <param name="index">The element's zero-based position in the submitted payload.</param>
+    /// <param name="batched">
+    /// <c>true</c> when the payload arrived as a JSON array (batch submission); <c>false</c> when it
+    /// arrived as a lone JSON object. A validator that defaults a field from receipt time uses this to
+    /// refuse the default under batch submission, where one write instant cannot stand in for many
+    /// elements assembled after the fact.
+    /// </param>
+    public delegate EmitElementError ValidateEmitElement(JObject element, int index, bool batched);
+
+    /// <summary>
+    /// In-memory authoring surface for a single SARIF run. A producer appends fully-formed SARIF
+    /// objects — results, invocations, reporting descriptors — and each <c>Add*</c> call validates
+    /// every element atomically and appends an event per element to the backing <see cref="IEmitSink"/>,
+    /// returning a structured <see cref="EmitReport"/>. <see cref="ResolveToLog"/> replays the sink into
+    /// a <see cref="SarifLog"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the in-process C# counterpart to the <c>add-*</c> CLI verbs: a .NET producer can
+    /// drive it directly — over an <see cref="InMemoryEmitSink"/> or a <see cref="FileEmitSink"/> —
+    /// without spawning a process per call. The CLI verbs are thin shells over this type.</para>
+    /// <para>Results and resolution stay index-free: a result carries its <c>ruleId</c>, never a
+    /// <c>ruleIndex</c>, and the replay engine re-derives run-scoped indices at resolution. That is
+    /// what makes a run a self-contained shard.</para>
+    /// </remarks>
+    public sealed class RunEmitContext
+    {
+        private readonly IEmitSink _sink;
+
+        public RunEmitContext(IEmitSink sink)
+        {
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        /// <summary>Appends the run skeleton (everything except results/invocations/notifications).</summary>
+        public void SetRunHeader(JObject runSkeleton)
+        {
+            _sink.Append(SarifEventKinds.RunHeader, runSkeleton ?? new JObject());
+        }
+
+        /// <summary>Validates and appends one result object or an array of result objects.</summary>
+        public EmitReport AddResults(JToken payload)
+            => AppendBatch(payload, "result", SarifEventKinds.Result, () => ValidateResult);
+
+        /// <summary>Validates and appends one invocation object or an array of invocation objects.</summary>
+        public EmitReport AddInvocations(JToken payload)
+            => AppendBatch(payload, "invocation", SarifEventKinds.Invocation, () => ValidateInvocation);
+
+        /// <summary>Validates and appends one rule reportingDescriptor or an array of them.</summary>
+        public EmitReport AddRuleDescriptors(JToken payload)
+            => AppendBatch(
+                payload,
+                "rule descriptor",
+                SarifEventKinds.RuleDescriptor,
+                () => BuildDescriptorValidator(isRules: true, "rule descriptor"));
+
+        /// <summary>Validates and appends one notification reportingDescriptor or an array of them.</summary>
+        public EmitReport AddNotificationDescriptors(JToken payload)
+            => AppendBatch(
+                payload,
+                "notification descriptor",
+                SarifEventKinds.NotificationDescriptor,
+                () => BuildDescriptorValidator(isRules: false, "notification descriptor"));
+
+        /// <summary>Replays the events appended so far into a single-run <see cref="SarifLog"/>.</summary>
+        public SarifLog ResolveToLog() => SarifEventReplayer.Replay(_sink.ReadAll());
+
+        /// <summary>
+        /// Shared orchestration: accept a lone JSON object or an array of objects, validate every
+        /// element atomically, and append all or none. On any rejection nothing reaches the sink.
+        /// </summary>
+        private EmitReport AppendBatch(
+            JToken token,
+            string payloadKind,
+            string eventKind,
+            Func<ValidateEmitElement> buildValidator)
+        {
+            if (token == null)
+            {
+                return new EmitReport(
+                    0,
+                    Array.Empty<EmitElementError>(),
+                    payloadError: string.Format(
+                        CultureInfo.CurrentCulture,
+                        "{0} JSON must be a JSON object or an array of objects, but no payload was supplied.",
+                        Capitalize(payloadKind)));
+            }
+
+            var elements = new List<JObject>();
+            var errors = new List<EmitElementError>();
+            bool batched;
+
+            if (token.Type == JTokenType.Object)
+            {
+                batched = false;
+                elements.Add((JObject)token);
+            }
+            else if (token.Type == JTokenType.Array)
+            {
+                batched = true;
+                int i = 0;
+                foreach (JToken item in (JArray)token)
+                {
+                    if (item.Type == JTokenType.Object)
+                    {
+                        elements.Add((JObject)item);
+                    }
+                    else
+                    {
+                        // Keep the index aligned so the report cites the submitted position.
+                        elements.Add(null);
+                        errors.Add(new EmitElementError(
+                            i,
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                "{0} batch element must be a JSON object, but element {1} was a JSON {2}.",
+                                Capitalize(payloadKind),
+                                i,
+                                item.Type.ToString().ToLowerInvariant())));
+                    }
+
+                    i++;
+                }
+            }
+            else
+            {
+                return new EmitReport(
+                    0,
+                    Array.Empty<EmitElementError>(),
+                    payloadError: string.Format(
+                        CultureInfo.CurrentCulture,
+                        "{0} JSON must be a JSON object or an array of objects, but the parsed payload was a {1}.",
+                        Capitalize(payloadKind),
+                        token.Type.ToString().ToLowerInvariant()));
+            }
+
+            ValidateEmitElement validate = buildValidator();
+
+            for (int index = 0; index < elements.Count; index++)
+            {
+                JObject element = elements[index];
+                if (element == null) { continue; } // already captured as a structural error
+
+                EmitElementError error = validate(element, index, batched);
+                if (error != null) { errors.Add(error); }
+            }
+
+            // Atomic: any rejection appends nothing, so a retry of the corrected payload never
+            // double-appends the elements that were already valid.
+            if (errors.Count > 0)
+            {
+                return new EmitReport(0, errors.OrderBy(e => e.Index).ToArray());
+            }
+
+            foreach (JObject element in elements)
+            {
+                _sink.Append(eventKind, element);
+            }
+
+            return new EmitReport(elements.Count, Array.Empty<EmitElementError>());
+        }
+
+        private static EmitElementError ValidateResult(JObject result, int index, bool batched)
+        {
+            JToken ruleIdToken = result["ruleId"];
+            if (ruleIdToken != null
+                && ruleIdToken.Type != JTokenType.Null
+                && ruleIdToken.Type != JTokenType.String)
+            {
+                // ThrowIfUnacceptable(null) would surface this as "(empty ruleId)" — misleading when
+                // the producer supplied a value of the wrong JSON type. Emit a specific message in
+                // the AI1012 namespace so the orchestrator can detect and correct.
+                return new EmitElementError(
+                    index,
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "result.ruleId must be a JSON string, but the payload supplied a JSON {0}. See docs/ai/generating-sarif.md#rule-id-convention.",
+                        ruleIdToken.Type.ToString().ToLowerInvariant()),
+                    AIRuleIdConventionException.ErrorCode);
+            }
+
+            string ruleId = ruleIdToken?.Type == JTokenType.String
+                ? ruleIdToken.Value<string>()
+                : null;
+
+            try
+            {
+                AIRuleIdConvention.ThrowIfUnacceptable(ruleId);
+            }
+            catch (AIRuleIdConventionException ex)
+            {
+                // The message is already shaped for AI consumption (see
+                // AIRuleIdConventionException.BuildMessage) — surface it verbatim.
+                return new EmitElementError(index, ex.Message, AIRuleIdConventionException.ErrorCode);
+            }
+
+            return null;
+        }
+
+        private static EmitElementError ValidateInvocation(JObject invocation, int index, bool batched)
+        {
+            string message = ValidateInvocationReceipt(invocation);
+            if (message != null) { return new EmitElementError(index, message); }
+
+            JToken endTimeUtc = invocation["endTimeUtc"];
+            bool hasEndTimeUtc = endTimeUtc != null && endTimeUtc.Type != JTokenType.Null;
+            if (!hasEndTimeUtc)
+            {
+                if (batched)
+                {
+                    return new EmitElementError(
+                        index,
+                        "Invalid invocation: 'endTimeUtc' is required when submitting invocations as a batch. The receipt-time default applies only to single (one-object) submission, where the write is roughly coincident with the invocation's conclusion; a batch is assembled after the fact, so each invocation must carry its own 'endTimeUtc'.");
+                }
+
+                StampEndTimeUtc(invocation, DateTime.UtcNow);
+            }
+
+            return null;
+        }
+
+        // Receipt gate for the required fields of ai-invocation.schema.json; full structural
+        // validation runs at emit-finalize --validate. Returns null when the invocation is
+        // acceptable; otherwise a message describing the first violation.
+        private static string ValidateInvocationReceipt(JObject invocation)
+        {
+            JToken executionSuccessful = invocation["executionSuccessful"];
+            if (executionSuccessful == null || executionSuccessful.Type != JTokenType.Boolean)
+            {
+                return "Invalid invocation: 'executionSuccessful' is required and must be a boolean.";
+            }
+
+            JToken commandLine = invocation["commandLine"];
+            if (commandLine == null
+                || commandLine.Type != JTokenType.String
+                || string.IsNullOrWhiteSpace(commandLine.Value<string>()))
+            {
+                return "Invalid invocation: 'commandLine' is required and must be a non-whitespace string.";
+            }
+
+            JToken workingDirectory = invocation["workingDirectory"];
+            if (workingDirectory == null || workingDirectory.Type != JTokenType.Object)
+            {
+                return "Invalid invocation: 'workingDirectory' is required and must be an artifactLocation.";
+            }
+
+            // A SARIF artifactLocation is addressable by 'uri' and/or 'uriBaseId'. emit-finalize
+            // rebases a repo-root workingDirectory to an empty 'uri' under a 'uriBaseId', so accept
+            // either anchor; only a workingDirectory carrying neither is unanchored and rejected.
+            var workingDirectoryObject = (JObject)workingDirectory;
+            JToken workingDirectoryUri = workingDirectoryObject["uri"];
+            JToken workingDirectoryUriBaseId = workingDirectoryObject["uriBaseId"];
+            bool hasUri = workingDirectoryUri?.Type == JTokenType.String
+                && !string.IsNullOrWhiteSpace(workingDirectoryUri.Value<string>());
+            bool hasUriBaseId = workingDirectoryUriBaseId?.Type == JTokenType.String
+                && !string.IsNullOrWhiteSpace(workingDirectoryUriBaseId.Value<string>());
+            if (!hasUri && !hasUriBaseId)
+            {
+                return "Invalid invocation: 'workingDirectory' must be an artifactLocation with a non-whitespace 'uri' or 'uriBaseId'.";
+            }
+
+            // The AI profile requires timeUtc on every inline notification.
+            return ValidateNotificationTimes(invocation["toolExecutionNotifications"], "toolExecutionNotifications")
+                ?? ValidateNotificationTimes(invocation["toolConfigurationNotifications"], "toolConfigurationNotifications");
+        }
+
+        private static string ValidateNotificationTimes(JToken notifications, string arrayName)
+        {
+            if (notifications == null || notifications.Type == JTokenType.Null) { return null; }
+
+            if (notifications.Type != JTokenType.Array)
+            {
+                return string.Format(CultureInfo.CurrentCulture, "Invalid invocation: '{0}' must be an array.", arrayName);
+            }
+
+            foreach (JToken item in (JArray)notifications)
+            {
+                JToken timeUtc = (item as JObject)?["timeUtc"];
+                if (timeUtc == null
+                    || timeUtc.Type != JTokenType.String
+                    || string.IsNullOrWhiteSpace(timeUtc.Value<string>()))
+                {
+                    return string.Format(
+                        CultureInfo.CurrentCulture,
+                        "Invalid invocation: every '{0}' entry requires a non-whitespace 'timeUtc'.",
+                        arrayName);
+                }
+            }
+
+            return null;
+        }
+
+        private static void StampEndTimeUtc(JObject invocation, DateTime endTimeUtc)
+        {
+            invocation["endTimeUtc"] = endTimeUtc.ToString(
+                SarifUtilities.SarifDateTimeFormatMillisecondsPrecision,
+                CultureInfo.InvariantCulture);
+        }
+
+        private ValidateEmitElement BuildDescriptorValidator(bool isRules, string payloadKind)
+        {
+            string targetArray = isRules ? "rules" : "notifications";
+            string eventKind = isRules
+                ? SarifEventKinds.RuleDescriptor
+                : SarifEventKinds.NotificationDescriptor;
+
+            // Read the existing-log ids once (O(events)) so a batch does not re-scan the log per
+            // element. Track ids seen earlier in this batch so two same-id elements are rejected.
+            HashSet<string> existingIds = ReadExistingDescriptorIds(eventKind, targetArray);
+            var batchIds = new HashSet<string>(StringComparer.Ordinal);
+
+            return (descriptor, index, batched) =>
+            {
+                // SARIF §3.49.3 requires a non-empty reportingDescriptor.id string.
+                JToken idToken = descriptor["id"];
+                if (idToken == null || idToken.Type != JTokenType.String)
+                {
+                    return new EmitElementError(
+                        index,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "{0} JSON must include a non-empty 'id' string (SARIF §3.49.3). {1}.",
+                            Capitalize(payloadKind),
+                            idToken == null
+                                ? "The payload had no 'id' field"
+                                : string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    "The payload supplied 'id' as JSON {0}",
+                                    idToken.Type.ToString().ToLowerInvariant())));
+                }
+
+                string id = idToken.Value<string>();
+                if (string.IsNullOrEmpty(id))
+                {
+                    return new EmitElementError(
+                        index,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "{0} JSON 'id' must be a non-empty string (SARIF §3.49.3).",
+                            Capitalize(payloadKind)));
+                }
+
+                // Rule descriptors are accepted only for flat NOVEL- ids.
+                if (isRules && !(AIRuleIdConvention.IsNovel(id) && AIRuleIdConvention.IsAcceptable(id)))
+                {
+                    return new EmitElementError(
+                        index,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "rule descriptor id '{0}' is not a well-formed NOVEL- id. The add-rule-reporting-descriptors verb is reserved for novel-finding descriptors that have no taxonomy entry; descriptors for taxonomy-mapped rules (e.g., 'CWE-89') come from the taxonomy enricher, not from this verb. Use a NOVEL- escape-hatch id: 'NOVEL-' followed by a lowercase-alphanumeric kebab sub-id (single hyphens, no slash, no trailing hyphen), e.g., 'NOVEL-prompt-injection-via-system-message'. See docs/ai/generating-sarif.md#rule-id-convention.",
+                            id),
+                        AIRuleIdConventionException.ErrorCode);
+                }
+
+                if (existingIds.Contains(id))
+                {
+                    return new EmitElementError(
+                        index,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "a {0} with id '{1}' is already present in the event log under tool.driver.{2}. Each id may appear at most once per event log. (--force is not yet supported.)",
+                            payloadKind,
+                            id,
+                            targetArray));
+                }
+
+                if (!batchIds.Add(id))
+                {
+                    return new EmitElementError(
+                        index,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "a {0} with id '{1}' appears more than once in this batch. Each id may appear at most once per event log. (--force is not yet supported.)",
+                            payloadKind,
+                            id));
+                }
+
+                return null;
+            };
+        }
+
+        /// <summary>
+        /// Collects every descriptor id already targeting <paramref name="targetArray"/> in the staged
+        /// event log, counting both run-header pre-populated descriptors and prior descriptor events.
+        /// </summary>
+        private HashSet<string> ReadExistingDescriptorIds(string targetKind, string targetArray)
+        {
+            var ids = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (SarifEvent evt in _sink.ReadAll())
+            {
+                if (string.Equals(evt.Kind, SarifEventKinds.RunHeader, StringComparison.Ordinal))
+                {
+                    JToken driverArray = evt.Payload?["tool"]?["driver"]?[targetArray];
+                    if (driverArray is JArray descriptors)
+                    {
+                        foreach (JToken descriptor in descriptors)
+                        {
+                            if (descriptor?["id"]?.Type == JTokenType.String)
+                            {
+                                ids.Add(descriptor["id"].Value<string>());
+                            }
+                        }
+                    }
+                }
+                else if (string.Equals(evt.Kind, targetKind, StringComparison.Ordinal))
+                {
+                    if (evt.Payload?["id"]?.Type == JTokenType.String)
+                    {
+                        ids.Add(evt.Payload["id"].Value<string>());
+                    }
+                }
+            }
+
+            return ids;
+        }
+
+        private static string Capitalize(string s)
+        {
+            if (string.IsNullOrEmpty(s)) { return s; }
+            return char.ToUpperInvariant(s[0]) + s.Substring(1);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Emit/RunEmitContextTests.cs
+++ b/src/Test.UnitTests.Sarif/Emit/RunEmitContextTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Emit;
+
+using Newtonsoft.Json.Linq;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Test.UnitTests.Emit
+{
+    /// <summary>
+    /// Exercises <see cref="RunEmitContext"/> directly over an <see cref="InMemoryEmitSink"/>,
+    /// confirming the emit pipeline is usable in-process — no file, no process spawn — and that the
+    /// returned <see cref="EmitReport"/> carries the same validation and all-or-none semantics the
+    /// CLI verbs expose.
+    /// </summary>
+    public class RunEmitContextTests
+    {
+        [Fact]
+        public void AddResults_SingleValid_AppendsOneResultEvent()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddResults(Obj(@"{ ""ruleId"": ""CWE-89/sql-injection"" }"));
+
+            report.Succeeded.Should().BeTrue();
+            report.Appended.Should().Be(1);
+            sink.Events.Should().ContainSingle(e => e.Kind == SarifEventKinds.Result);
+        }
+
+        [Fact]
+        public void AddResults_ValidArray_AppendsEveryElement()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddResults(Arr(
+                @"[ { ""ruleId"": ""CWE-89/sql-injection"" }, { ""ruleId"": ""NOVEL-prompt-injection"" } ]"));
+
+            report.Succeeded.Should().BeTrue();
+            report.Appended.Should().Be(2);
+            sink.Events.Count(e => e.Kind == SarifEventKinds.Result).Should().Be(2);
+        }
+
+        [Fact]
+        public void AddResults_NonStringRuleId_RejectsWithAi1012AndAppendsNothing()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddResults(Obj(@"{ ""ruleId"": 7 }"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Appended.Should().Be(0);
+            report.Rejected.Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(AIRuleIdConventionException.ErrorCode);
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddResults_BatchWithInvalidLastElement_RejectsAtomically()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            // The first element is valid; the second (the Nth) is not — the whole batch is refused.
+            EmitReport report = context.AddResults(Arr(
+                @"[ { ""ruleId"": ""CWE-89/sql-injection"" }, { ""ruleId"": ""not a valid id"" } ]"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Appended.Should().Be(0);
+            report.Rejected.Should().ContainSingle().Which.Index.Should().Be(1);
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddInvocations_SingleOmittingEndTimeUtc_StampsReceiptTime()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddInvocations(Obj(
+                @"{ ""executionSuccessful"": true, ""commandLine"": ""scan"", ""workingDirectory"": { ""uri"": ""file:///repo/"" } }"));
+
+            report.Succeeded.Should().BeTrue();
+            report.Appended.Should().Be(1);
+            JToken appended = sink.Events.Single(e => e.Kind == SarifEventKinds.Invocation).Payload;
+            appended["endTimeUtc"].Should().NotBeNull();
+        }
+
+        [Fact]
+        public void AddInvocations_BatchOmittingEndTimeUtc_IsRejected()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddInvocations(Arr(
+                @"[ { ""executionSuccessful"": true, ""commandLine"": ""scan"", ""workingDirectory"": { ""uri"": ""file:///repo/"" } } ]"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Appended.Should().Be(0);
+            report.Rejected.Should().ContainSingle()
+                .Which.Message.Should().Contain("endTimeUtc");
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddRuleDescriptors_NovelId_Appends()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddRuleDescriptors(Obj(@"{ ""id"": ""NOVEL-prompt-injection"" }"));
+
+            report.Succeeded.Should().BeTrue();
+            sink.Events.Should().ContainSingle(e => e.Kind == SarifEventKinds.RuleDescriptor);
+        }
+
+        [Fact]
+        public void AddRuleDescriptors_NonNovelId_RejectsWithAi1012()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddRuleDescriptors(Obj(@"{ ""id"": ""CWE-89"" }"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Rejected.Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(AIRuleIdConventionException.ErrorCode);
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddRuleDescriptors_DuplicateIdInBatch_RejectsAtomically()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddRuleDescriptors(Arr(
+                @"[ { ""id"": ""NOVEL-a"" }, { ""id"": ""NOVEL-a"" } ]"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Appended.Should().Be(0);
+            report.Rejected.Should().ContainSingle().Which.Index.Should().Be(1);
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddRuleDescriptors_DuplicateOfPriorlyAppendedId_IsRejected()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            context.AddRuleDescriptors(Obj(@"{ ""id"": ""NOVEL-a"" }")).Succeeded.Should().BeTrue();
+
+            EmitReport report = context.AddRuleDescriptors(Obj(@"{ ""id"": ""NOVEL-a"" }"));
+
+            report.Succeeded.Should().BeFalse();
+            report.Rejected.Should().ContainSingle()
+                .Which.Message.Should().Contain("already present");
+            sink.Events.Count(e => e.Kind == SarifEventKinds.RuleDescriptor).Should().Be(1);
+        }
+
+        [Fact]
+        public void AddResults_ScalarPayload_IsWholePayloadRejection()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            EmitReport report = context.AddResults(JToken.Parse("42"));
+
+            report.Succeeded.Should().BeFalse();
+            report.PayloadError.Should().NotBeNull();
+            report.Rejected.Should().BeEmpty();
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ResolveToLog_MaterializesAppendedEventsIntoSingleRun()
+        {
+            var sink = new InMemoryEmitSink();
+            var context = new RunEmitContext(sink);
+
+            context.SetRunHeader(Obj(@"{ ""tool"": { ""driver"": { ""name"": ""demo"" } } }"));
+            context.AddResults(Obj(
+                @"{ ""ruleId"": ""CWE-89/sql-injection"", ""message"": { ""text"": ""sql injection"" } }"))
+                .Succeeded.Should().BeTrue();
+
+            SarifLog log = context.ResolveToLog();
+
+            log.Runs.Should().ContainSingle();
+            log.Runs[0].Tool.Driver.Name.Should().Be("demo");
+            log.Runs[0].Results.Should().ContainSingle();
+        }
+
+        private static JObject Obj(string json) => (JObject)JToken.Parse(json);
+
+        private static JArray Arr(string json) => (JArray)JToken.Parse(json);
+    }
+}

--- a/src/build.props
+++ b/src/build.props
@@ -13,7 +13,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.0.10</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## Summary

Lift the validated `add-*` emit pipeline out of the CLI command layer into a public in-memory C# API, so a .NET producer can author SARIF event logs in-process with no per-call process spawn. The CLI verbs become thin shells over the new surface; behavior is identical.

This is **Phase 1** of the in-memory emit work. It is the keystone the rest builds on (see Roadmap).

## Motivation

The `add-*` verbs were the only way to drive the event-log pipeline. Each call crossed a process boundary, so a producer emitting a large result set paid a spawn per call — batching amortizes that but doesn't remove the boundary. Worse, the validation that gives the verbs their value — the AI ruleId convention (`AI1012`), the `NOVEL-` rule grammar, descriptor duplicate detection, the invocation receipt gate and the single-vs-batch `endTimeUtc` rule — was welded to the command classes with no in-process entry point. A .NET producer had to shell out or re-implement the gates.

## What changed

New public surface in `Microsoft.CodeAnalysis.Sarif.Emit`:

| Type | Role |
| --- | --- |
| `IEmitSink` | Append destination abstraction (`Append` + `ReadAll`). |
| `FileEmitSink` | Durable, crash-safe, resumable `*.wip.jsonl` sink. |
| `InMemoryEmitSink` | Resident `List<SarifEvent>` sink — fast/short runs, no file. |
| `EmitElementError` / `EmitReport` | Outcome as a value: `Appended`, `Rejected`, `PayloadError`, `Succeeded`. |
| `RunEmitContext` | `AddResults` / `AddInvocations` / `AddRuleDescriptors` / `AddNotificationDescriptors` over an `IEmitSink`, plus `SetRunHeader` and `ResolveToLog`. |

The validators move into `RunEmitContext` verbatim. Results stay index-free (`ruleId`, never `ruleIndex`) so a run remains a self-contained shard whose indices are re-derived at resolution — the property the multi-run finalize (Phase 2) will lean on.

The CLI verbs are now thin shells: `EmitBatchProcessor` resolves the wip path, reads the JSON payload (file or stdin), drives a `RunEmitContext` over a `FileEmitSink`, and maps the `EmitReport` to the existing stdout-report / stderr / exit-code contract. A whole-payload rejection (`PayloadError`) routes to stderr; per-element rejections render byte-identically to the existing stdout report. `AddResultsCommand`, `AddInvocationsCommand`, and `ReportingDescriptorEmitter` are one-line delegations.

## Verification

- **216** existing emit/`add-*`/descriptor tests pass unchanged → CLI behavior is identical.
- **12** new `RunEmitContextTests` exercise the API directly over an `InMemoryEmitSink`: happy single/array, atomic reject (incl. invalid Nth element), `endTimeUtc` single-stamp vs batch-reject, descriptor NOVEL accept / non-NOVEL reject / intra-batch dup / prior-append dup, scalar-payload `PayloadError`, and `ResolveToLog` round-trip.
- Strict Release build (`GenerateDocumentationFile` + `EnforceCodeStyleInBuild`) clean — no IDE0005.

## Roadmap (not in this PR)

- **Phase 2 — `SarifEmitSession`**: a parent owning N ordered `RunEmitContext`s + the log envelope, with `Finalize()` (in-memory) and `FinalizeToFile()` as a streaming byte-splice of compact per-run blobs (isolate-by-default taxonomies). The run-as-shard isolation makes multi-run finalize a near-trivial concat.
- Sharded sink + intra-run parallelism build on `IEmitSink`.

## Release

Targets **v5.1.0** (new public API → minor bump). The 5.1.0 cycle will also carry the SARIF → flat-rows projection verb (#3024); that lands as a separate PR under the same version section.

---

_[This comment authored with Copilot]_
