### PR TITLE
Bump test-infrastructure dependencies (tier-1 true-up)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Json.Pointer" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Json.Schema" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
@@ -34,13 +34,14 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="1.8.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="YamlDotNet" Version="11.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Test.UnitTests.Sarif.Converters/CppCheckErrorTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/CppCheckErrorTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     }
                 }, Location.ValueComparer).Should().BeTrue();
 
-            Assert.Equal(1, result.CodeFlows.Count);
+            Assert.Single(result.CodeFlows);
             result.CodeFlows.First().ThreadFlows.First().Locations.SequenceEqual(new[]
                 {
                     new ThreadFlowLocation {

--- a/src/Test.UnitTests.Sarif.Converters/FortifyConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyConverterTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Builder builder = FortifyConverterTests.GetBasicBuilder();
             builder.Source = FortifyConverterTests.s_dummyPathSourceElement;
             Result result = FortifyConverter.ConvertFortifyIssueToSarifIssue(builder.ToImmutable());
-            Assert.Equal(1, result.Locations.Count);
+            Assert.Single(result.Locations);
             Assert.Equal("filePath", result.Locations.First().PhysicalLocation.ArtifactLocation.Uri.ToString());
             Assert.True(result.Locations.First().PhysicalLocation.Region.ValueEquals(new Region { StartLine = 1729 }));
         }
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Builder builder = FortifyConverterTests.GetBasicBuilder();
             builder.Source = FortifyConverterTests.s_dummyPathSourceElement;
             Result result = FortifyConverter.ConvertFortifyIssueToSarifIssue(builder.ToImmutable());
-            Assert.Equal(1, result.CodeFlows.Count);
+            Assert.Single(result.CodeFlows);
             IList<ThreadFlowLocation> flowLocations = result.CodeFlows.First().ThreadFlows.First().Locations;
             Assert.Equal("sourceFilePath", flowLocations[0].Location.PhysicalLocation.ArtifactLocation.Uri.ToString());
             Assert.True(flowLocations[0].Location.PhysicalLocation.Region.ValueEquals(new Region { StartLine = 42 }));

--- a/src/Test.UnitTests.Sarif.Multitool.Library/GenericCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/GenericCommandTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                         {
                             if (parameters.ContainsKey(result.ShortName))
                             {
-                                Assert.True(false, $"{type.Name} has a conflict for {result.ShortName} between {result.LongName} and {parameters[result.ShortName].LongName}.");
+                                Assert.Fail($"{type.Name} has a conflict for {result.ShortName} between {result.LongName} and {parameters[result.ShortName].LongName}.");
                             }
 
                             parameters[result.ShortName] = result;

--- a/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
+++ b/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
@@ -34,6 +34,10 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Reflection.Metadata" />
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="TestData\EmptyResults.sarif" />
     <EmbeddedResource Include="TestData\Invalid.sarif" />

--- a/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/SarifLogTests.cs
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             }
             catch (Exception ex)
             {
-                Assert.True(false, $"Unhandled exception: {ex}");
+                Assert.Fail($"Unhandled exception: {ex}");
             }
         }
 
@@ -444,7 +444,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Core
             }
             catch (Exception ex)
             {
-                Assert.True(false, $"Unhandled exception: {ex}");
+                Assert.Fail($"Unhandled exception: {ex}");
             }
             httpMock.Clear();
         }

--- a/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/HashUtilitiesTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
                     if (File.Exists(filePath)) { File.Delete(filePath); }
                 }
 
-                Assert.True(false, e.Message);
+                Assert.Fail(e.Message);
             }
 
             //  An custom textwriter.S
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
                 }
                 Console.SetOut(defaultOut);
 
-                Assert.True(false, "Exception was expected but not thrown");
+                Assert.Fail("Exception was expected but not thrown");
             }
             catch (InvalidOperationException)
             {
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
             }
             catch
             {
-                Assert.True(false, "Unexpected exception.");
+                Assert.Fail("Unexpected exception.");
             }
             finally
             {

--- a/src/Test.UnitTests.Sarif/Writers/SarifConsolidatorTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifConsolidatorTests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             };
 
             IList<Location> result = consolidator.Trim(locations);
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.Null(result[0].PhysicalLocation.ArtifactLocation.UriBaseId);
             Assert.Equal(-1, result[0].PhysicalLocation.Region.CharOffset);
         }
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             };
 
             IList<LogicalLocation> result = consolidator.Trim(locations);
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.Null(result[0].Name);
         }
 

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 else
                 {
-                    Assert.False(true, pathToExe + " " + commandLine);
+                    Assert.Fail(pathToExe + " " + commandLine);
                 }
 
                 using (_ = new SarifLogger(textWriter,
@@ -1052,7 +1052,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
             catch (Exception e)
             {
-                Assert.True(false, e.ToString());
+                Assert.Fail(e.ToString());
             }
             finally
             {
@@ -1452,7 +1452,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         // 'InvalidOperationException: Collection was modified' inside
         // JsonSerializerInternalWriter.SerializeDictionary on .NET Framework.
         [Fact]
-        public void SarifLogger_DisposeIsThreadSafeWhenSarifRewritingVisitorRunsConcurrently()
+        public async Task SarifLogger_DisposeIsThreadSafeWhenSarifRewritingVisitorRunsConcurrently()
         {
             const int iterations = 50;
             const int ruleCount = 64;
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 stop.Cancel();
-                Task.WaitAll(mutatorTasks);
+                await Task.WhenAll(mutatorTasks);
                 yieldingWriter.Dispose();
 
                 if (caughtExceptions.Count > 0) { break; }


### PR DESCRIPTION
## Summary

Tier-1 true-up of the **test-only** dependency stack. No shipping package (`Sarif.Sdk`, `Driver`, `Converters`, `Multitool*`) is affected — these are test-host and framework references only, so there is no `ReleaseHistory.md` entry and no version bump.

## Changes

`src/Directory.Packages.props`:

| Package | From | To |
|---|---|---|
| `Microsoft.NET.Test.Sdk` | 17.4.1 | 17.12.0 |
| `xunit` | 2.4.2 | 2.9.3 |
| `xunit.runner.console` | 2.4.2 | 2.9.3 |
| `xunit.runner.visualstudio` | 2.4.5 | 2.8.2 |
| `System.Reflection.Metadata` | — | 1.8.0 (added; net48 test host) |

The xunit 2.9 analyzers flag the old assertion/concurrency idioms, so the eight affected tests migrate to `Assert.Fail(...)` and `await Task.WhenAll(...)`. These are the only source changes the bump requires.

## Verification

- Solution builds **0 warnings / 0 errors**.
- All test projects pass: Sarif 1008, Converters 286, Driver 143, Multitool.Library 577, Multitool 11, Sarif.WorkItems 41 (net8+net48), WorkItems 16 (net8+net48), Functional 126.
- This bump also resolves the local `dotnet test` adapter mismatch (`Method 'LogRaw' ... does not have an implementation`) caused by the old `Microsoft.NET.Test.Sdk` / `xunit.runner.visualstudio` pairing.

## Note

A single `Test.UnitTests.Sarif.Multitool.Library` test failed on the first pass and passed on immediate re-run — a pre-existing intermittent (test-isolation flake), not introduced by this bump. Tracking separately rather than blocking this hygiene change.
