### PR TITLE
Host finding-grouping cross-links on relatedLocations, not result.locations

### DIFF
--- a/docs/ai/grouping-findings.md
+++ b/docs/ai/grouping-findings.md
@@ -74,9 +74,13 @@ relationship kinds (§3.34.3): **`includes`** and **`isIncludedBy`**.
 
 A `locationRelationship` relates one *location* to another *location* by the target
 location's `id` (§3.34.2 — `target` is a location `id`, **not** an array index). To make the
-relationship cross **results** (and cross **runs**), the target location is a member of the
-result's `relatedLocations[]` whose `physicalLocation.artifactLocation.uri` is a **`sarif:`
-URI** pointing at the other result.
+relationship cross **results** (and cross **runs**), it lives on the member of the result's
+`relatedLocations[]` whose `physicalLocation.artifactLocation.uri` is a **`sarif:` URI**
+pointing at the other result. That same related-location is both the carrier of the
+cross-result pointer and the bearer of the kind, so its `target` is its **own `id`** (a
+self-reference — see the note below). The cluster cross-link therefore stays entirely within
+`relatedLocations[]`; `result.locations[]` remains the detection's own physical sites and
+never references a clustering parent.
 
 Concretely, for a synthesized cluster `runs[1].results[3]` that consolidates
 `runs[0].results[7]`:
@@ -90,16 +94,16 @@ Concretely, for a synthesized cluster `runs[1].results[3]` that consolidates
   "locations": [
     {
       "id": 0,
-      "physicalLocation": { "artifactLocation": { "uri": "src/api/proxy.ts" }, "region": { "startLine": 40 } },
-      "relationships": [
-        { "target": 1, "kinds": [ "includes" ] }   // -> relatedLocations[id=1]
-      ]
+      "physicalLocation": { "artifactLocation": { "uri": "src/api/proxy.ts" }, "region": { "startLine": 40 } }
     }
   ],
   "relatedLocations": [
     {
       "id": 1,
-      "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/0/results/7" } }
+      "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/0/results/7" } },
+      "relationships": [
+        { "target": 1, "kinds": [ "includes" ] }   // target: 1 == this location's own id
+      ]
     }
   ]
 }
@@ -113,24 +117,32 @@ Concretely, for a synthesized cluster `runs[1].results[3]` that consolidates
   "locations": [
     {
       "id": 0,
-      "physicalLocation": { "artifactLocation": { "uri": "src/api/proxy.ts" }, "region": { "startLine": 42 } },
-      "relationships": [
-        { "target": 1, "kinds": [ "isIncludedBy" ] }  // -> relatedLocations[id=1]
-      ]
+      "physicalLocation": { "artifactLocation": { "uri": "src/api/proxy.ts" }, "region": { "startLine": 42 } }
     }
   ],
   "relatedLocations": [
     {
       "id": 1,
-      "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/1/results/3" } }
+      "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/1/results/3" } },
+      "relationships": [
+        { "target": 1, "kinds": [ "isIncludedBy" ] }  // target: 1 == this location's own id
+      ]
     }
   ]
 }
 ```
 
-A synthesized result with *N* members has *N* `relatedLocations` (each a `sarif:` pointer to
-one member) and *N* `includes` relationships on its primary location. Each member carries one
-`isIncludedBy` pointer back to its cluster. The relationship is reciprocal by construction.
+A synthesized result with *N* members has *N* `relatedLocations`, each a `sarif:` pointer to
+one member and each carrying its own `includes` relationship. Each member carries one
+`relatedLocation` pointing back to its cluster with the inverse `isIncludedBy`. The relationship
+is reciprocal by construction.
+
+> **On the self-reference.** `locationRelationship.target` is a *required* field
+> (§3.34.2). Because the kind (`includes` / `isIncludedBy`) and the `sarif:` pointer ride on
+> the *same* related-location, `target` resolves to that location's own `id`. This is the
+> deliberate cost of keeping the cluster cross-link out of `result.locations[]` while still
+> using the spec's well-known relationship kinds: the relationship is being used to *type* the
+> pointer-bearing location, and the required `target` is satisfied by its own `id`.
 
 ```mermaid
 flowchart LR
@@ -262,8 +274,8 @@ producer.
 A reader that understands this convention may rely on:
 
 - `run.properties["ai/origin"]` partitions runs into tiers; `synthesized` runs hold clusters.
-- A synthesized result's members are exactly the results its primary-location `includes`
-  relationships resolve to (via the `sarif:` pointers in its `relatedLocations`).
+- A synthesized result's members are exactly the results the `includes` relationships on its
+  `relatedLocations` resolve to (each via that related-location's own `sarif:` pointer).
 - Every member result resolves back via `isIncludedBy` (reciprocity is validator-enforced).
 - A consumer that ignores the synthesized tier loses no raw findings; a consumer that ignores
   the generated tier loses no synthesized findings (the synthesized result is self-contained —

--- a/docs/ai/samples/grouping-findings/GroupingGenerateSample.ps1
+++ b/docs/ai/samples/grouping-findings/GroupingGenerateSample.ps1
@@ -22,9 +22,12 @@
       runs[1]  ai/origin = synthesized  one cluster:
                  results[0] CWE-918/ssrf-via-unvalidated-fetch
 
-    The cluster's primary location 'includes' both raw findings via 'sarif:'
-    pointers in its relatedLocations; each raw finding carries the inverse
-    'isIncludedBy' pointer back to the cluster. The links are reciprocal by
+    The cluster's relatedLocations 'include' both raw findings via 'sarif:'
+    pointers (each carrying the 'includes' relationship that links to itself,
+    the pointer-bearing location); each raw finding carries the inverse
+    'isIncludedBy' pointer back to the cluster the same way. Cross-finding
+    grouping never touches result.locations[] (the detection's own sites) -
+    it lives entirely in relatedLocations[]. The links are reciprocal by
     construction (AI1015) and flow synthesized -> generated (AI2020); every
     'sarif:' pointer resolves against the final assembled log (SARIF1013).
 
@@ -159,12 +162,12 @@ try {
         locations = @([ordered]@{
             id = 0
             physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'src/api/proxy.ts'; uriBaseId = 'SRCROOT' }; region = [ordered]@{ startLine = 7 } }
-            relationships = @([ordered]@{ target = 1; kinds = @('isIncludedBy') })
         })
         relatedLocations = @([ordered]@{
             id = 1
             physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/1/results/0' } }
             message = [ordered]@{ text = 'Grouping parent: the SSRF cluster that includes this finding.' }
+            relationships = @([ordered]@{ target = 1; kinds = @('isIncludedBy') })
         })
         properties = [ordered]@{ 'ai/exploitability' = 'poc'; 'ai/attackerPosition' = 'unauthenticated-remote' }
     })
@@ -181,12 +184,12 @@ try {
         locations = @([ordered]@{
             id = 0
             physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'src/api/proxy.ts'; uriBaseId = 'SRCROOT' }; region = [ordered]@{ startLine = 6 } }
-            relationships = @([ordered]@{ target = 1; kinds = @('isIncludedBy') })
         })
         relatedLocations = @([ordered]@{
             id = 1
             physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/1/results/0' } }
             message = [ordered]@{ text = 'Grouping parent: the SSRF cluster that includes this finding.' }
+            relationships = @([ordered]@{ target = 1; kinds = @('isIncludedBy') })
         })
         properties = [ordered]@{ 'ai/exploitability' = 'theoretical'; 'ai/attackerPosition' = 'unauthenticated-remote' }
     })
@@ -203,14 +206,10 @@ try {
         locations = @([ordered]@{
             id = 0
             physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'src/api/proxy.ts'; uriBaseId = 'SRCROOT' }; region = [ordered]@{ startLine = 8 } }
-            relationships = @(
-                [ordered]@{ target = 1; kinds = @('includes') },
-                [ordered]@{ target = 2; kinds = @('includes') }
-            )
         })
         relatedLocations = @(
-            [ordered]@{ id = 1; physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/0/results/0' } }; message = [ordered]@{ text = 'Member: the missing authentication check.' } },
-            [ordered]@{ id = 2; physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/0/results/1' } }; message = [ordered]@{ text = 'Member: the unvalidated outbound fetch.' } }
+            [ordered]@{ id = 1; physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/0/results/0' } }; message = [ordered]@{ text = 'Member: the missing authentication check.' }; relationships = @([ordered]@{ target = 1; kinds = @('includes') }) },
+            [ordered]@{ id = 2; physicalLocation = [ordered]@{ artifactLocation = [ordered]@{ uri = 'sarif:/runs/0/results/1' } }; message = [ordered]@{ text = 'Member: the unvalidated outbound fetch.' }; relationships = @([ordered]@{ target = 2; kinds = @('includes') }) }
         )
         properties = [ordered]@{ 'ai/exploitability' = 'poc'; 'ai/attackerPosition' = 'unauthenticated-remote' }
     })

--- a/docs/ai/samples/grouping-findings/GroupingSample.sarif
+++ b/docs/ai/samples/grouping-findings/GroupingSample.sarif
@@ -118,15 +118,7 @@
                     "text": "  const target = new URL(req.url).searchParams.get(\"target\"); // unvalidated input\n  // No authentication gate guards this public ingress (CWE-306).\n  return await fetch(target!);                                 // SSRF sink (CWE-918)"
                   }
                 }
-              },
-              "relationships": [
-                {
-                  "target": 1,
-                  "kinds": [
-                    "isIncludedBy"
-                  ]
-                }
-              ]
+              }
             }
           ],
           "partialFingerprints": {
@@ -142,7 +134,15 @@
               },
               "message": {
                 "text": "Grouping parent: the SSRF cluster that includes this finding."
-              }
+              },
+              "relationships": [
+                {
+                  "target": 1,
+                  "kinds": [
+                    "isIncludedBy"
+                  ]
+                }
+              ]
             }
           ],
           "rank": 80.0,
@@ -190,15 +190,7 @@
                     "text": "export async function proxy(req: Request): Promise<Response> {\n  const target = new URL(req.url).searchParams.get(\"target\"); // unvalidated input\n  // No authentication gate guards this public ingress (CWE-306)."
                   }
                 }
-              },
-              "relationships": [
-                {
-                  "target": 1,
-                  "kinds": [
-                    "isIncludedBy"
-                  ]
-                }
-              ]
+              }
             }
           ],
           "partialFingerprints": {
@@ -214,7 +206,15 @@
               },
               "message": {
                 "text": "Grouping parent: the SSRF cluster that includes this finding."
-              }
+              },
+              "relationships": [
+                {
+                  "target": 1,
+                  "kinds": [
+                    "isIncludedBy"
+                  ]
+                }
+              ]
             }
           ],
           "rank": 75.0,
@@ -333,21 +333,7 @@
                     "text": "  // No authentication gate guards this public ingress (CWE-306).\n  return await fetch(target!);                                 // SSRF sink (CWE-918)\n}"
                   }
                 }
-              },
-              "relationships": [
-                {
-                  "target": 1,
-                  "kinds": [
-                    "includes"
-                  ]
-                },
-                {
-                  "target": 2,
-                  "kinds": [
-                    "includes"
-                  ]
-                }
-              ]
+              }
             }
           ],
           "partialFingerprints": {
@@ -363,7 +349,15 @@
               },
               "message": {
                 "text": "Member: the missing authentication check."
-              }
+              },
+              "relationships": [
+                {
+                  "target": 1,
+                  "kinds": [
+                    "includes"
+                  ]
+                }
+              ]
             },
             {
               "id": 2,
@@ -374,7 +368,15 @@
               },
               "message": {
                 "text": "Member: the unvalidated outbound fetch."
-              }
+              },
+              "relationships": [
+                {
+                  "target": 2,
+                  "kinds": [
+                    "includes"
+                  ]
+                }
+              ]
             }
           ],
           "rank": 90.0,

--- a/docs/ai/samples/grouping-findings/README.md
+++ b/docs/ai/samples/grouping-findings/README.md
@@ -1,0 +1,62 @@
+# GroupingSample.sarif
+
+A deterministic, generated worked example of the **two-tier finding-grouping
+convention** — how a *synthesized* finding (one assembled from other findings)
+links to the raw findings it consolidates, and how each raw finding links back.
+See [`../../grouping-findings.md`](../../grouping-findings.md) for the full design.
+
+## What it shows
+
+An unauthenticated SSRF assembled from two raw findings:
+
+| | `ai/origin` | Results |
+|---|---|---|
+| `runs[0]` | `generated` | `[0]` CWE-306 missing-auth-check, `[1]` CWE-918 unvalidated-fetch |
+| `runs[1]` | `synthesized` | `[0]` CWE-918 ssrf-via-unvalidated-fetch (the cluster) |
+
+## How the cross-links are encoded
+
+The cluster cross-link lives **entirely in `relatedLocations[]`**;
+`result.locations[]` stays the detection's own physical sites and never
+references a clustering parent.
+
+Each cross-link is one `relatedLocation` that carries:
+
+- a **`sarif:` URI** (`sarif:/runs/<r>/results/<i>`) in
+  `physicalLocation.artifactLocation.uri` — the **address** of the linked result;
+- a **`locationRelationship`** whose `kinds` is `includes` (synthesized → member)
+  or `isIncludedBy` (member → cluster) — the **type** of the edge.
+
+Because the kind and the `sarif:` pointer ride on the same related-location, the
+relationship's required `target` resolves to that location's **own `id`** (a
+self-reference). This keeps the link out of `result.locations[]` while still
+using SARIF's well-known relationship kinds.
+
+```jsonc
+// runs[0].results[0] (a raw finding) — points back at its cluster
+"relatedLocations": [
+  {
+    "id": 1,
+    "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/1/results/0" } },
+    "message": { "text": "Grouping parent: the SSRF cluster that includes this finding." },
+    "relationships": [ { "target": 1, "kinds": [ "isIncludedBy" ] } ]
+  }
+]
+```
+
+The links are reciprocal by construction (**AI1015**), flow synthesized →
+generated (**AI2020**), and every `sarif:` pointer resolves against the assembled
+log (**SARIF1013**).
+
+## Regenerating
+
+The sample is produced by the official multitool emit chain, never hand-authored:
+
+```powershell
+# build the multitool first, e.g. dotnet build src\Sarif.Multitool\Sarif.Multitool.csproj -c Release
+pwsh docs\ai\samples\grouping-findings\GroupingGenerateSample.ps1
+```
+
+`GroupingGeneratedSampleTests.cs` gates byte-identical regeneration, so any change
+to the convention must flow through `GroupingGenerateSample.ps1` and this file
+must be regenerated — a hand-edit will fail the test.


### PR DESCRIPTION
## What

Moves the two-tier finding-grouping **cross-link off `result.locations[]`** and into `relatedLocations[]`, so a result's primary locations stay the detection's own physical sites and never carry cross-finding cluster membership.

## Why

`result.locations[]` describes *where the detection is*. Cluster membership (which raw findings a synthesized finding consolidates, and the reciprocal back-links) is result-graph metadata, not a detection site. The sample previously hung the `includes` / `isIncludedBy` `locationRelationship` on each result's `locations[0]`, conflating the two.

## How

The same `relatedLocation` that carries the `sarif:` pointer now also carries the relationship kind:

```jsonc
// a raw finding pointing back at its cluster
"relatedLocations": [
  {
    "id": 1,
    "physicalLocation": { "artifactLocation": { "uri": "sarif:/runs/1/results/0" } },
    "message": { "text": "Grouping parent: the SSRF cluster that includes this finding." },
    "relationships": [ { "target": 1, "kinds": [ "isIncludedBy" ] } ]
  }
]
```

`locationRelationship.target` is a **required** field — a `target`-less relationship fails schema validation (`JSON1002`). Because the kind and the `sarif:` pointer ride on the same related-location, `target` resolves to that location's **own `id`** (a self-reference). This keeps `result.locations[]` detection-only while still using SARIF's well-known relationship kinds, rather than inventing a property convention.

## Scope / blast radius

- **No rule code changes.** `GroupingRelationshipHelper` already enumerates `relatedLocations` as relationship hosts and resolves `target` → the `sarif:`-bearing location. The edge *content* (kind + target run/result) is unchanged, so **AI1015** (reciprocity), **AI2020** (direction) and **SARIF1013** (`sarif:` resolution) behave identically.
- `GroupingSample.sarif` regenerated via `GroupingGenerateSample.ps1` (the byte-gate source of truth); `emit-finalize --validate` reports `0 error(s), 0 warning(s), 0 note(s) [Sarif+AI]`.
- `grouping-findings.md` §2.2 / §4 updated to the new shape, with a callout explaining the self-`target`.
- New `docs/ai/samples/grouping-findings/README.md` describing the sample.

## Verification

- `GroupingGeneratedSampleTests` (byte-identical regen), `AI1015`, `AI2020`, `AILogSchemaDriftTests` — **20/20 pass**.
- Structural check: `result.locations[].relationships` count across all results = **0**.

No public API or rule-behavior change — sample data + docs only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
