### PR TITLE
Lower .NET Framework floor to net462; retarget release as v5.4.4

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,9 +13,8 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
-## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
-* BRK: Raise the .NET Framework floor to `net481` for all packages, dropping the `net461` and `net462` targets.
-* DEP: Update the minor-and-patch dependency group, notably `Microsoft.Diagnostics.Tracing.TraceEvent` 3.2.4, `System.Collections.Immutable` and `System.Reflection.Metadata` 9.0.8, and `System.Data.SqlClient` 4.9.1.
+## **v5.4.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.4) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.4)
+* DEP: Update the minor-and-patch dependency group, notably `Microsoft.Diagnostics.Tracing.TraceEvent` 3.2.4, `System.Collections.Immutable` and `System.Reflection.Metadata` 9.0.8, and `System.Data.SqlClient` 4.9.1; these drop `net461`, raising the `net461` packages to a `net462` floor.
 * DEP: `Microsoft.Extensions.Logging.ApplicationInsights` 2.23.0; `ServiceProviderFactory` configures Application Insights via connection string instead of the obsolete instrumentation-key API.
 
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -10,14 +10,14 @@
 $Frameworks = @{}
 
 # .NET Framework versions for which we build.
-# net481 is our minimal supported .NET Framework, and the floor
+# net462 is our minimal supported .NET Framework, and the floor
 # required for internal Microsoft consumption.
-$Frameworks.NetFx = @("net481")
+$Frameworks.NetFx = @("net462")
 
 # Frameworks for which we build libraries.
 $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 
-# net481 is the current minimum supported .NET
+# net462 is the current minimum supported .NET
 # framework, so we use it for all client tools.
 # it is fine to support a down-level, unsupported
 # .NET framework for a library, because the client 
@@ -25,7 +25,7 @@ $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 # current .NET framework. When we control the app
 # we will require the minimal supported version to 
 # ensure that the runtime we are executing on is secure.
-$Frameworks.ApplicationNetFx = @("net481")
+$Frameworks.ApplicationNetFx = @("net462")
 
 # Frameworks for which we build applications.
 $Frameworks.Application = @("net8.0") + $Frameworks.ApplicationNetFx

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -21,14 +21,14 @@
   </metadata>
   <files>
     <!-- The subfolder layout for the different TargetFrameworks is intentionally inconsistent -->
-    <!-- net481 and net8.0 pack to tools\TargetFramework\* for backcompat -->
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\Sarif.Multitool.exe.config"
-          target="tools\net481" />
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\**"
-          target="tools\net481"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\Sarif*;bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net481\WorkItems.dll;" />
-    <file src="bld\bin\Signing\net481\**"
-          target="tools\net481" />
+    <!-- net462 and net8.0 pack to tools\TargetFramework\* for backcompat -->
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\Sarif.Multitool.exe.config"
+          target="tools\net462" />
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\**"
+          target="tools\net462"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\Sarif*;bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net462\WorkItems.dll;" />
+    <file src="bld\bin\Signing\net462\**"
+          target="tools\net462" />
 
     <!-- net8.0 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net8.0\**"

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
+++ b/src/Sarif.Multitool.Library/Sarif.Multitool.Library.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Sarif.Multitool</RootNamespace>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="default.configuration.xml" Pack="true" PackagePath="lib/netstandard2.0;lib/net481" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="default.configuration.xml" Pack="true" PackagePath="lib/netstandard2.0;lib/net462" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\policies\*" Pack="true" PackagePath="policies" />
     <None Include="**\*.cs" Pack="true" PackagePath="src" />
     <None Include="..\..\ReleaseHistory.md" Pack="true" PackagePath="/" />

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -34,8 +34,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <!-- net481 is the current minimal supported .NET framework. -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <!-- net462 is the current minimal supported .NET framework. -->
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sarif.WorkItems/Sarif.WorkItems.csproj
+++ b/src/Sarif.WorkItems/Sarif.WorkItems.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 

--- a/src/Test.Plugins/Test.Plugins.csproj
+++ b/src/Test.Plugins/Test.Plugins.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
+++ b/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Test.UnitTests.Sarif.WorkItems</RootNamespace>
@@ -34,7 +34,7 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
 

--- a/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
+++ b/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -20,8 +20,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <!-- We require net481 as a minimal framework due to dependency such as Microsoft.Extensions.Logging.Console -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+    <!-- net462 is the floor: System.Collections.Immutable / System.Reflection.Metadata 9.x drop net461. -->
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.5.0</VersionPrefix>
+    <VersionPrefix>5.4.4</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
Lower the .NET Framework floor from `net481` to `net462` across all packages, and retarget this cycle's release as a `5.4.4` patch (was `5.5.0`).

The dependency bumps landed in #3120 require only `net462` — `System.Collections.Immutable` / `System.Reflection.Metadata` 9.0.8 and `System.Data.SqlClient` 4.9.1 drop `net461`. `net481` was not technically required. Since the effective consumer floor only moves `net461` -> `net462`, a patch is warranted rather than a minor.

### Changes
- `net481` -> `net462` across all csproj/nuspec/psm1 (14 files).
- `VersionPrefix` 5.5.0 -> 5.4.4.
- `ReleaseHistory.md`: retarget the section to v5.4.4; the floor change is folded into the dependency `DEP` bullet.

### Validation
- `dotnet build -c Release`: 0 warnings / 0 errors.
- net462 WorkItems tests: 57/57 pass (16 + 41).

Supersedes the closed release PR #3122.
