### PR TITLE
Exempt repo-less --no-repo runs from the version-control-provenance requirement

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,10 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.4.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.1) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.1)
+* NEW: `emit-finalize --no-repo` in `@microsoft/sarif-multitool-ts` finalizes a repo-less scan, eliding transient local roots and stamping `properties.unpublishable`, matching the .NET switch.
+* BUG: `AI1004.ProvideVersionControlProvenance` and the `ai-sarif-log.schema.json` whole-log contract exempt a run stamped `properties.unpublishable` (finalized `--no-repo`), so `emit-finalize --no-repo --validate` no longer faults the provenance it omits.
+
 ## **v5.4.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.0)
 * BRK: Bundled schema files are renamed from the `2.1.0-rtm.6` prerelease name to finalized `sarif-2.1.0.json` and `sarif-external-property-file-2.1.0.json`; `VersionConstants.SchemaVersionAsPublishedToSchemaStoreOrg` is now `2.1.0`.
 * NEW: `emit-finalize --validate` in `@microsoft/sarif-multitool-ts` validates the finalized SARIF against `ai-sarif-log.schema.json` and exits non-zero when the log does not conform.

--- a/npm/sarif-multitool-ts/features/emit-finalize-no-repo.feature
+++ b/npm/sarif-multitool-ts/features/emit-finalize-no-repo.feature
@@ -1,0 +1,28 @@
+Feature: emit-finalize --no-repo finalizes a repo-less scan
+
+  As an AI producer scanning code with no version control
+  I want emit-finalize to finalize a run that declares no versionControlProvenance
+  So that --validate accepts it instead of faulting it for the provenance it has none of
+
+  Background:
+    Given a clean working directory
+
+  Scenario: A repo-less run is stamped unpublishable and elides its local root
+    Given an open event log for tool "ai-scanner" with a source root, no VCP, and ai/origin "generated"
+    When emit-results is invoked with a conformant AI result at "src/app.ts" line 1 with ruleId "CWE-79/dom-xss"
+    And emit-finalize is invoked with no-repo
+    Then the finalized SARIF run property "unpublishable" is true
+    And the finalized SARIF result 0 artifactLocation uri equals "src/app.ts"
+    And the finalized SARIF contains no "file://" anywhere
+
+  Scenario: A repo-less run validates clean under --no-repo --validate
+    Given an open event log for tool "ai-scanner" with a source root, no VCP, and ai/origin "generated"
+    When emit-results is invoked with a conformant AI result at "src/app.ts" line 1 with ruleId "CWE-79/dom-xss"
+    And emit-finalize is invoked with no-repo and validation
+    Then the finalized SARIF conforms to the AI whole-log schema
+
+  Scenario: --no-repo with versionControlProvenance present is a contradiction and fails
+    Given an open event log for tool "ai-scanner" with a GitHub source root and VCP
+    When emit-results is invoked with a result at "src/app.ts" line 1
+    And emit-finalize is invoked with no-repo expecting failure
+    Then the failure message mentions "--no-repo was specified, but run.versionControlProvenance"

--- a/npm/sarif-multitool-ts/features/steps/steps.mjs
+++ b/npm/sarif-multitool-ts/features/steps/steps.mjs
@@ -121,6 +121,22 @@ Given(
   },
 );
 
+Given(
+  'an open event log for tool {string} with a source root, no VCP, and ai\\/origin {string}',
+  async function (name, origin) {
+    if (!this.tmp) this.init();
+    this.runHeader = this.finalizableRunHeader(false);
+    this.runHeader.tool.driver.name = name;
+    this.runHeader.properties = { 'ai/origin': origin };
+    await emitRun({
+      output: this.output,
+      run: this.runHeader,
+      forceOverwrite: true,
+      env: this.env,
+    });
+  },
+);
+
 Given('emit-run has already been invoked', async function () {
   await emitRun({ output: this.output, run: this.runHeader, env: this.env });
 });
@@ -338,6 +354,26 @@ When('emit-finalize is invoked expecting failure', async function () {
   }
 });
 
+When('emit-finalize is invoked with no-repo', async function () {
+  const r = await emitFinalize({ output: this.output, keepWip: true, noRepo: true });
+  this.finalizedLog = r.log;
+});
+
+When('emit-finalize is invoked with no-repo and validation', async function () {
+  const r = await emitFinalize({ output: this.output, keepWip: true, noRepo: true, validate: true });
+  this.finalizedLog = r.log;
+  this.validation = r.validation;
+});
+
+When('emit-finalize is invoked with no-repo expecting failure', async function () {
+  try {
+    await emitFinalize({ output: this.output, keepWip: true, noRepo: true });
+    assert.fail('emit-finalize --no-repo was expected to fail but succeeded');
+  } catch (err) {
+    this.lastError = err;
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Then — event log
 // ---------------------------------------------------------------------------
@@ -520,6 +556,10 @@ Then(
 Then('the finalized SARIF contains no {string} anywhere', function (fragment) {
   const text = readFileSync(this.output, 'utf8');
   assert.ok(!text.includes(fragment), `output SARIF still contains '${fragment}'`);
+});
+
+Then('the finalized SARIF run property {string} is true', function (key) {
+  assert.equal(finalizedRun(this).properties?.[key], true);
 });
 
 Then('the finalized SARIF rule {string} has a non-empty {string}', function (id, field) {

--- a/npm/sarif-multitool-ts/src/cli.ts
+++ b/npm/sarif-multitool-ts/src/cli.ts
@@ -126,7 +126,7 @@ emit chain:
   sarif emit-invocations <output.sarif> [--input <invocations.json>]
   sarif emit-rule-descriptors <output.sarif> [--input <descriptors.json>]
   sarif emit-notification-descriptors <output.sarif> [--input <descriptors.json>]
-  sarif emit-finalize <output.sarif> [--no-cwe-enrichment] [--minify] [--keep-wip] [--validate]
+  sarif emit-finalize <output.sarif> [--no-cwe-enrichment] [--minify] [--keep-wip] [--no-repo] [--validate]
 
 asset verbs:
   sarif get-schema <emit-verb> [--output <path>] [--force-overwrite] | --list
@@ -191,6 +191,7 @@ async function main(): Promise<number> {
         noCweEnrichment: !!flags['no-cwe-enrichment'],
         minify: !!flags.minify,
         keepWip: !!flags['keep-wip'],
+        noRepo: !!flags['no-repo'],
         validate: !!flags.validate,
       });
       for (const w of r.warnings) process.stderr.write(w + '\n');

--- a/npm/sarif-multitool-ts/src/emitFinalize.ts
+++ b/npm/sarif-multitool-ts/src/emitFinalize.ts
@@ -48,6 +48,13 @@ export interface EmitFinalizeOptions {
    * SARIF file is written regardless; validation is a report, not a gate.
    */
   validate?: boolean;
+  /**
+   * Finalize a repo-less scan: the run carries no versionControlProvenance. Local file:// roots
+   * are elided (not rebased onto a repository root) and the run is stamped
+   * `properties.unpublishable = true`, which exempts it from the version-control-provenance
+   * requirement in both the schema and the AI1004 rule. Mirrors the .NET --no-repo switch.
+   */
+  noRepo?: boolean;
 }
 
 export interface EmitFinalizeOutcome {
@@ -109,9 +116,14 @@ export async function emitFinalize(opts: EmitFinalizeOptions): Promise<EmitFinal
   // file:// bases.
   for (const run of log.runs ?? []) {
     if (!run) continue;
-    const r = rebaseRun(run);
+    const r = rebaseRun(run, opts.noRepo);
     if (!r.success) {
       throw new EmitVerbError(r.errors.join('\n'));
+    }
+    // --no-repo asserts the scan has no version control; stamp the run so the schema and the
+    // AI1004 rule exempt it from the version-control-provenance requirement.
+    if (opts.noRepo) {
+      run.properties = { ...run.properties, unpublishable: true };
     }
   }
 

--- a/npm/sarif-multitool-ts/src/rebase.ts
+++ b/npm/sarif-multitool-ts/src/rebase.ts
@@ -31,7 +31,9 @@ export interface RebaseResult {
 }
 
 /** Rebases the run in place. Returns errors (success ↔ errors.length === 0). */
-export function rebaseRun(run: Run): RebaseResult {
+export function rebaseRun(run: Run, noRepo = false): RebaseResult {
+  if (noRepo) return rebaseRunRepoless(run);
+
   const errors: string[] = [];
   const referencedBaseIds = new Set<string>();
   const leakUris: string[] = [];
@@ -66,9 +68,56 @@ export function rebaseRun(run: Run): RebaseResult {
   return { success: errors.length === 0, errors };
 }
 
-// ---------------------------------------------------------------------------
-// Planning
-// ---------------------------------------------------------------------------
+/**
+ * Rebases a run finalized with --no-repo: the scan asserts it has no version control, so there is
+ * no portable root to rebase onto. Locations are leak-checked but never rewritten, and each base's
+ * transient local file:// root is elided so the finalized log carries no machine-specific path.
+ *
+ * Ported from EmitFinalizeRebaseVisitor.VisitRunRepoless.
+ */
+function rebaseRunRepoless(run: Run): RebaseResult {
+  const errors: string[] = [];
+  const referencedBaseIds = new Set<string>();
+  const leakUris: string[] = [];
+
+  // --no-repo asserts the scan has no version control. A run that nonetheless declares
+  // versionControlProvenance is a contradictory signal; refuse rather than ship a log that
+  // claims both.
+  if (run.versionControlProvenance && run.versionControlProvenance.length > 0) {
+    errors.push(
+      '--no-repo was specified, but run.versionControlProvenance declares one or more repositories. Remove --no-repo to rebase artifact locations to portable, per-repository roots derived from versionControlProvenance, or remove the provenance to finalize as a repo-less scan.',
+    );
+    return { success: false, errors };
+  }
+
+  const cycleErr = validateNoBaseCycles(run.originalUriBaseIds);
+  if (cycleErr) {
+    errors.push(cycleErr);
+    return { success: false, errors };
+  }
+
+  // A repo-less location must be expressed relative to a declared base. A rooted local path
+  // (absolute file://, or a rooted relative shape) cannot be made portable without a repository
+  // root, so it is a leak the final assertion rejects.
+  walkArtifactLocations(run, (al) => {
+    if (al.uriBaseId) referencedBaseIds.add(al.uriBaseId);
+    if (al.uri && isRootedLocalShape(al.uri)) leakUris.push(al.uri);
+  });
+
+  // Drop the transient local file:// root from each base, keeping the base symbol (and any
+  // description / parent chain) so locations remain <BASE>-relative.
+  if (run.originalUriBaseIds) {
+    for (const entry of Object.values(run.originalUriBaseIds)) {
+      if (entry?.uri && entry.uri.startsWith('file:')) {
+        entry.uri = undefined;
+      }
+    }
+  }
+
+  verifyNoLeak(run, referencedBaseIds, leakUris, errors);
+
+  return { success: errors.length === 0, errors };
+}
 
 function buildPlan(run: Run, errors: string[]): RepoRoot[] | undefined {
   const vcp = run.versionControlProvenance;

--- a/npm/sarif-multitool-ts/test/validate.test.js
+++ b/npm/sarif-multitool-ts/test/validate.test.js
@@ -69,6 +69,26 @@ test('a missing ai/origin is reported', () => {
   );
 });
 
+test('a run missing versionControlProvenance is reported', () => {
+  const log = conformantLog();
+  delete log.runs[0].versionControlProvenance;
+  const r = validateFinalizedLog(log);
+  assert.equal(r.valid, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('versionControlProvenance')),
+    r.errors.join('\n'),
+  );
+});
+
+test('a repo-less run stamped unpublishable validates without versionControlProvenance', () => {
+  const log = conformantLog();
+  delete log.runs[0].versionControlProvenance;
+  log.runs[0].properties.unpublishable = true;
+  const r = validateFinalizedLog(log);
+  assert.equal(r.valid, true, r.errors.join('\n'));
+  assert.deepEqual(r.errors, []);
+});
+
 test('a result without message.markdown is reported', () => {
   const log = conformantLog();
   log.runs[0].results[0].message = { text: 'XSS' };

--- a/src/Sarif.Multitool.Library/GetSchema/ai-sarif-log.schema.json
+++ b/src/Sarif.Multitool.Library/GetSchema/ai-sarif-log.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/microsoft/sarif-sdk/main/src/Sarif.Multitool.Library/GetSchema/ai-sarif-log.schema.json",
   "title": "SARIF AI emit profile \u2014 finalized whole log",
-  "description": "Whole-document contract for a fully-enriched SARIF AI log: the output of the emit-finalize verb. An overlay on the canonical SARIF 2.1.0 document that reuses the base shape by $ref and tightens it to the Error-level AI rules at whole-log scale. Unlike the per-object input schemas, this is a POST-enrichment contract: it ACCEPTS the index/identity state finalize assigns (result.ruleIndex, result.guid, artifactLocation.index, run.taxonomies) and REQUIRES the run-scoped fields the AI profile mandates (tool.driver.name, a versionControlProvenance entry, properties[ai/origin]) plus, when a run carries the Azure DevOps pipeline shape, the GHAzDO automationDetails contract (GHAzDO1019/GHAzDO1020). What this schema cannot express at whole-log fidelity (e.g. the full org/project/buildId segment structure of automationDetails.id) is deferred to emit-finalize --validate.",
+  "description": "Whole-document contract for a fully-enriched SARIF AI log: the output of the emit-finalize verb. An overlay on the canonical SARIF 2.1.0 document that reuses the base shape by $ref and tightens it to the Error-level AI rules at whole-log scale. Unlike the per-object input schemas, this is a POST-enrichment contract: it ACCEPTS the index/identity state finalize assigns (result.ruleIndex, result.guid, artifactLocation.index, run.taxonomies) and REQUIRES the run-scoped fields the AI profile mandates (tool.driver.name, a versionControlProvenance entry unless the run is stamped properties[unpublishable]=true by emit-finalize --no-repo, properties[ai/origin]) plus, when a run carries the Azure DevOps pipeline shape, the GHAzDO automationDetails contract (GHAzDO1019/GHAzDO1020). What this schema cannot express at whole-log fidelity (e.g. the full org/project/buildId segment structure of automationDetails.id) is deferred to emit-finalize --validate.",
   "type": "object",
   "allOf": [
     {
@@ -27,7 +27,7 @@
   },
   "$defs": {
     "aiLogRun": {
-      "description": "A finalized AI run. Reuses the base run by $ref and tightens it to the AI profile: a named tool driver, at least one versionControlProvenance entry, properties[ai/origin], and a results array (which finalize always writes, possibly empty). Header-only forbids from the input profile are lifted here \u2014 results live in the whole log.",
+      "description": "A finalized AI run. Reuses the base run by $ref and tightens it to the AI profile: a named tool driver, properties[ai/origin], a results array (which finalize always writes, possibly empty), and \u2014 unless the run is stamped properties[unpublishable]=true by emit-finalize --no-repo \u2014 at least one versionControlProvenance entry. Header-only forbids from the input profile are lifted here \u2014 results live in the whole log.",
       "type": "object",
       "allOf": [
         {
@@ -36,10 +36,33 @@
       ],
       "required": [
         "tool",
-        "versionControlProvenance",
         "properties",
         "results"
       ],
+      "if": {
+        "required": [
+          "properties"
+        ],
+        "properties": {
+          "properties": {
+            "required": [
+              "unpublishable"
+            ],
+            "properties": {
+              "unpublishable": {
+                "const": true
+              }
+            }
+          }
+        }
+      },
+      "then": true,
+      "else": {
+        "description": "A publishable run must carry version-control provenance; a run finalized --no-repo (properties[unpublishable]=true) is exempt.",
+        "required": [
+          "versionControlProvenance"
+        ]
+      },
       "properties": {
         "tool": {
           "type": "object",

--- a/src/Sarif.Multitool.Library/Rules/AI1004.ProvideVersionControlProvenance.cs
+++ b/src/Sarif.Multitool.Library/Rules/AI1004.ProvideVersionControlProvenance.cs
@@ -31,6 +31,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected override void Analyze(Run run, string runPointer)
         {
+            // A run finalized with emit-finalize --no-repo declares it has no version control and
+            // is stamped unpublishable. It must not be faulted for the version-control provenance
+            // it has deliberately asserted is absent; every other AI-profile check still applies.
+            if (run.TryGetProperty(EmitFinalizeCommand.UnpublishablePropertyName, out bool unpublishable)
+                && unpublishable)
+            {
+                return;
+            }
+
             if (run.VersionControlProvenance == null || run.VersionControlProvenance.Count == 0)
             {
                 LogResult(

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Emit/EmitFinalizeCommandTests.cs
@@ -538,6 +538,36 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
+        public void Run_WithNoRepoAndValidate_DoesNotFaultRepolessRunForMissingVersionControl()
+        {
+            // Regression for #3100: --no-repo deliberately omits versionControlProvenance and stamps
+            // the run unpublishable. The --validate gate must not fault that run with AI1004 (the rule
+            // skips the unpublishable marker), even though other AI-profile findings may still fire.
+            SeedWip(
+                (SarifEventKinds.RunHeader, RepoLessRunHeader()),
+                (SarifEventKinds.Result, NovelResult()));
+
+            new EmitFinalizeCommand().Run(new EmitFinalizeOptions
+            {
+                OutputFilePath = OutPath,
+                NoRepo = true,
+                Validate = true,
+            });
+
+            string reportPath = Path.Combine(_dir, "scan.validate-report.sarif");
+            File.Exists(reportPath).Should().BeTrue();
+
+            using var sr = new StreamReader(reportPath);
+            using var jr = new JsonTextReader(sr);
+            SarifLog report = JsonSerializer.CreateDefault().Deserialize<SarifLog>(jr);
+
+            report.Runs
+                .SelectMany(r => r.Results ?? new List<Result>())
+                .Where(res => res.RuleId == "AI1004")
+                .Should().BeEmpty("--no-repo stamps the run unpublishable, exempting it from AI1004");
+        }
+
+        [Fact]
         public void Run_StampsCweSecuritySeverityFromCuratedTable()
         {
             // A finding on a CWE rule (sub-id form collapses to descriptor "CWE-79"); finalize

--- a/src/Test.UnitTests.Sarif.Multitool.Library/GetSchema/AILogSchemaDriftTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/GetSchema/AILogSchemaDriftTests.cs
@@ -73,6 +73,39 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         }
 
         [Fact]
+        public void AILogSchema_AcceptsRepoLessRunWhenStampedUnpublishable()
+        {
+            // emit-finalize --no-repo finalizes a run with no versionControlProvenance and stamps
+            // properties[unpublishable]=true. The schema must exempt that run from the VCP requirement
+            // (parity with the AI1004 rule, which skips the same marker) while still rejecting an
+            // unmarked VCP-less run.
+            var offenders = new List<string>();
+
+            void Expect(string label, JsonObject run, bool accept)
+            {
+                if (Accepts(s_logSchema, MakeLog(run)) != accept)
+                {
+                    offenders.Add($"  [{label}] expected accept={accept}");
+                }
+            }
+
+            JsonObject unpublishable = MakeRun();
+            unpublishable.Remove("versionControlProvenance");
+            unpublishable["properties"] = new JsonObject { ["ai/origin"] = "generated", ["unpublishable"] = true };
+            Expect("no-vcp-unpublishable", unpublishable, true);
+
+            JsonObject falseMarker = MakeRun();
+            falseMarker.Remove("versionControlProvenance");
+            falseMarker["properties"] = new JsonObject { ["ai/origin"] = "generated", ["unpublishable"] = false };
+            Expect("no-vcp-unpublishable-false", falseMarker, false);
+
+            offenders.Should().BeEmpty(
+                "ai-sarif-log.schema.json must accept a versionControlProvenance-less run stamped " +
+                "properties[unpublishable]=true (emit-finalize --no-repo) and still reject one that is not:\n" +
+                string.Join("\n", offenders));
+        }
+
+        [Fact]
         public void AILogSchema_RequiresVersionAndNonEmptyRuns()
         {
             var offenders = new List<string>();

--- a/src/Test.UnitTests.Sarif.Multitool.Library/Rules/AIValidationRuleTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool.Library/Rules/AIValidationRuleTests.cs
@@ -611,6 +611,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             results.Should().BeEmpty("VCP is present in the valid log");
         }
 
+        [Fact]
+        public void AI1004_WhenRunMarkedUnpublishable_NoResult()
+        {
+            SarifLog log = CreateValidAISarifLog();
+            SetAIOrigin(log, "generated");
+            SetExploitability(log, "demonstrated");
+            log.Runs[0].VersionControlProvenance = null;
+            log.Runs[0].SetProperty(EmitFinalizeCommand.UnpublishablePropertyName, true);
+
+            SarifLog output = RunAIValidation(log);
+            List<Result> results = GetResultsForRule(output, "AI1004");
+
+            results.Should().BeEmpty(
+                "a run finalized --no-repo is stamped unpublishable and must be exempt from AI1004");
+        }
+
         #endregion
 
         #region SARIF2017 — does NOT fire in AI-only profile

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.4.0</VersionPrefix>
+    <VersionPrefix>5.4.1</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
## Summary

`emit-finalize --no-repo --validate` always failed `AI1004` (#3100). `--no-repo` deliberately finalizes a scan that has **no version control**: it omits `versionControlProvenance` (VCP) and stamps the run `properties.unpublishable = true`. But `--validate` runs the AI profile, whose `AI1004.ProvideVersionControlProvenance` rule (Error) faults a run with no VCP — so the validator faulted the run for the provenance `--no-repo` asserts it has none of.

This fixes it coherently across **both** SDKs, with a single shared source of truth.

## The exemption contract

A run stamped `properties.unpublishable === true` (only ever set by `emit-finalize --no-repo`) is exempt from the version-control-provenance requirement. Every other AI-profile constraint still applies, and a run that is **not** so stamped still requires VCP. A present-but-empty VCP still fails (the property schema's `minItems: 1` is unchanged).

## Changes

**C# rule** — the .NET `--validate` path runs the rule engine, not the schema:
- `AI1004.ProvideVersionControlProvenance.Analyze` returns early when the run is stamped unpublishable (keyed off `EmitFinalizeCommand.UnpublishablePropertyName`, the single source of truth for the property name).

**Shared schema** — `ai-sarif-log.schema.json` is the source of truth that `copy-assets.mjs` copies into the TS package at build, so this one edit fixes TS validation too:
- `versionControlProvenance` is removed from `aiLogRun.required` and gated behind `if/then/else`: `properties.unpublishable === true` ⇒ exempt; otherwise require VCP.

**TS producer parity** — the TS multitool had no `--no-repo`, so it could not even reach the scenario:
- `cli.ts`: add the `--no-repo` flag (HELP + wiring).
- `emitFinalize.ts`: add the `noRepo` option; stamp `properties.unpublishable`.
- `rebase.ts`: add `rebaseRunRepoless`, mirroring `EmitFinalizeRebaseVisitor.VisitRunRepoless` — reject a run that declares VCP under `--no-repo`, leak-check rooted-local locations, and elide transient local `file://` roots.

## Tests

- **C#**: `AI1004_WhenRunMarkedUnpublishable_NoResult`; `Run_WithNoRepoAndValidate_DoesNotFaultRepolessRunForMissingVersionControl` (integration — no `AI1004` in the report); `AILogSchema_AcceptsRepoLessRunWhenStampedUnpublishable` (drift test accepts a VCP-less unpublishable run, still rejects an unmarked / `unpublishable: false` one).
- **TS**: `emit-finalize-no-repo.feature` (stamp + elide, clean `--validate`, and the VCP-present contradiction); `validate.test.js` exemption unit tests.

## Verification

- `AIValidationRuleTests` + `AILogSchemaDriftTests`: 75/75. `EmitFinalizeCommandTests`: 51/51. `GetSkillCommandTests` unaffected.
- TS: 47/47 cucumber scenarios, 8/8 validator unit tests, 4/4 conformance (incl. the .NET⇔TS equivalence gate).
- Full `ReleaseHistoryStyleTests` class: 2/2.

Fixes #3100.

> Note: this PR targets `dev`. Because the repo's default branch is `main`, the `Fixes #3100` link will not auto-close on merge — #3100 will be closed manually when `dev` ships.
