### PR TITLE
Implement emit-finalize --validate in the TypeScript multitool

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.4.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.0)
+* NEW: `emit-finalize --validate` in `@microsoft/sarif-multitool-ts` validates the finalized SARIF against `ai-sarif-log.schema.json` and exits non-zero when the log does not conform.
+
 ## **v5.3.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.3.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.3.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.3.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.3.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.3.1)
 * BRK: `get-schema emit-finalize`'s schema is renamed `ai-log.schema.json` → `ai-sarif-log.schema.json`; update any direct `schemas/ai-log.schema.json` import or `$id` reference.
 * BUG: `get-schema emit-finalize` in `@microsoft/sarif-multitool-ts` serves `ai-sarif-log.schema.json`.

--- a/npm/sarif-multitool-ts/README.md
+++ b/npm/sarif-multitool-ts/README.md
@@ -69,21 +69,40 @@ the contract.
 
 ## Validation
 
-`emit-finalize --validate` is **deferred** in this package. The emit verbs
-perform receipt-time checks only — AI ruleId grammar (`AI1012`), required
-fields, batch atomicity, descriptor-id uniqueness — not the full SARIF/AI
-analyzer rule set.
+`emit-finalize --validate` checks the finalized SARIF against
+`ai-sarif-log.schema.json` — the AI emit profile overlay on the canonical
+SARIF 2.1.0 document schema. Both schemas are bundled, so validation runs
+fully offline. On a conforming log the CLI prints a confirmation and exits 0;
+on a non-conforming log it prints each `instancePath: message` to stderr and
+exits 1. The SARIF file is written either way — validation is a report, not a
+gate on the write.
 
-**If you adopt this package, keep a .NET validation step in your test/CI
-environment** until the AI-content JSON Schema ships:
+```sh
+npx @microsoft/sarif-multitool-ts emit-finalize scan.sarif --validate
+```
+
+Library callers read the verdict off the outcome (or validate an
+already-finalized log directly):
+
+```js
+import { emitFinalize, validateFinalizedLog } from '@microsoft/sarif-multitool-ts';
+
+const { validation } = await emitFinalize({ output: 'scan.sarif', validate: true });
+if (validation && !validation.valid) console.error(validation.errors.join('\n'));
+
+const { valid, errors } = validateFinalizedLog(log);
+```
+
+This is JSON-Schema validation: it enforces the whole-log AI contract —
+required `versionControlProvenance`, `properties[ai/origin]`, the result
+`ruleId` grammar, and the per-run GHAzDO `automationDetails` shape. It does
+**not** run the .NET analyzer rule set; for the full `Sarif;AI` rule pass keep
+a .NET step in your test/CI environment:
 
 ```sh
 dotnet tool install -g Sarif.Multitool   # once
 sarif validate --rule-kind "Sarif;AI" scan.sarif
 ```
-
-This is a **test-time-only** dependency — no CLR in your production path —
-and is the backstop that catches anything the sparse port lets through.
 
 ## Schemas
 
@@ -119,7 +138,7 @@ drift gate (`npm run test:conformance`).
 
 | Gap | Effect | Workaround |
 |---|---|---|
-| `--validate` | Stubbed (see above) | `.NET sarif validate` in CI |
+| `--validate` (analyzer rules) | TS `--validate` is JSON-Schema only — it does not run the full `Sarif;AI` analyzer rule set | `.NET sarif validate --rule-kind "Sarif;AI"` for the full rule pass |
 | `--embed-text-files` | Source bytes not inlined in artifacts | Run `.NET emit-finalize` with the flag if you need self-contained fixtures |
 
 ## Behavioral parity

--- a/npm/sarif-multitool-ts/features/emit-finalize-validate.feature
+++ b/npm/sarif-multitool-ts/features/emit-finalize-validate.feature
@@ -1,0 +1,21 @@
+Feature: emit-finalize --validate checks the finalized log against the AI whole-log schema
+
+  As an AI producer finalizing a SARIF log
+  I want emit-finalize to validate its output against ai-sarif-log.schema.json
+  So that an AI-profile violation is caught at finalize time, not downstream
+
+  Background:
+    Given a clean working directory
+
+  Scenario: A conformant finalized run validates clean
+    Given an open event log for tool "ai-scanner" with a GitHub source root, VCP, and ai/origin "generated"
+    When emit-results is invoked with a conformant AI result at "src/app.ts" line 1 with ruleId "CWE-79/dom-xss"
+    And emit-finalize is invoked with validation
+    Then the finalized SARIF conforms to the AI whole-log schema
+
+  Scenario: A run missing its ai/origin is reported as non-conformant
+    Given an open event log for tool "ai-scanner" with a GitHub source root and VCP
+    When emit-results is invoked with a result at "src/app.ts" line 1 with ruleId "CWE-79/dom-xss"
+    And emit-finalize is invoked with validation
+    Then the finalized SARIF does not conform to the AI whole-log schema
+    And a validation error mentions "properties"

--- a/npm/sarif-multitool-ts/features/steps/steps.mjs
+++ b/npm/sarif-multitool-ts/features/steps/steps.mjs
@@ -96,6 +96,17 @@ Given(
 );
 
 Given(
+  'an open event log for tool {string} with a GitHub source root, VCP, and ai\\/origin {string}',
+  async function (name, origin) {
+    if (!this.tmp) this.init();
+    this.runHeader = this.finalizableRunHeader(true);
+    this.runHeader.tool.driver.name = name;
+    this.runHeader.properties = { 'ai/origin': origin };
+    await emitRun({ output: this.output, run: this.runHeader, env: this.env });
+  },
+);
+
+Given(
   'an open event log for tool {string} with a source root but no VCP',
   async function (name) {
     if (!this.tmp) this.init();
@@ -194,6 +205,18 @@ When(
     this.lastOutcome = await emitResults({
       output: this.output,
       results: makeResult(ruleId, relPath, line),
+    });
+  },
+);
+
+When(
+  'emit-results is invoked with a conformant AI result at {string} line {int} with ruleId {string}',
+  async function (relPath, line, ruleId) {
+    this.lastOutcome = await emitResults({
+      output: this.output,
+      results: makeResult(ruleId, relPath, line, {
+        message: { text: 'finding', markdown: '**finding**' },
+      }),
     });
   },
 );
@@ -300,6 +323,12 @@ When('emit-finalize is invoked', async function () {
   this.finalizedLog = r.log;
 });
 
+When('emit-finalize is invoked with validation', async function () {
+  const r = await emitFinalize({ output: this.output, keepWip: true, validate: true });
+  this.finalizedLog = r.log;
+  this.validation = r.validation;
+});
+
 When('emit-finalize is invoked expecting failure', async function () {
   try {
     await emitFinalize({ output: this.output, keepWip: true });
@@ -390,6 +419,29 @@ Then('the replayed invocation {int} field {string} equals {string}', function (i
 function finalizedRun(world) {
   return world.finalizedLog.runs[0];
 }
+
+Then('the finalized SARIF conforms to the AI whole-log schema', function () {
+  assert.ok(this.validation, 'emit-finalize was not invoked with validation');
+  assert.ok(
+    this.validation.valid,
+    `expected conformance but got errors:\n  ${this.validation.errors.join('\n  ')}`,
+  );
+  assert.deepEqual(this.validation.errors, []);
+});
+
+Then('the finalized SARIF does not conform to the AI whole-log schema', function () {
+  assert.ok(this.validation, 'emit-finalize was not invoked with validation');
+  assert.equal(this.validation.valid, false, 'expected a non-conformant log');
+  assert.ok(this.validation.errors.length > 0, 'expected at least one validation error');
+});
+
+Then('a validation error mentions {string}', function (fragment) {
+  assert.ok(this.validation, 'emit-finalize was not invoked with validation');
+  assert.ok(
+    this.validation.errors.some((e) => e.includes(fragment)),
+    `no validation error mentions '${fragment}':\n  ${this.validation.errors.join('\n  ')}`,
+  );
+});
 
 Then('the finalized SARIF result {int} field {string} equals {string}', function (i, path, expected) {
   assert.equal(get(finalizedRun(this).results[i], path), expected);

--- a/npm/sarif-multitool-ts/features/steps/world.mjs
+++ b/npm/sarif-multitool-ts/features/steps/world.mjs
@@ -22,6 +22,7 @@ class EmitWorld {
     this.lastError = undefined;
     this.replayedLog = undefined;
     this.finalizedLog = undefined;
+    this.validation = undefined;
     /** Test seam: env getter for CI-context detection. Default = no CI. */
     this.env = () => undefined;
   }

--- a/npm/sarif-multitool-ts/package-lock.json
+++ b/npm/sarif-multitool-ts/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/sarif": "file:../sarif"
+        "@microsoft/sarif": "file:../sarif",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1"
       },
       "bin": {
         "sarif": "dist/cli.js"
@@ -28,7 +30,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.14.0",
+        "@types/node": "^26.0.0",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -332,6 +334,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -441,6 +476,28 @@
       "dependencies": {
         "stackframe": "^1.3.4"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -623,6 +680,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/knuth-shuffle-seeded": {
@@ -858,6 +921,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/seed-random": {

--- a/npm/sarif-multitool-ts/package.json
+++ b/npm/sarif-multitool-ts/package.json
@@ -9,7 +9,12 @@
     "url": "https://github.com/microsoft/sarif-sdk",
     "directory": "npm/sarif-multitool-ts"
   },
-  "keywords": ["sarif", "static-analysis", "security", "multitool"],
+  "keywords": [
+    "sarif",
+    "static-analysis",
+    "security",
+    "multitool"
+  ],
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -41,11 +46,14 @@
     "prebuild": "node scripts/copy-assets.mjs",
     "build": "tsc",
     "test": "npm run build && cucumber-js",
+    "test:unit": "npm run build && node --test test/validate.test.js",
     "test:conformance": "npm run build && node --test test/conformance.test.js",
     "test:memory": "npm run build && node --expose-gc test/memory-smoke.js"
   },
   "dependencies": {
-    "@microsoft/sarif": "file:../sarif"
+    "@microsoft/sarif": "file:../sarif",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^13.0.0",

--- a/npm/sarif-multitool-ts/scripts/copy-assets.mjs
+++ b/npm/sarif-multitool-ts/scripts/copy-assets.mjs
@@ -22,6 +22,17 @@ function cp(src, dstDir, dstName) {
 cp(join(repo, 'src/Sarif/Taxonomies/CweTaxonomy.sarif'), join(pkg, 'assets'));
 cp(join(repo, 'src/Sarif/Taxonomies/CweSecuritySeverity.json'), join(pkg, 'assets'));
 
+// Canonical SARIF 2.1.0 document schema, bundled for offline whole-log
+// validation (emit-finalize --validate resolves the ai-sarif-log overlay's
+// $ref to it). It lives under assets/, not schemas/: schemas/ is the
+// verb-addressable set, and a non-verb schema there would fail the get-schema
+// parity gate.
+cp(
+  join(repo, 'src/Sarif/Schemata/sarif-2.1.0-rtm.6.json'),
+  join(pkg, 'assets'),
+  'sarif-2.1.0.schema.json',
+);
+
 // Emit-verb input schemas.
 const schemaSrc = join(repo, 'src/Sarif.Multitool.Library/GetSchema');
 for (const f of readdirSync(schemaSrc)) {

--- a/npm/sarif-multitool-ts/src/cli.ts
+++ b/npm/sarif-multitool-ts/src/cli.ts
@@ -207,6 +207,10 @@ async function main(): Promise<number> {
           for (const e of r.validation.errors) process.stderr.write(`  ${e}\n`);
           return 1;
         }
+      } else {
+        process.stdout.write(
+          'Validation: not run. Pass --validate to check the finalized SARIF against ai-sarif-log.schema.json.\n',
+        );
       }
       return 0;
     }

--- a/npm/sarif-multitool-ts/src/cli.ts
+++ b/npm/sarif-multitool-ts/src/cli.ts
@@ -8,7 +8,7 @@
  * emit-* / get-* subset. Verbs not yet ported print a redirect to
  * @microsoft/sarif-multitool (the .NET wrapper).
  *
- * Zero runtime dependencies — argv is parsed by hand.
+ * Argv is parsed by hand — no command-line framework.
  */
 
 import { readFileSync } from 'node:fs';
@@ -197,6 +197,17 @@ async function main(): Promise<number> {
       process.stdout.write(
         `Wrote '${r.outputPath}' (${r.resultCount} result(s), ${r.ruleCount} rule(s)).\n`,
       );
+      if (r.validation) {
+        if (r.validation.valid) {
+          process.stdout.write('Validation: conforms to ai-sarif-log.schema.json.\n');
+        } else {
+          process.stderr.write(
+            `Validation: does not conform to ai-sarif-log.schema.json (${r.validation.errors.length} error(s)):\n`,
+          );
+          for (const e of r.validation.errors) process.stderr.write(`  ${e}\n`);
+          return 1;
+        }
+      }
       return 0;
     }
 

--- a/npm/sarif-multitool-ts/src/emitFinalize.ts
+++ b/npm/sarif-multitool-ts/src/emitFinalize.ts
@@ -8,8 +8,9 @@
  *
  * Ported from src/Sarif.Multitool.Library/Emit/EmitFinalizeCommand.cs.
  *
- * `--validate` is DEFERRED in this package — it returns a notice pointing at
- * the .NET `sarif validate` verb. See README#Validation.
+ * With `--validate`, the finalized log is checked against
+ * `ai-sarif-log.schema.json` and the verdict is carried on the outcome's
+ * `validation` field. See README#Validation.
  */
 
 import { promises as fs } from 'node:fs';
@@ -30,6 +31,7 @@ import {
   collapseResultRuleSubIds,
 } from './cwe.js';
 import { rebaseRun } from './rebase.js';
+import { validateFinalizedLog, type ValidationOutcome } from './validate.js';
 
 export interface EmitFinalizeOptions {
   /** Final SARIF file path. The event log is read from `<output>.wip.jsonl`. */
@@ -41,9 +43,9 @@ export interface EmitFinalizeOptions {
   /** Keep the .wip.jsonl after a successful finalize (default: delete). */
   keepWip?: boolean;
   /**
-   * DEFERRED. The .NET tool runs the SARIF+AI analyzer rule set; this package
-   * emits a deferral notice instead. Run `sarif validate --rule-kind "Sarif;AI"`
-   * in your test/CI environment as the backstop.
+   * Validate the finalized log against `ai-sarif-log.schema.json` (the AI
+   * whole-log contract) and report the verdict on `outcome.validation`. The
+   * SARIF file is written regardless; validation is a report, not a gate.
    */
   validate?: boolean;
 }
@@ -54,10 +56,13 @@ export interface EmitFinalizeOutcome {
   ruleCount: number;
   warnings: string[];
   log: SarifLog;
+  /** Present only when `validate` was requested. */
+  validation?: ValidationOutcome;
 }
 
 export async function emitFinalize(opts: EmitFinalizeOptions): Promise<EmitFinalizeOutcome> {
   const warnings: string[] = [];
+  let validation: ValidationOutcome | undefined;
 
   const wipPath = resolveWipPath(opts.output);
   const outputPath = resolvePath(opts.output);
@@ -128,13 +133,8 @@ export async function emitFinalize(opts: EmitFinalizeOptions): Promise<EmitFinal
   }
 
   if (opts.validate) {
-    warnings.push(
-      '--validate is not implemented in @microsoft/sarif-multitool-ts. The output SARIF was written successfully; ' +
-        'run the .NET multitool `sarif validate --rule-kind "Sarif;AI" ' +
-        outputPath +
-        '` in your test/CI environment as the validation backstop. See README#Validation.',
-    );
+    validation = validateFinalizedLog(log);
   }
 
-  return { outputPath, resultCount, ruleCount, warnings, log };
+  return { outputPath, resultCount, ruleCount, warnings, log, validation };
 }

--- a/npm/sarif-multitool-ts/src/index.ts
+++ b/npm/sarif-multitool-ts/src/index.ts
@@ -28,6 +28,7 @@ export {
   type AddReportingDescriptorsOptions as EmitDescriptorsOptions,
 } from './addReportingDescriptors.js';
 export { emitFinalize, type EmitFinalizeOptions, type EmitFinalizeOutcome } from './emitFinalize.js';
+export { validateFinalizedLog, type ValidationOutcome } from './validate.js';
 
 // get-* verbs.
 export { getSchema, listSchemas, SchemaByVerb } from './getSchema.js';

--- a/npm/sarif-multitool-ts/src/validate.ts
+++ b/npm/sarif-multitool-ts/src/validate.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Whole-log JSON Schema validation for the SARIF that `emit-finalize` writes.
+ * Validates against `ai-sarif-log.schema.json` (draft 2020-12) — the AI emit
+ * profile overlay on the canonical SARIF 2.1.0 document schema. The overlay
+ * `$ref`s the full SARIF 2.1.0 schema by its schemastore `$id`; the base schema
+ * is bundled under assets/ and registered under that id so validation runs
+ * fully offline.
+ */
+
+import { readFileSync } from 'node:fs';
+import type { SarifLog } from '@microsoft/sarif';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import type { ErrorObject, ValidateFunction } from 'ajv';
+import _addFormats from 'ajv-formats';
+import { assetPath } from './assets.js';
+import { getSchema } from './getSchema.js';
+
+// ajv-formats publishes a CJS default export that NodeNext types as a module
+// namespace rather than the callable plugin; its `.default` carries the call
+// signature, and at runtime the import already is that function.
+const addFormats = _addFormats as unknown as typeof _addFormats.default;
+
+// The schemastore `$id` the ai-sarif-log overlay `$ref`s. The bundled SARIF
+// 2.1.0 base schema is registered under it so the overlay's refs to the base
+// document, `#/definitions/run`, and `#/definitions/result` resolve.
+const SARIF_2_1_0_ID = 'https://json.schemastore.org/sarif-2.1.0.json';
+
+export interface ValidationOutcome {
+  /** True when the finalized log conforms to ai-sarif-log.schema.json. */
+  valid: boolean;
+  /** Human-readable `instancePath: message` strings, empty when valid. */
+  errors: string[];
+}
+
+let cachedValidate: ValidateFunction | undefined;
+
+function buildValidator(): ValidateFunction {
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+
+  const base = JSON.parse(
+    readFileSync(assetPath('assets', 'sarif-2.1.0.schema.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  // The bundled base carries a draft-04 `id` schema keyword that Ajv2020
+  // rejects. It is registered under its canonical `$id` explicitly below, so
+  // the in-body keyword is redundant — drop it.
+  delete base.id;
+  ajv.addSchema(base, SARIF_2_1_0_ID);
+
+  const overlay = JSON.parse(getSchema('emit-finalize')) as Record<string, unknown>;
+  return ajv.compile(overlay);
+}
+
+function formatErrors(errors: readonly ErrorObject[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const e of errors) {
+    const where = e.instancePath === '' ? '/' : e.instancePath;
+    const message = `${where}: ${e.message ?? 'is invalid'}`;
+    if (!seen.has(message)) {
+      seen.add(message);
+      out.push(message);
+    }
+  }
+  return out;
+}
+
+/**
+ * Validates a finalized SARIF log against `ai-sarif-log.schema.json`. The
+ * compiled validator is cached across calls. Never throws on a non-conforming
+ * log — the verdict is carried in the returned outcome.
+ */
+export function validateFinalizedLog(log: SarifLog): ValidationOutcome {
+  cachedValidate ??= buildValidator();
+  const valid = cachedValidate(log) as boolean;
+  return valid
+    ? { valid: true, errors: [] }
+    : { valid: false, errors: formatErrors(cachedValidate.errors ?? []) };
+}

--- a/npm/sarif-multitool-ts/test/validate.test.js
+++ b/npm/sarif-multitool-ts/test/validate.test.js
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Unit coverage for `validateFinalizedLog` — the engine behind
+ * `emit-finalize --validate`. Asserts the direct library API surface: a
+ * conformant whole-log validates clean, and the AI-profile constraints
+ * (ruleId grammar, required ai/origin, message.markdown) are each reported.
+ *
+ * Runs against the built dist/. Run via `npm run test:unit`.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateFinalizedLog } from '../dist/index.js';
+
+function conformantLog() {
+  return {
+    version: '2.1.0',
+    runs: [
+      {
+        tool: { driver: { name: 'ai-scanner' } },
+        versionControlProvenance: [{ repositoryUri: 'https://github.com/contoso/widgets' }],
+        properties: { 'ai/origin': 'generated' },
+        results: [
+          {
+            ruleId: 'CWE-79',
+            message: { text: 'XSS', markdown: '**XSS**' },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: { uri: 'src/app.ts' },
+                  region: { startLine: 1 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test('a conformant finalized log validates clean', () => {
+  const r = validateFinalizedLog(conformantLog());
+  assert.equal(r.valid, true, r.errors.join('\n'));
+  assert.deepEqual(r.errors, []);
+});
+
+test('a non-grammar ruleId is reported', () => {
+  const log = conformantLog();
+  log.runs[0].results[0].ruleId = 'not-a-valid-id';
+  const r = validateFinalizedLog(log);
+  assert.equal(r.valid, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('/runs/0/results/0/ruleId')),
+    r.errors.join('\n'),
+  );
+});
+
+test('a missing ai/origin is reported', () => {
+  const log = conformantLog();
+  delete log.runs[0].properties;
+  const r = validateFinalizedLog(log);
+  assert.equal(r.valid, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('properties')),
+    r.errors.join('\n'),
+  );
+});
+
+test('a result without message.markdown is reported', () => {
+  const log = conformantLog();
+  log.runs[0].results[0].message = { text: 'XSS' };
+  const r = validateFinalizedLog(log);
+  assert.equal(r.valid, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('/runs/0/results/0/message')),
+    r.errors.join('\n'),
+  );
+});
+
+test('the bare CWE collapsed id form is accepted', () => {
+  const log = conformantLog();
+  log.runs[0].results[0].ruleId = 'CWE-89';
+  assert.equal(validateFinalizedLog(log).valid, true);
+});
+
+test('the NOVEL escape-hatch ruleId is accepted', () => {
+  const log = conformantLog();
+  log.runs[0].results[0].ruleId = 'NOVEL-llm-leak';
+  assert.equal(validateFinalizedLog(log).valid, true);
+});

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.3.1</VersionPrefix>
+    <VersionPrefix>5.4.0</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.6</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## What

Implements a real `--validate` for the TypeScript `emit-finalize` verb in `@microsoft/sarif-multitool-ts`. It validates the finalized SARIF against `ai-sarif-log.schema.json` — the AI emit profile overlay on the canonical SARIF 2.1.0 document schema — and reports a structured verdict.

- **CLI:** `sarif emit-finalize scan.sarif --validate` prints each `instancePath: message` to stderr and **exits 1** on a non-conforming log; on a conforming log it prints a confirmation and exits 0. The SARIF file is written either way — validation is a report, not a gate on the write.
- **Library:** `emitFinalize({ validate: true })` populates `outcome.validation` (`{ valid, errors }`), and a new exported `validateFinalizedLog(log)` validates any already-finalized log directly.

Replaces the prior deferral-notice stub.

## How it validates offline

The overlay `$ref`s the full SARIF 2.1.0 schema by its schemastore `$id` (`https://json.schemastore.org/sarif-2.1.0.json`), plus `#/definitions/run` and `#/definitions/result`. To resolve those offline:

- The SARIF 2.1.0 base schema (`src/Sarif/Schemata/sarif-2.1.0-rtm.6.json`, draft 2020-12) is bundled at prebuild into **`assets/`** as `sarif-2.1.0.schema.json` and registered under that `$id`.
- It is staged to `assets/`, **not `schemas/`**: `schemas/` is the verb-addressable set held to the get-schema parity/drift gate, and a non-verb schema there would fail it.
- The base carries a draft-04 `id` schema keyword that `Ajv2020` rejects; it's dropped before registration (the schema is registered under its canonical `$id` explicitly).

Validation uses `Ajv2020` (draft 2020-12) + `ajv-formats`. These are the package's **first third-party runtime dependencies**; the CLI header's "zero runtime dependencies" note is updated accordingly.

## Tests

- **Cucumber** (`emit-finalize-validate.feature`): a conformant run validates clean; a run missing `ai/origin` is reported non-conformant. Runs under the standard `npm test`.
- **node:test** (`test/validate.test.js`, via `npm run test:unit`): ruleId grammar (CWE sub-id, bare collapsed CWE, NOVEL escape hatch), required `ai/origin`, and required `message.markdown`.
- Local: 44/44 cucumber scenarios, 6/6 unit tests, `npm run build`, and `npm pack` all green.

## Flags for review

1. **Base branch is `main`, not `dev`.** This feature requires `ai-sarif-log.schema.json`, which only exists on `main` (via #3084). `dev` still has the old `ai-log.schema.json`. Targeting `dev` would first need the rename backmerged.
2. **First runtime deps:** `ajv` + `ajv-formats`. Reasonable for JSON-Schema validation, but worth a conscious nod since the package was dependency-free.
3. **Version bump to v5.4.0** (minor, new feature) with a terse `NEW:` ReleaseHistory entry. Happy to retarget the version if you'd rather land this on a different line.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
