### PR TITLE
Add Dependabot config targeting dev for npm and NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot configuration.
+#
+# Dependabot always reads this file from the repository's default branch (main),
+# but every update below opens its PRs against `dev` via `target-branch`: dependency
+# bumps land on the integration branch and flow `dev` -> `main` with the rest of the
+# feature work, rather than landing on `main` directly.
+#
+# Minor and patch updates are grouped into a single PR per package directory to keep
+# the queue quiet; major updates still arrive as individual PRs so they get reviewed
+# on their own (e.g. a test-framework major bump that can break the suite).
+version: 2
+updates:
+  # --- npm: native-TypeScript packages ---
+  # Only npm/sarif and npm/sarif-multitool-ts carry real dependencies; the .NET
+  # multitool wrapper packages (sarif-multitool[-win32|-linux|-darwin]) have none.
+  - package-ecosystem: "npm"
+    directory: "/npm/sarif"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/npm/sarif-multitool-ts"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # --- NuGet: the SARIF SDK solution and its projects under /src ---
+  - package-ecosystem: "nuget"
+    directory: "/src"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` (the repo had none). Configures Dependabot for the two ecosystems with real dependencies and points every update at the **`dev`** integration branch.

| ecosystem | directory | target |
|---|---|---|
| npm | `/npm/sarif` | `dev` |
| npm | `/npm/sarif-multitool-ts` | `dev` |
| NuGet | `/src` | `dev` |

Minor/patch bumps are grouped into one PR per directory; majors still arrive individually so they get reviewed on their own.

## Why

With no config, Dependabot defaulted to opening PRs against the default branch (`main`). We want dependency bumps to land on `dev` and flow `dev` → `main` with the rest of the feature work. That also fixes the friction we just hit: manually retargeting Dependabot's main-based PRs to `dev` produced real add/add conflicts (the branches share no ancestry with `dev`'s squash-merged history), and `@dependabot rebase` snapped them back to `main`.

## Note on placement

This file is committed to **`main`** on purpose: Dependabot always reads its configuration from the repository's **default branch**, even though the updates it generates here target `dev`.

## Follow-up

Once merged, `@dependabot recreate` on #3045 will rebuild the `@cucumber/cucumber` 10→13 bump cleanly against `dev`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
