### PR TITLE
Add publishConfig.access=public to the scoped TS npm packages (dev sync)

### DIFF
--- a/npm/sarif-multitool-ts/package.json
+++ b/npm/sarif-multitool-ts/package.json
@@ -34,6 +34,9 @@
     "assets/",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/npm/sarif/package.json
+++ b/npm/sarif/package.json
@@ -26,6 +26,9 @@
     "dist/",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc"
   },


### PR DESCRIPTION
Syncs the `publishConfig.access=public` fix already applied to `main` in the v5.1.1 release PR #3040 back to `dev`.

`@microsoft/sarif` and `@microsoft/sarif-multitool-ts` are **scoped** packages, which npm publishes as *restricted* by default. Release def 135's `Npm@1` publish task passes no `--access` flag, so without this the pipeline publish **402-fails**. This keeps `dev` from carrying the bug forward into the next release.

Tiny: 2 files, +6 lines.
