### PR TITLE
Document emit-sarif host-conditional collapse and GHAZDO ingestion gaps

### DIFF
--- a/skills/emit-sarif/SKILL.md
+++ b/skills/emit-sarif/SKILL.md
@@ -103,6 +103,8 @@ The verb validates a small set of profile-essential fields at receipt: `tool.dri
 
 When the `TF_BUILD=True` environment indicates an Azure DevOps pipeline, `emit-run` stamps `automationDetails.id` plus the four `azuredevops/pipeline/build/*` properties required by GHAzDO ingestion. If your JSON supplies any of those fields, the values must match what the env detects, otherwise the verb fails with a conflict diagnostic — pick one source of truth.
 
+Outside a pipeline (`TF_BUILD` unset — a local or non-Azure-DevOps run), `emit-run` stamps neither `automationDetails.id` nor the `azuredevops/pipeline/build/*` properties, so the finalized log **cannot be published to GHAZDO**: it fails the GHAzDO ingestion contract (`GHAzDO1014`/`GHAzDO1019`/`GHAzDO1020`) and [`publish-to-ghazdo`](../publish-to-ghazdo/SKILL.md) refuses it up front. A clean `Sarif;AI` validate does **not** imply publishability — see [`publish-to-ghazdo` Step 3](../publish-to-ghazdo/SKILL.md).
+
 ### Step 2 — Append each result
 
 For each finding, construct a complete SARIF `result` JSON object that conforms to `docs/ai/generating-sarif.md § Result Structure`, then append it:
@@ -174,8 +176,9 @@ What this does:
 2. Runs `InsertOptionalDataVisitor` against the local source root to populate snippets, context regions, and artifact hashes.
 3. Enriches CWE-as-rule-id descriptors from the embedded MITRE CWE taxonomy (omit with `--no-cwe-enrichment` if you've already populated descriptors).
 4. Rewrites `originalUriBaseIds["SRCROOT"]` to a portable, commit-pinned root derived from `versionControlProvenance` (a GitHub blob permalink such as `https://github.com/<org>/<repo>/blob/<sha>/`, or an Azure DevOps repository root) so the published log anchors at a host-independent location.
-5. Embeds text-file artifact contents (`--embed-text-files`). Useful for self-contained AI fixtures and to clear `SARIF2013`.
-6. Runs the validator against the output with `--rule-kind Sarif;AI` (`--validate`). Fails non-zero with a summary if any Error-level findings are reported.
+5. For **GitHub-hosted runs only** (host detected from `versionControlProvenance`), collapses each result's `ruleId` sub-id to its base CWE descriptor id (`CWE-79/dom-xss-via-sanitizer-bypass` → `CWE-79`), keeping `result.rule.id` equal in step, so GitHub code scanning — which binds a result to its rule by `ruleId`-string equality and does not follow hierarchical `ruleIndex` resolution — finds the descriptor and its `security-severity`/tags. **Azure DevOps / GHAZDO-hosted runs keep the authored sub-id intact.** The sub-id carries no descriptor metadata, so nothing classifiable is lost; but it is not relocated either, so if you need the authored sub-classifier to survive finalize on a GitHub-hosted run, park it in a tool-namespaced `result.properties` key (e.g. `myscanner/subId`) — `result.ruleId` is not a durable carrier for it. See [`generating-sarif.md § GitHub-hosted collapse`](../../docs/ai/generating-sarif.md).
+6. Embeds text-file artifact contents (`--embed-text-files`). Useful for self-contained AI fixtures and to clear `SARIF2013`.
+7. Runs the validator against the output with `--rule-kind Sarif;AI` (`--validate`). Fails non-zero with a summary if any Error-level findings are reported. This covers the `Sarif;AI` profile **only — not the GHAzDO ingestion contract.** When your destination is GHAZDO, also validate with `--rule-kind "Sarif;AI;GHAzDO"` to exercise `GHAzDO1014`/`GHAzDO1019`/`GHAzDO1020` offline; a run that is clean under `Sarif;AI` can still be rejected at ingestion (HTTP 400). See [`publish-to-ghazdo` Step 3](../publish-to-ghazdo/SKILL.md).
 
 If `--validate` reports errors, the produced file is on disk but did not meet the profile. Treat this as a generation defect: fix the offending result or notification, regenerate, and re-finalize.
 
@@ -195,7 +198,7 @@ dotnet dnx Sarif.Multitool --yes -- emit-finalize "{{OUTPUT_PATH}}" `
 
 This skill's contract is satisfied when:
 
-1. `emit-finalize --validate` exits with code 0 (no Error-level rule findings under `--rule-kind Sarif;AI`).
+1. `emit-finalize --validate` exits with code 0 (no Error-level rule findings under `--rule-kind Sarif;AI`). This is the `Sarif;AI` profile only; if the destination is GHAZDO, a clean result here is necessary but not sufficient — also run `--rule-kind "Sarif;AI;GHAzDO"` (see Step 5 and [`publish-to-ghazdo` Step 3](../publish-to-ghazdo/SKILL.md)).
 2. The file passes the [validate-sarif skill](../validate-sarif/SKILL.md) at full profile depth.
 3. The file is consumable by the SDK object model (`SarifLog.Load`) without exceptions.
 


### PR DESCRIPTION
## What & why

The `emit-sarif` skill walks a producer through `emit-run` → `emit-results` → `emit-finalize --validate`, but three behaviors that only bite a **GHAZDO**-targeting producer were undocumented in the skill — each surfaces as a late, confusing failure (silent sub-id loss, or an HTTP 400 at ingestion after a clean local validate). This PR closes that gap. Docs-only; no code or behavior change.

Closes #3061, closes #3063, closes #3064.

## Changes (all in `skills/emit-sarif/SKILL.md`)

- **#3061 — sub-id collapse is host-conditional.** Step 5 now states the `result.ruleId` sub-id collapse (`CWE-79/<sub>` → `CWE-79`) fires for **GitHub-hosted runs only**; **Azure DevOps / GHAZDO runs keep the sub-id**. Adds guidance: a sub-classifier that must survive finalize on a GitHub-hosted run belongs in a tool-namespaced `result.properties` key — `result.ruleId` is not a durable carrier. Cross-links `generating-sarif.md § GitHub-hosted collapse` (which already documents this; the skill simply didn't).
- **#3063 — `--validate` ≠ GHAZDO ingestion contract.** Step 5 item 7 and the Validation section now state `--validate` covers `Sarif;AI` only, and recommend `--rule-kind "Sarif;AI;GHAzDO"` (`GHAzDO1014`/`GHAzDO1019`/`GHAzDO1020`) for GHAZDO destinations, cross-linked to `publish-to-ghazdo` Step 3. A clean `Sarif;AI` run can still 400 at ingestion.
- **#3064 — `TF_BUILD` → publishability coupling.** The `TF_BUILD` stamping note now states the consequence: outside a pipeline the `azuredevops/pipeline/build/*` properties and `automationDetails.id` are absent, so the log **cannot be published to GHAZDO** and a clean `Sarif;AI` validate does not imply publishability.

## Verification

- `GetSkillCommandTests` (reads the live `SKILL.md`, exercises relative-link → pinned-permalink rewriting): **20/20 pass**. New relative links (`../publish-to-ghazdo/SKILL.md`, `../../docs/ai/generating-sarif.md`) follow the same pattern the rewrite test already covers.
- "step 4" cross-references elsewhere in the skill still resolve to the unchanged VCP-rewrite item.
