### PR TITLE
Enforce code style in Release builds via build.props

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -6,6 +6,7 @@
     <AnalysisMode>Default</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild Condition=" '$(Configuration)' == 'Release' ">true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
## What

Set `EnforceCodeStyleInBuild=true` for **Release** builds in `src/build.props`, so any Release build — `dotnet build -c Release`, a single-project Release build, or an IDE build configured for Release — enforces the same code-style analyzers (IDE0005 et al.) that CI does.

## Why

CI runs `pwsh ./scripts/BuildAndTest.ps1 -NoFormat`, and `BuildAndTest.ps1` builds the solution with `--configuration Release ... /p:EnforceCodeStyleInBuild=true`. That `/p:` flag — which promotes diagnostics like **IDE0005** ("unnecessary using directive") to build errors — lived **only** on the script's command line, not in the project files.

The consequence: a plain `dotnet build` (especially Debug, single-project — the common inner-loop and the usual "let me verify this compiles" command) does **not** enforce code style, so style violations sail through locally and only fail in CI. This has bitten multiple recent PRs with IDE0005 errors that were invisible until the CI leg ran.

Moving the flag into `build.props` makes every Release build authoritative without anyone needing to remember the `/p:` switch or run the full build script.

## Why Release-only (not unconditional)

Enabling the flag **unconditionally** (Debug too) is not free today: a Debug full-solution build surfaces **14 pre-existing** `IDE0060` / `IDE0007` / `IDE0008` violations in `Sarif.csproj` alone (Debug compiles `DEBUG;CODE_ANALYSIS` paths and applies stricter analysis than the Release legs CI runs). Cleaning those is a separate, larger change.

Scoping to `Configuration == Release` mirrors CI exactly: CI builds Release, so this introduces **zero** new breakage while closing the local/CI gap. Verified: `dotnet build src\Sarif.Sdk.sln -c Release` is clean with this change.

A follow-up could clean the 14 Debug-only style issues and then drop the condition to enforce on every build; tracked separately.

## Notes

- No behavior change to shipped assemblies; build-time analysis only.
- `BuildAndTest.ps1` continues to pass the flag explicitly (now redundant on the Release path, still correct).
- No release note (build-infrastructure change, no consumer-facing surface).

_[This comment authored with Copilot]_
