### PR TITLE
Register the publish-to-ghas skill with get-skill

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.4.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.1)
+* BUG: `get-skill` registers the `publish-to-ghas` skill, which shipped in the repository but was absent from the catalog; `get-skill --list` now enumerates it and `get-skill publish-to-ghas` resolves it.
+
 ## **v5.4.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.0)
 * BRK: Bundled schema files are renamed from the `2.1.0-rtm.6` prerelease name to finalized `sarif-2.1.0.json` and `sarif-external-property-file-2.1.0.json`; `VersionConstants.SchemaVersionAsPublishedToSchemaStoreOrg` is now `2.1.0`.
 * NEW: `emit-finalize --validate` in `@microsoft/sarif-multitool-ts` validates the finalized SARIF against `ai-sarif-log.schema.json` and exits non-zero when the log does not conform.

--- a/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
+++ b/src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             new SortedDictionary<string, string>(StringComparer.Ordinal)
             {
                 ["emit-sarif"] = "skills/emit-sarif",
+                ["publish-to-ghas"] = "skills/publish-to-ghas",
                 ["publish-to-ghazdo"] = "skills/publish-to-ghazdo",
                 ["validate-sarif"] = "skills/validate-sarif",
             };

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -33,6 +33,9 @@
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\..\skills\emit-sarif\SKILL.md">
       <LogicalName>Microsoft.CodeAnalysis.Sarif.Multitool.Skills.emit-sarif.SKILL.md</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\..\skills\publish-to-ghas\SKILL.md">
+      <LogicalName>Microsoft.CodeAnalysis.Sarif.Multitool.Skills.publish-to-ghas.SKILL.md</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\..\skills\publish-to-ghazdo\SKILL.md">
       <LogicalName>Microsoft.CodeAnalysis.Sarif.Multitool.Skills.publish-to-ghazdo.SKILL.md</LogicalName>
     </EmbeddedResource>

--- a/src/Test.UnitTests.Sarif.Multitool.Library/GetSkill/GetSkillCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/GetSkill/GetSkillCommandTests.cs
@@ -93,6 +93,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
+        public void GetSkill_Catalog_CoversEverySkillThatShipsOnDisk()
+        {
+            // The embedded-resource and byte-identity tests above iterate the catalog, so a skill that
+            // ships a skills\<name>\SKILL.md on disk but is missing from SkillSourceDirectory is invisible
+            // to them: it is simply never enumerated. This test closes that gap by driving from disk —
+            // every skills\<name>\SKILL.md must be registered in the catalog (and reachable by name).
+            string repositoryRoot = FindRepositoryRoot();
+            string skillsRoot = Path.Combine(repositoryRoot, "skills");
+
+            IEnumerable<string> onDisk = Directory
+                .EnumerateFiles(skillsRoot, "SKILL.md", SearchOption.AllDirectories)
+                .Select(path => Path.GetFileName(Path.GetDirectoryName(path)));
+
+            onDisk.Should().BeEquivalentTo(
+                GetSkillCommand.SkillSourceDirectory.Keys,
+                "every skills\\<name>\\SKILL.md that ships in the repository must be registered in " +
+                "GetSkillCommand.SkillSourceDirectory so get-skill --list enumerates it and get-skill " +
+                "<name> resolves it.");
+        }
+
+        [Fact]
         public void GetSkill_EmitSarifFindings_RewritesRelativeLinksToPinnedPermalinks()
         {
             string emitted = RunToString("emit-sarif");

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.4.0</VersionPrefix>
+    <VersionPrefix>5.4.1</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## Summary

`get-skill` could neither list nor resolve the **`publish-to-ghas`** skill, even though its `SKILL.md` ships in the repository. Its sibling `publish-to-ghazdo` exposes both a verb and a skill; `publish-to-ghas` (verb added in #3033) shipped only the verb. Agents discovering capabilities via `get-skill --list` therefore got no GHAS publish guidance and had to hand-roll the publish from `publish-to-ghas --help`.

## Root cause

`publish-to-ghas` was registered in neither of the two places `get-skill` reads:

1. **`src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj`** — no `<EmbeddedResource>` for `skills/publish-to-ghas/SKILL.md`, so the SKILL.md was never embedded as `...Skills.publish-to-ghas.SKILL.md`.
2. **`src/Sarif.Multitool.Library/GetSkill/GetSkillCommand.cs`** — the hardcoded `SkillSourceDirectory` map omitted `publish-to-ghas`, so it was neither enumerated by `--list` nor resolvable by name.

## Fix

- Add the `<EmbeddedResource>` entry (LogicalName `Microsoft.CodeAnalysis.Sarif.Multitool.Skills.publish-to-ghas.SKILL.md`).
- Add `["publish-to-ghas"] = "skills/publish-to-ghas"` to `SkillSourceDirectory`.

## Why it wasn't caught

`GetSkill_EverySkill_EmbeddedBytesMatchDiskSource` and `GetSkill_CatalogSkills_MatchEmbeddedResources` both iterate `SkillSourceDirectory`, so a `SKILL.md` present on disk but missing from the catalog is simply never visited. New test `GetSkill_Catalog_CoversEverySkillThatShipsOnDisk` drives from disk — enumerating every `skills/<name>/SKILL.md` and asserting the catalog covers it — and fails pre-fix (4 on disk vs 3 in catalog).

## Verification

- `GetSkillCommandTests`: 21/21 pass (was 20 + the new disk-driven regression test).
- Full `ReleaseHistoryStyleTests` class: 2/2 pass.

Fixes #3099.
