### PR TITLE
Ship empty TypeScript npm shells to main as v5.1.1 (npm publish-path proof)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,10 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.1.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.1.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.1.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.1.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.1.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.1.1)
+* NEW: Add the empty `@microsoft/sarif` and `@microsoft/sarif-multitool-ts` npm package shells as a publish-path proof ahead of the native-TypeScript SARIF SDK port; `scripts/BuildSarifTsForNpm.ps1` builds and stages them.
+* FUN: The `ado-build.yml` pipeline builds the TypeScript npm packages on every successful build.
+
 ## **v5.1.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.1.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.1.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.1.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.1.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.1.0)
 * BRK: Rename the four `add-*` emit verbs to the `emit-` prefix, dropping the `-reporting-` segment: `emit-results`, `emit-invocations`, `emit-rule-descriptors`, `emit-notification-descriptors`. The old names still work with a stderr deprecation and are removed in v6; `get-schema` keys follow.
 * NEW: `RunEmitContext` runs the `add-*` emit pipeline in-process over a pluggable `IEmitSink` (`FileEmitSink`/`InMemoryEmitSink`): `AddResults`/`AddInvocations`/`AddRuleDescriptors`/`AddNotificationDescriptors` validate atomically and return an `EmitReport`, with no process spawn per call.

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -47,3 +47,15 @@ jobs:
         inputs:
           targetType: filePath
           filePath: ./scripts/BuildMultitoolForNpm.ps1
+
+      - task: NodeTool@0
+        displayName: Use Node.js LTS
+        inputs:
+          versionSpec: "20.x"
+
+      # Build @microsoft/sarif and @microsoft/sarif-multitool-ts for npm
+      - task: PowerShell@2
+        displayName: Build Sarif TS for npm
+        inputs:
+          targetType: filePath
+          filePath: ./scripts/BuildSarifTsForNpm.ps1

--- a/npm/sarif-multitool-ts/.gitignore
+++ b/npm/sarif-multitool-ts/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+assets/
+schemas/
+skills/
+*.tsbuildinfo

--- a/npm/sarif-multitool-ts/README.md
+++ b/npm/sarif-multitool-ts/README.md
@@ -1,0 +1,17 @@
+# @microsoft/sarif-multitool-ts
+
+Native-TypeScript SARIF Multitool verbs (`emit-*`, `get-*`, `validate`).
+In-process library + arg-compatible `sarif` CLI. No CLR dependency.
+
+> **v0.0.x is a placeholder** that reserves the package name and proves the
+> publish pipeline. Every verb currently throws / exits with a pointer to
+> `@microsoft/sarif-multitool` (the .NET-backed wrapper). The TypeScript
+> implementation lands in a subsequent release; track progress at
+> https://github.com/microsoft/sarif-sdk.
+
+Depends on [`@microsoft/sarif`](https://www.npmjs.com/package/@microsoft/sarif)
+for the open-typed object model and core helpers.
+
+## License
+
+MIT

--- a/npm/sarif-multitool-ts/package-lock.json
+++ b/npm/sarif-multitool-ts/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "@microsoft/sarif-multitool-ts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@microsoft/sarif-multitool-ts",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/sarif": "file:../sarif"
+      },
+      "bin": {
+        "sarif": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../sarif": {
+      "name": "@microsoft/sarif",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@microsoft/sarif": {
+      "resolved": "../sarif",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/npm/sarif-multitool-ts/package.json
+++ b/npm/sarif-multitool-ts/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@microsoft/sarif-multitool-ts",
+  "version": "0.0.0",
+  "description": "Native-TypeScript SARIF Multitool verbs (emit-*, get-*, validate). In-process library + arg-compatible CLI; no CLR dependency.",
+  "author": "Microsoft",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/sarif-sdk",
+    "directory": "npm/sarif-multitool-ts"
+  },
+  "keywords": ["sarif", "static-analysis", "security", "multitool"],
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "sarif": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./schemas/*": "./schemas/*",
+    "./skills/*": "./skills/*"
+  },
+  "files": [
+    "dist/",
+    "schemas/",
+    "skills/",
+    "assets/",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@microsoft/sarif": "file:../sarif"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/npm/sarif-multitool-ts/src/cli.ts
+++ b/npm/sarif-multitool-ts/src/cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import process from 'node:process';
+
+const verb = process.argv[2] ?? '';
+
+process.stderr.write(
+  `@microsoft/sarif-multitool-ts v0.0.x placeholder — '${verb || '<verb>'}' is not yet implemented.\n` +
+    `Use the .NET-backed wrapper instead:\n` +
+    `  npx @microsoft/sarif-multitool ${process.argv.slice(2).join(' ')}\n` +
+    `Track progress at https://github.com/microsoft/sarif-sdk.\n`,
+);
+process.exit(1);

--- a/npm/sarif-multitool-ts/src/index.ts
+++ b/npm/sarif-multitool-ts/src/index.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * @microsoft/sarif-multitool-ts — native-TypeScript SARIF Multitool verbs.
+ *
+ * v0.0.x PLACEHOLDER. This release reserves the package name and proves the
+ * publish pipeline; the verb implementations (emit-run, emit-results,
+ * emit-invocations, emit-rule-descriptors, emit-notification-descriptors,
+ * emit-finalize, get-schema, get-skill, get-cwe, validate) land in a
+ * subsequent release tracked at https://github.com/microsoft/sarif-sdk.
+ *
+ * Until then, use `@microsoft/sarif-multitool` (the .NET-backed wrapper).
+ */
+
+export * from '@microsoft/sarif';
+
+function notYetImplemented(verb: string): never {
+  throw new Error(
+    `@microsoft/sarif-multitool-ts: '${verb}' is not yet implemented in this v0.0.x ` +
+      `placeholder release. Use \`npx @microsoft/sarif-multitool ${verb}\` (the .NET-backed ` +
+      `wrapper) until the TypeScript implementation ships. ` +
+      `Track progress at https://github.com/microsoft/sarif-sdk.`,
+  );
+}
+
+export const emitRun = () => notYetImplemented('emit-run');
+export const emitResults = () => notYetImplemented('emit-results');
+export const emitInvocations = () => notYetImplemented('emit-invocations');
+export const emitRuleDescriptors = () => notYetImplemented('emit-rule-descriptors');
+export const emitNotificationDescriptors = () => notYetImplemented('emit-notification-descriptors');
+export const emitFinalize = () => notYetImplemented('emit-finalize');
+export const getSchema = () => notYetImplemented('get-schema');
+export const getSkill = () => notYetImplemented('get-skill');
+export const getCwe = () => notYetImplemented('get-cwe');
+export const validate = () => notYetImplemented('validate');

--- a/npm/sarif-multitool-ts/tsconfig.json
+++ b/npm/sarif-multitool-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/npm/sarif/.gitignore
+++ b/npm/sarif/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/npm/sarif/README.md
+++ b/npm/sarif/README.md
@@ -1,0 +1,15 @@
+# @microsoft/sarif
+
+SARIF SDK for Node.js — native-TypeScript open-typed object model, region/snippet
+resolution, AI ruleId convention, and serialization helpers. No CLR dependency.
+
+> **v0.0.x is a placeholder** that reserves the package name and proves the
+> publish pipeline. The implementation lands in a subsequent release; track
+> progress at https://github.com/microsoft/sarif-sdk.
+
+This is the base package. For the multitool verbs (`emit-*`, `get-*`,
+`validate`) see [`@microsoft/sarif-multitool-ts`](https://www.npmjs.com/package/@microsoft/sarif-multitool-ts).
+
+## License
+
+MIT

--- a/npm/sarif/package-lock.json
+++ b/npm/sarif/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@microsoft/sarif",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@microsoft/sarif",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/npm/sarif/package.json
+++ b/npm/sarif/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@microsoft/sarif",
+  "version": "0.0.0",
+  "description": "SARIF SDK for Node.js: open-typed object model, region/snippet resolution, AI ruleId convention, and serialization helpers. Native TypeScript; no CLR dependency.",
+  "author": "Microsoft",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/sarif-sdk",
+    "directory": "npm/sarif"
+  },
+  "keywords": ["sarif", "static-analysis", "security"],
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/npm/sarif/src/index.ts
+++ b/npm/sarif/src/index.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * @microsoft/sarif — SARIF SDK for Node.js.
+ *
+ * v0.0.x PLACEHOLDER. This release reserves the package name and proves the
+ * publish pipeline; the implementation (open-typed SARIF object model,
+ * FileRegionsCache, AIRuleIdConvention, serialization helpers) lands in a
+ * subsequent release tracked at https://github.com/microsoft/sarif-sdk.
+ */
+
+export const SARIF_SCHEMA_URI =
+  'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/csd01/schemas/sarif-schema-2.1.0.json';

--- a/npm/sarif/tsconfig.json
+++ b/npm/sarif/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/scripts/BuildSarifTsForNpm.ps1
+++ b/scripts/BuildSarifTsForNpm.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Build and stage the @microsoft/sarif and @microsoft/sarif-multitool-ts npm packages.
+.DESCRIPTION
+    Compiles both TypeScript packages, copies them to bld/Publish/npm-ts/, stamps the
+    {version} and {version-range} placeholders, and runs `npm pack` so each is ready for
+    `npm publish --access public`. Mirrors BuildMultitoolForNpm.ps1's stage-then-publish
+    pattern for the .NET-backed sarif-multitool packages.
+.PARAMETER Version
+    The version to stamp into both package.json files. Defaults to the SDK package
+    version from Get-PackageVersion (so released packages lock-step with the .NET SDK).
+    For the v0.0.x publish-pipeline proof, pass -Version 0.0.1.
+#>
+
+[CmdletBinding()]
+param(
+    [string]
+    $Version
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-PackageVersion
+}
+Write-Information "Stamping version $Version."
+
+# Build order matters: @microsoft/sarif-multitool-ts compiles against @microsoft/sarif's
+# source via a tsconfig path mapping, but at publish time it depends on the built dist/.
+$packages = @("sarif", "sarif-multitool-ts")
+$npmSourceFolder = "$RepoRoot\npm"
+$npmBuildFolder  = "$BuildRoot\Publish\npm-ts"
+
+Remove-DirectorySafely $npmBuildFolder
+New-DirectorySafely $npmBuildFolder
+
+foreach ($pkg in $packages) {
+    $src = Join-Path $npmSourceFolder $pkg
+    Write-Information "Building $pkg..."
+    Push-Location $src
+    try {
+        npm install --no-audit --no-fund
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed for $pkg (exit $LASTEXITCODE)." }
+        npm run build
+        if ($LASTEXITCODE -ne 0) { throw "npm run build failed for $pkg (exit $LASTEXITCODE)." }
+    }
+    finally { Pop-Location }
+}
+
+Write-Information "Staging packages to $npmBuildFolder..."
+foreach ($pkg in $packages) {
+    $src = Join-Path $npmSourceFolder $pkg
+    $dst = Join-Path $npmBuildFolder $pkg
+    New-DirectorySafely $dst
+    # Copy only what `files` in package.json declares plus the manifest itself; npm pack
+    # would do this too, but staging a clean folder makes the placeholder stamping safe.
+    Copy-Item -Force "$src\package.json" -Destination $dst
+    Copy-Item -Force "$src\README.md"    -Destination $dst
+    Copy-Item -Force -Recurse "$src\dist" -Destination $dst
+    foreach ($assetDir in @("schemas", "skills", "assets")) {
+        if (Test-Path "$src\$assetDir") {
+            Copy-Item -Force -Recurse "$src\$assetDir" -Destination $dst
+        }
+    }
+}
+
+Write-Information "Injecting version $Version and rewriting local dependency range..."
+foreach ($pkg in $packages) {
+    $manifest = Join-Path $npmBuildFolder "$pkg\package.json"
+    # Source manifests carry "version": "0.0.0" so `npm install` in-source sees valid
+    # semver; the publish stage stamps the real version. Targeted replace so any other
+    # 0.0.0 occurrence (none today) is left alone.
+    Find-AndReplaceInFile $manifest '"version": "0.0.0"' "`"version`": `"$Version`""
+    # @microsoft/sarif-multitool-ts depends on @microsoft/sarif via "file:../sarif" in
+    # source so local `npm install` resolves it without an npm registry round-trip; the
+    # publish stage rewrites that to a caret range on the same SDK version.
+    Find-AndReplaceInFile $manifest '"file:../sarif"' "`"^$Version`""
+}
+
+Write-Information "Running npm pack (dry verification of package contents)..."
+foreach ($pkg in $packages) {
+    Push-Location (Join-Path $npmBuildFolder $pkg)
+    try {
+        npm pack
+        if ($LASTEXITCODE -ne 0) { throw "npm pack failed for $pkg (exit $LASTEXITCODE)." }
+    }
+    finally { Pop-Location }
+}
+
+# To Publish:
+# from [sarif-sdk]\bld\Publish\npm-ts, for each package folder, run:
+#   npm login   (Once; need a token from npmjs.com with @microsoft scope publish rights)
+#   npm publish --access public
+#
+# Publish @microsoft/sarif FIRST so @microsoft/sarif-multitool-ts's dependency resolves.
+# For the initial v0.0.x pipeline proof, run this script with -Version 0.0.1.
+
+Write-Information "$ScriptName SUCCEEDED. Tarballs staged under $npmBuildFolder."

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>5.1.1</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## What

Forward-ports the **empty** `@microsoft/sarif` and `@microsoft/sarif-multitool-ts` npm package shells (merged to `dev` in #3036) to `main` as **v5.1.1**, so we can exercise the npm publish path end-to-end *before* the real TypeScript implementation lands.

## Why a main-based branch (not raw dev→main)

`main` is content-identical to `dev` at 5.1.0 except for the 15 TS-shell files — the true incremental. A raw `dev`→`main` PR would render a noisy **132-file three-dot diff** that re-displays all of 5.1.0, an artifact of the squash merge that shipped 5.1.0 (`dev` never pulled the squash commit back, so the merge-base is pre-5.1.0). Branching off `main` keeps this PR to the genuine delta.

## Changes

- **15 TS-shell files** brought over verbatim from `dev` (packages, `tsconfig`, `BuildSarifTsForNpm.ps1`, `ado-build.yml` build wiring).
- **`publishConfig.access=public`** added to both scoped `package.json`. Scoped npm packages default to *restricted*, and release def 135's `Npm@1` publish task passes no `--access` flag — without this the pipeline publish **402-fails**.
- **Version** `5.1.0` → `5.1.1`.
- **ReleaseHistory.md** v5.1.1 section (bullets 222/97 chars, under the 300 cap).

## Publishing note

The empty TS packages are versioned **independently** of the SDK. Publish them with `-Version 0.0.1` — do **not** stamp them 5.1.1 (that would burn the real version on an empty package).

## Still required to actually publish (not in this PR)

Release def **135** (`microsoft.sarif-sdk.release`) `npm` stage currently builds/publishes only the multitool packages. To publish these TS packages it needs (a) a `NodeTool` + `BuildSarifTsForNpm.ps1` task, and (b) two `Npm@1 publish` tasks (`bld/Publish/npm-ts/sarif` then `…/sarif-multitool-ts`, sarif first). That release-pipeline edit is tracked separately.
