### PR TITLE
Adopt full dependency group + raise .NET Framework floor to net481 (release 5.5.0)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,11 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
+* BRK: Raise the .NET Framework floor to `net481` for all packages, dropping the `net461` and `net462` targets.
+* DEP: Update the minor-and-patch dependency group, notably `Microsoft.Diagnostics.Tracing.TraceEvent` 3.2.4, `System.Collections.Immutable` and `System.Reflection.Metadata` 9.0.8, and `System.Data.SqlClient` 4.9.1.
+* DEP: `Microsoft.Extensions.Logging.ApplicationInsights` 2.23.0; `ServiceProviderFactory` configures Application Insights via connection string instead of the obsolete instrumentation-key API.
+
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)
 * BUG: `GHAzDO1019.ProvidePipelineProperties`, the `emit-run` pipeline-context producer, and the `ai-sarif-log.schema.json` build contract accept `-1` as the buildDefinitionId sentinel for runs with no saved definition, still rejecting `0` and other negatives.
 * BUG: `SarifLogger` indexes only extension `toolComponent`s that declare the optional `guid` (SARIF §3.19.6), instead of throwing when one is absent.

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -10,15 +10,14 @@
 $Frameworks = @{}
 
 # .NET Framework versions for which we build.
-# net462 is this minimal support .NET framework. We allow linkage
-# to net461 for compatibility reasons.
-# and any upstream consumer of them.
-$Frameworks.NetFx = @("net461")
+# net481 is our minimal supported .NET Framework, and the floor
+# required for internal Microsoft consumption.
+$Frameworks.NetFx = @("net481")
 
 # Frameworks for which we build libraries.
 $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 
-# net462 is the current minimum supported .NET
+# net481 is the current minimum supported .NET
 # framework, so we use it for all client tools.
 # it is fine to support a down-level, unsupported
 # .NET framework for a library, because the client 
@@ -26,7 +25,7 @@ $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 # current .NET framework. When we control the app
 # we will require the minimal supported version to 
 # ensure that the runtime we are executing on is secure.
-$Frameworks.ApplicationNetFx = @("net462")
+$Frameworks.ApplicationNetFx = @("net481")
 
 # Frameworks for which we build applications.
 $Frameworks.Application = @("net8.0") + $Frameworks.ApplicationNetFx

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,8 @@
     <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" />
-    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.32" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.32" />
@@ -27,14 +28,14 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.205.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="System.Composition" Version="5.0.1" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="1.8.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,9 +20,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Json.Pointer" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.Json.Schema" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Json.Pointer" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Json.Schema" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.205.3" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,40 +8,40 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="JsonSchema.Net" Version="9.2.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.20.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.Json.Pointer" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Json.Schema" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Json.Pointer" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Json.Schema" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Json.Schema.Validation" Version="2.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="16.205.3" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageVersion Include="System.Composition" Version="5.0.0" />
+    <PackageVersion Include="System.Composition" Version="5.0.1" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="1.8.0" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="6.0.1" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="YamlDotNet" Version="11.2.0" />
+    <PackageVersion Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 </Project>

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -21,16 +21,14 @@
   </metadata>
   <files>
     <!-- The subfolder layout for the different TargetFrameworks is intentionally inconsistent -->
-    <!-- net462 and net8.0 pack to tools\TargetFramework\* for backcompat -->
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\Sarif.Multitool.exe.config"
-          target="tools\net462" />
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\**"
-          target="tools\net462"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\Sarif*;bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\WorkItems.dll;" />
-    <file src="bld\bin\Signing\net462\**"
-          target="tools\net462" />
-    <file src="bld\bin\Signing\net461\**"
-          target="tools\net462" />
+    <!-- net481 and net8.0 pack to tools\TargetFramework\* for backcompat -->
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\Sarif.Multitool.exe.config"
+          target="tools\net481" />
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\**"
+          target="tools\net481"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\Sarif*;bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\WorkItems.dll;" />
+    <file src="bld\bin\Signing\net481\**"
+          target="tools\net481" />
 
     <!-- net8.0 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net8.0\**"

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Sarif.Multitool</RootNamespace>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="default.configuration.xml" Pack="true" PackagePath="lib/netstandard2.0;lib/net461" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="default.configuration.xml" Pack="true" PackagePath="lib/netstandard2.0;lib/net481" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\policies\*" Pack="true" PackagePath="policies" />
     <None Include="**\*.cs" Pack="true" PackagePath="src" />
     <None Include="..\..\ReleaseHistory.md" Pack="true" PackagePath="/" />

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -34,8 +34,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <!-- net462 is the current minimal supported .NET framework. -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <!-- net481 is the current minimal supported .NET framework. -->
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool/appsettings.json
+++ b/src/Sarif.Multitool/appsettings.json
@@ -2,7 +2,7 @@
   "Sarif-WorkItems": {
     "Logging": {
       "ApplicationInsights": {
-        "InstrumentationKey": "PUT_YOUR_INSTRUMENTATION_KEY_HERE",
+        "ConnectionString": "PUT_YOUR_CONNECTION_STRING_HERE",
         "LogLevel": {
           "Microsoft": "Information"
         }

--- a/src/Sarif.WorkItems/Sarif.WorkItems.csproj
+++ b/src/Sarif.WorkItems/Sarif.WorkItems.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 

--- a/src/Test.Plugins/Test.Plugins.csproj
+++ b/src/Test.Plugins/Test.Plugins.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
+++ b/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Test.UnitTests.Sarif.WorkItems</RootNamespace>
@@ -34,7 +34,7 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
 

--- a/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
+++ b/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/WorkItems/ServiceProviderFactory.cs
+++ b/src/WorkItems/ServiceProviderFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.WorkItems
         private const string LoggingSection = "Sarif-WorkItems:Logging";
         private const string LoggingApplicationInsightsSection = "Sarif-WorkItems:Logging:ApplicationInsights";
         private const string LoggingApplicationInsightsInstrumentationKey = "Sarif-WorkItems:Logging:ApplicationInsights:InstrumentationKey";
+        private const string LoggingApplicationInsightsConnectionString = "Sarif-WorkItems:Logging:ApplicationInsights:ConnectionString";
         private const string LoggingConsoleSection = "Sarif-WorkItems:Logging:Console";
 
         public static IServiceProvider ServiceProvider { get; private set; }
@@ -48,9 +49,20 @@ namespace Microsoft.WorkItems
 
                     if (config.GetSection(LoggingApplicationInsightsSection).Exists())
                     {
-                        if (!string.IsNullOrEmpty(config[LoggingApplicationInsightsInstrumentationKey]))
+                        // Prefer an explicit connection string; express a legacy instrumentation
+                        // key as one so both configuration shapes route to the same ingestion.
+                        string connectionString = config[LoggingApplicationInsightsConnectionString];
+
+                        if (string.IsNullOrEmpty(connectionString) && !string.IsNullOrEmpty(config[LoggingApplicationInsightsInstrumentationKey]))
                         {
-                            builder.AddApplicationInsights(config[LoggingApplicationInsightsInstrumentationKey], options => options.FlushOnDispose = true);
+                            connectionString = $"InstrumentationKey={config[LoggingApplicationInsightsInstrumentationKey]}";
+                        }
+
+                        if (!string.IsNullOrEmpty(connectionString))
+                        {
+                            builder.AddApplicationInsights(
+                                telemetryConfiguration => telemetryConfiguration.ConnectionString = connectionString,
+                                options => options.FlushOnDispose = true);
                         }
                     }
 

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -20,8 +20,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <!-- We require 461 as a minimal framework due to dependency such as Microsoft.Extensions.Logging.Console -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <!-- We require net481 as a minimal framework due to dependency such as Microsoft.Extensions.Logging.Console -->
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.4.3</VersionPrefix>
+    <VersionPrefix>5.5.0</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -102,6 +102,17 @@
 
   <ItemGroup>
     <Compile Include="$(MsBuildThisFileDirectory)Shared\CommonAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <!-- On .NET Framework, the newer System.* (9.x) runtime packages pull facade
+       assemblies that forward System.Net.Http / System.IO.Compression types and
+       displace the built-in framework references, and CsvHelper drags in an older
+       Microsoft.Bcl.HashCode. Reference the framework facades explicitly and pin
+       Microsoft.Bcl.HashCode so the assembly graph unifies. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.IO.Compression" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
## Summary

Adopts the Dependabot minor-and-patch dependency group and raises the .NET Framework build floor to `net481`. Releases **v5.5.0**.

## Changes

- **TFM floor → `net481`** across the 10 in-solution .NET Framework projects, the packaging framework lists (`scripts/Projects.psm1`), and the Multitool `nuspec` Publish/Signing folder references.
- **Dependency group adopted**, including `Microsoft.Diagnostics.Tracing.TraceEvent` 3.2.4, `System.Collections.Immutable` and `System.Reflection.Metadata` 9.0.8, and `System.Data.SqlClient` 4.9.1. `Microsoft.Json.Pointer` / `Schema` / `Schema.Validation` held at 2.1.0 (see #3121).
- **Obsolete-API migration:** `ServiceProviderFactory` configures Application Insights via connection string instead of the obsolete instrumentation-key overload.
- **netfx build fixes centralized in `src/build.props`:** explicit `System.Net.Http` / `System.IO.Compression` facade references and a `Microsoft.Bcl.HashCode` 6.0.0 pin.
- **Release 5.5.0:** `BRK` ReleaseHistory entry for the floor increase; `VersionPrefix` bumped.

Closes #3119. Supersedes #3109.
