### PR TITLE
Omit contextRegion when no proper superset of region fits the cap (#3096)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.5.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.1)
+* BUG: `FileRegionsCache.ConstructMultilineContextSnippet` omits `contextRegion` unless it is a proper superset of `region`, so enriched multi-line regions no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
+
 ## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
 * BRK: Bundled schema files are renamed from the `2.1.0-rtm.6` prerelease name to finalized `sarif-2.1.0.json` and `sarif-external-property-file-2.1.0.json`; `VersionConstants.SchemaVersionAsPublishedToSchemaStoreOrg` is now `2.1.0`.
 * BUG: `ArtifactRoles` adds the spec-valid `ConversionSource`, `ExternalPropertyFile`, and `RepositoryRoot` values, which the schema previously omitted and rejected on round-trip.

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -185,7 +185,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (originalRegion.CharLength >= BIGSNIPPETLENGTH)
             {
-                return originalRegion.DeepClone();
+                // A context region must be a proper superset of the region (SARIF spec
+                // contextRegion, enforced by SARIF1008). The region already meets the snippet
+                // cap, so no larger in-cap snippet exists; omit the context region rather than
+                // return one identical to the region.
+                return null;
             }
 
             int maxLineNumber = newLineIndex.MaximumLineNumber;
@@ -215,9 +219,12 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             multilineContextSnippet = this.PopulateTextRegionProperties(region, uri, populateSnippet: true, fileText);
 
-            // We can't generate a contextRegion which is smaller than the original region.
-            Debug.Assert(originalRegion.CharLength <= multilineContextSnippet.CharLength);
-            return multilineContextSnippet;
+            // The capped char-offset window does not always contain the region (a region longer
+            // than the window's reach past its start runs off the end). Emit the context region
+            // only when it is a genuine proper superset of the region; otherwise omit it.
+            return multilineContextSnippet.IsProperSupersetOf(originalRegion)
+                ? multilineContextSnippet
+                : null;
         }
 
         private static void PopulatePropertiesFromCharOffsetAndLength(NewLineIndex newLineIndex, Region region, bool overwriteExistingData)

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Rules/ContextRegionSnippetValidationTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Rules/ContextRegionSnippetValidationTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Visitors;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    // Enrichment that synthesizes a contextRegion must not emit SARIF that the SDK's own SARIF1008
+    // rule rejects. These tests run the real InsertOptionalDataVisitor enrichment path and then run
+    // the validator over its output, closing the gap where enrichment was only ever checked against
+    // serialized baselines that never invoked SARIF1008.
+    public class ContextRegionSnippetValidationTests
+    {
+        private const string LineOf220 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+        [Fact]
+        public void InsertContextRegionSnippets_SmallRegion_EmitsValidContextRegion()
+        {
+            // Control: a small region in a multi-line file yields a real contextRegion (proving the
+            // enrichment path actually executes in this harness) and validates cleanly.
+            string fileContent = string.Join(Environment.NewLine, "alpha", "beta", "gamma", "delta", "epsilon");
+
+            (Region contextRegion, IList<Result> sarif1008Results) =
+                EnrichAndValidate(fileContent, new Region { StartLine = 3, EndLine = 3 });
+
+            contextRegion.Should().NotBeNull();
+            sarif1008Results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void InsertContextRegionSnippets_LargeMultilineRegion_OmitsContextRegionAndValidates()
+        {
+            // Mode A: a multi-line region whose snippet exceeds the 512-character cap previously
+            // produced a contextRegion identical to the region, failing SARIF1008. It is now omitted.
+            string fileContent = string.Join(Environment.NewLine, LineOf220, LineOf220, LineOf220);
+
+            (Region contextRegion, IList<Result> sarif1008Results) =
+                EnrichAndValidate(fileContent, new Region { StartLine = 1, EndLine = 3 });
+
+            contextRegion.Should().BeNull();
+            sarif1008Results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void InsertContextRegionSnippets_CharOffsetWindowCannotContainRegion_OmitsContextRegionAndValidates()
+        {
+            // Mode B: a long single-line region whose context falls back to a capped char-offset
+            // window that runs off the end of the region previously emitted a contextRegion that did
+            // not contain the region, failing SARIF1008. It is now omitted.
+            string fileContent = new string('x', 1000);
+
+            (Region contextRegion, IList<Result> sarif1008Results) =
+                EnrichAndValidate(fileContent, new Region { CharOffset = 100, CharLength = 450 });
+
+            contextRegion.Should().BeNull();
+            sarif1008Results.Should().BeEmpty();
+        }
+
+        private static (Region contextRegion, IList<Result> sarif1008Results) EnrichAndValidate(string fileContent, Region region)
+        {
+            string sourcePath = Path.GetTempFileName();
+            string inputPath = Path.GetTempFileName() + ".sarif";
+            string outputPath = Path.GetTempFileName() + ".sarif";
+
+            try
+            {
+                File.WriteAllText(sourcePath, fileContent);
+
+                var run = new Run
+                {
+                    Tool = new Tool
+                    {
+                        Driver = new ToolComponent
+                        {
+                            Name = "ContextRegionTest",
+                            Rules = new[] { new ReportingDescriptor { Id = "TEST0001" } }
+                        }
+                    },
+                    Results = new List<Result>
+                    {
+                        new Result
+                        {
+                            RuleId = "TEST0001",
+                            Message = new Message { Text = "test" },
+                            Locations = new List<Location>
+                            {
+                                new Location
+                                {
+                                    PhysicalLocation = new PhysicalLocation
+                                    {
+                                        ArtifactLocation = new ArtifactLocation { Uri = new Uri(sourcePath) },
+                                        Region = region
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var visitor = new InsertOptionalDataVisitor(
+                    OptionallyEmittedData.ContextRegionSnippets,
+                    new FileRegionsCache(),
+                    run,
+                    insertProperties: null);
+
+                visitor.VisitRun(run);
+
+                Region contextRegion = run.Results[0].Locations[0].PhysicalLocation.ContextRegion;
+
+                var log = new SarifLog { Runs = new[] { run } };
+                log.Save(inputPath);
+
+                var options = new ValidateOptions
+                {
+                    TargetFileSpecifiers = new[] { inputPath },
+                    OutputFilePath = outputPath,
+                    OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite },
+                    RuleKindOption = new List<RuleKind> { RuleKind.Sarif },
+                    Kind = new List<ResultKind> { ResultKind.Fail },
+                    Level = new List<FailureLevel> { FailureLevel.Note, FailureLevel.Warning, FailureLevel.Error }
+                };
+
+                var context = new SarifValidationContext { FileSystem = FileSystem.Instance };
+                new ValidateCommand().Run(options, ref context);
+
+                SarifLog output = SarifLog.Load(outputPath);
+                IList<Result> sarif1008Results = output.Runs[0].Results
+                    .Where(r => r.RuleId == "SARIF1008")
+                    .ToList();
+
+                return (contextRegion, sarif1008Results);
+            }
+            finally
+            {
+                foreach (string path in new[] { sourcePath, inputPath, outputPath })
+                {
+                    if (File.Exists(path)) { File.Delete(path); }
+                }
+            }
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
+++ b/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
         }
 
         [Fact]
-        public void FileRegionsCache_IncreasingToLeftAndRight()
+        public void FileRegionsCache_OmitsContextRegionWhenRegionMeetsSnippetCap()
         {
             var uri = new Uri(@"c:\temp\myFile.cpp");
             string fileContent = $"{new string('a', 200)}{new string('b', 800)}";
@@ -821,8 +821,34 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
             var fileRegionsCache = new FileRegionsCache();
             region = fileRegionsCache.PopulateTextRegionProperties(region, uri, true, fileContent);
 
+            // The region's CharLength (600) already meets the 512-character snippet cap, so no
+            // larger in-cap context region exists. A context region identical to the region would
+            // fail SARIF1008's proper-superset requirement, so the context region is omitted.
             Region multilineRegion = fileRegionsCache.ConstructMultilineContextSnippet(region, uri);
-            multilineRegion.CharLength.Should().Be(region.CharLength);
+            multilineRegion.Should().BeNull();
+        }
+
+        [Fact]
+        public void FileRegionsCache_OmitsContextRegionWhenCharOffsetWindowCannotContainRegion()
+        {
+            var uri = new Uri(@"c:\temp\myFile.cpp");
+            string fileContent = new string('a', 1000);
+
+            var region = new Region
+            {
+                CharOffset = 100,
+                CharLength = 450,
+            };
+
+            var fileRegionsCache = new FileRegionsCache();
+            region = fileRegionsCache.PopulateTextRegionProperties(region, uri, true, fileContent);
+
+            // The single-line context expansion exceeds the cap, so the routine falls back to a
+            // 512-character char-offset window starting 128 characters before the region. That
+            // window (chars 0-512) ends before the region (chars 100-550), so it is not a proper
+            // superset; the context region is omitted rather than emitted as an undershoot.
+            Region multilineRegion = fileRegionsCache.ConstructMultilineContextSnippet(region, uri);
+            multilineRegion.Should().BeNull();
         }
 
         [Fact]

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.5.0</VersionPrefix>
+    <VersionPrefix>5.5.1</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## Summary

`FileRegionsCache.ConstructMultilineContextSnippet` could emit a `contextRegion` that is **not a proper superset** of `region`, which the SDK's own validator then rejects with **SARIF1008** (`ContextRegionMustBeProperSupersetOfRegion`). Because `InsertOptionalDataVisitor` calls this routine whenever `ContextRegionSnippets` is requested (`rewrite --insert ContextRegionSnippets`, and the same path `emit-finalize` uses), enriching multi-line regions produced SARIF that **fails to validate against the SDK that produced it**.

This is the concrete, repro'd correctness bug filed as #3096.

## Root cause — two paths violated the invariant

The SARIF 2.1.0 spec (§3.29.5, `contextRegion`) requires that when `contextRegion` is present it **SHALL** be a *proper superset* of `region` (strictly larger; contains at least one position outside `region`). `SARIF1008` enforces this.

- **Mode A** — when `originalRegion.CharLength >= BIGSNIPPETLENGTH (512)`, the routine cloned the region, so `contextRegion == region`.
- **Mode B** — the capped char-offset fallback builds a 512-char window starting 128 chars before the region. For a region longer than the window's reach past its start, the window **ends before the region ends**, so `contextRegion` does not contain `region`. The `Debug.Assert` guard only checked `CharLength` (not containment) and is inert in release builds.

## Fix

Emit a `contextRegion` only when it is a genuine proper superset of the region; otherwise **omit** it — exactly what SARIF1008's own message prescribes ("If `region` and `contextRegion` are identical, the tool must omit `contextRegion`"). When the region already meets the snippet cap, no larger in-cap snippet exists, so omission is the only spec-compliant outcome.

- Mode A returns `null`.
- Mode B returns the char-offset window only when `IsProperSupersetOf(originalRegion)` (checked against clones so the returned region is not mutated), otherwise `null`.

Both callers are already null-safe (`InsertOptionalDataVisitor` leaves `ContextRegion` unset; the partial-fingerprint path uses `?.Snippet`).

## Tests

- **Enrich-then-validate integration test** (`ContextRegionSnippetValidationTests`) — runs the real `InsertOptionalDataVisitor` enrichment, then runs `SARIF1008` over its output, asserting zero violations. This closes the coverage gap that let the bug ship: enrichment was only ever checked against serialized baselines that never invoked the validator. A control case (small region → valid `contextRegion`) guards against a vacuous pass. **Verified the two omit cases fail on the pre-fix code and pass after.**
- **Unit tests** (`FileRegionsCacheTests`) — focused Mode A and Mode B omission cases (the former replaces `FileRegionsCache_IncreasingToLeftAndRight`, which had asserted the degenerate equal-size context region).

Full `Test.UnitTests.Sarif`, `Test.UnitTests.Sarif.Multitool.Library`, and `Test.FunctionalTests.Sarif` suites pass with no baseline changes.

## Versioning

BUG fix, no API change → `5.5.1` (patch). `build.props` bumped; `ReleaseHistory.md` v5.5.1 section added.

Fixes #3096.
