### PR TITLE
Omit non-superset contextRegion in TypeScript constructMultilineContextSnippet

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
-* BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char snippet cap or the char-offset window is not a proper superset of `region`, matching the .NET `FileRegionsCache.ConstructMultilineContextSnippet` so long single lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
+* BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char snippet cap or the char window is not a proper superset of `region`, matching the .NET port so long lines no longer emit SARIF that `SARIF1008` rejects.
 
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)
 * BUG: `GHAzDO1019.ProvidePipelineProperties`, the `emit-run` pipeline-context producer, and the `ai-sarif-log.schema.json` build contract accept `-1` as the buildDefinitionId sentinel for runs with no saved definition, still rejecting `0` and other negatives.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **UNRELEASED**
+* BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char snippet cap or the char-offset window is not a proper superset of `region`, matching the .NET `FileRegionsCache.ConstructMultilineContextSnippet` so long single lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
+
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)
 * BUG: `GHAzDO1019.ProvidePipelineProperties`, the `emit-run` pipeline-context producer, and the `ai-sarif-log.schema.json` build contract accept `-1` as the buildDefinitionId sentinel for runs with no saved definition, still rejecting `0` and other negatives.
 * BUG: `SarifLogger` indexes only extension `toolComponent`s that declare the optional `guid` (SARIF §3.19.6), instead of throwing when one is absent.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,7 @@ Each release entry below is prefixed with one of:
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
 ## **UNRELEASED**
-* BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char snippet cap or the char window is not a proper superset of `region`, matching the .NET port so long lines no longer emit SARIF that `SARIF1008` rejects.
+* BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char cap or the window is not a proper superset of `region`, so long lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
 
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)
 * BUG: `GHAzDO1019.ProvidePipelineProperties`, the `emit-run` pipeline-context producer, and the `ai-sarif-log.schema.json` build contract accept `-1` as the buildDefinitionId sentinel for runs with no saved definition, still rejecting `0` and other negatives.

--- a/npm/sarif/src/regions.ts
+++ b/npm/sarif/src/regions.ts
@@ -223,7 +223,11 @@ export class FileRegionsCache {
     const original = this.populateTextRegionProperties(inputRegion, absoluteUri, true);
 
     if ((original.charLength ?? 0) >= BIG_SNIPPET_LENGTH) {
-      return { ...original };
+      // A context region must be a proper superset of the region (SARIF §3.29.5,
+      // enforced by SARIF1008). The region already meets the snippet cap, so no
+      // larger in-cap snippet exists; omit the context region rather than return
+      // one identical to the region.
+      return undefined;
     }
 
     const maxLine = idx.maximumLineNumber;
@@ -243,7 +247,12 @@ export class FileRegionsCache {
     const charOffset = Math.max(0, (original.charOffset ?? 0) - SMALL_SNIPPET_LENGTH);
     const charLength = Math.min(BIG_SNIPPET_LENGTH, fileText.length - charOffset);
     context = this.populateTextRegionProperties({ charOffset, charLength }, absoluteUri, true);
-    return context;
+
+    // The capped char-offset window does not always contain the region (a region
+    // longer than the window's reach past its start runs off the end). Emit the
+    // context region only when it is a genuine proper superset of the region;
+    // otherwise omit it (SARIF §3.29.5 / SARIF1008).
+    return isProperSupersetOf(context, original) ? context : undefined;
   }
 }
 
@@ -253,6 +262,80 @@ export class FileRegionsCache {
 
 function isBinaryRegion(r: Region): boolean {
   return r.byteOffset !== undefined && r.byteOffset >= 0;
+}
+
+// ---------------------------------------------------------------------------
+// Proper-superset test (mirrors Region.IsProperSupersetOf)
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `sup` strictly contains `sub`: every position covered by `sub` lies
+ * within `sup` and the two spans are not identical. Each populated coordinate
+ * dimension (line/column, char offset) must independently hold. Mirrors
+ * Region.IsProperSupersetOf.
+ */
+function isProperSupersetOf(sup: Region, sub: Region): boolean {
+  if (
+    isLineColumnBasedRegion(sup) &&
+    isLineColumnBasedRegion(sub) &&
+    !isLineColumnProperSupersetOf(sup, sub)
+  ) {
+    return false;
+  }
+
+  if (
+    isOffsetBasedRegion(sup) &&
+    isOffsetBasedRegion(sub) &&
+    !isOffsetProperSupersetOf(sup, sub)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isLineColumnBasedRegion(r: Region): boolean {
+  return (r.startLine ?? 0) >= 1;
+}
+
+function isOffsetBasedRegion(r: Region): boolean {
+  return (r.charOffset ?? -1) >= 0;
+}
+
+function isLineColumnProperSupersetOf(sup: Region, sub: Region): boolean {
+  const supStartLine = sup.startLine ?? 0;
+  const supEndLine = sup.endLine ?? supStartLine;
+  const supStartColumn = sup.startColumn ?? 1;
+  const supEndColumn = sup.endColumn ?? Number.MAX_SAFE_INTEGER;
+  const subStartLine = sub.startLine ?? 0;
+  const subEndLine = sub.endLine ?? subStartLine;
+  const subStartColumn = sub.startColumn ?? 1;
+  const subEndColumn = sub.endColumn ?? Number.MAX_SAFE_INTEGER;
+
+  if (supStartLine > subStartLine || supEndLine < subEndLine) return false;
+  if (supStartLine === subStartLine && supStartColumn > subStartColumn) return false;
+  if (supEndLine === subEndLine && supEndColumn < subEndColumn) return false;
+
+  // Identical span is not a proper superset.
+  return !(
+    supStartLine === subStartLine &&
+    supEndLine === subEndLine &&
+    supStartColumn === subStartColumn &&
+    supEndColumn === subEndColumn
+  );
+}
+
+function isOffsetProperSupersetOf(sup: Region, sub: Region): boolean {
+  const supOffset = sup.charOffset ?? 0;
+  const supLength = sup.charLength ?? 0;
+  const subOffset = sub.charOffset ?? 0;
+  const subLength = sub.charLength ?? 0;
+
+  if (supOffset > subOffset) return false;
+  if (supOffset + supLength < subOffset + subLength) return false;
+
+  // Same start and no greater length is not a proper superset.
+  return !(supOffset === subOffset && supLength <= subLength);
 }
 
 function reconcile(

--- a/npm/sarif/test/regions.test.js
+++ b/npm/sarif/test/regions.test.js
@@ -36,6 +36,22 @@ function withTempFile(content, fn) {
   }
 }
 
+// A context region must be a proper superset of its region (SARIF §3.29.5,
+// enforced by SARIF1008): it must fully contain the region and not be identical
+// to it. Omitting the context region entirely is always conformant.
+function assertContextOmittedOrProperSuperset(ctx, regionStart, regionEnd) {
+  if (ctx === undefined) return;
+  const ctxStart = ctx.charOffset ?? 0;
+  const ctxEnd = ctxStart + (ctx.charLength ?? 0);
+  const contains = ctxStart <= regionStart && ctxEnd >= regionEnd;
+  const identical = ctxStart === regionStart && ctxEnd === regionEnd;
+  assert.ok(
+    contains && !identical,
+    `context region [${ctxStart}..${ctxEnd}] must be a proper superset of region ` +
+      `[${regionStart}..${regionEnd}] (SARIF §3.29.5 / SARIF1008), or be omitted`,
+  );
+}
+
 test('NewLineIndex counts lines across LF, CRLF, and bare CR', () => {
   assert.equal(new NewLineIndex(MIXED).maximumLineNumber, 4);
 });
@@ -127,5 +143,38 @@ test('constructMultilineContextSnippet widens to the neighbouring lines', () => 
     // line 2 of 4 → context spans lines 1..3.
     assert.equal(ctx.startLine, 1);
     assert.equal(ctx.endLine, 3);
+  });
+});
+
+// Variant 1 — the region already meets the 512-char snippet cap (a minified /
+// pathologically long line). No larger in-cap context exists, so the context
+// region must be omitted rather than returned byte-identical to the region.
+// The C# reference (FileRegionsCache.ConstructMultilineContextSnippet) returns
+// null here; the TypeScript port returned a clone of the region → SARIF1008.
+test('constructMultilineContextSnippet omits the context region when the region meets the snippet cap', () => {
+  const longLine = 'x'.repeat(900); // region charLength 900 >= 512
+  withTempFile(longLine, (uri) => {
+    const ctx = new FileRegionsCache().constructMultilineContextSnippet(
+      { startLine: 1, endLine: 1 },
+      uri,
+    );
+    assertContextOmittedOrProperSuperset(ctx, 0, 900);
+  });
+});
+
+// Variant 2 — the ±128 / 512-char char-offset window clamps short of a wide
+// region, so the window does not contain the region's full span. The C#
+// reference returns the window only when IsProperSupersetOf(region); the
+// TypeScript port returned it unconditionally → SARIF1008.
+test('constructMultilineContextSnippet omits the context region when the clamped window does not contain the region', () => {
+  const longLine = 'x'.repeat(1200);
+  withTempFile(longLine, (uri) => {
+    // region [600..1100]: charLength 500 (< 512, so the cap guard is skipped),
+    // window becomes [472..984], which ends before the region does.
+    const ctx = new FileRegionsCache().constructMultilineContextSnippet(
+      { charOffset: 600, charLength: 500 },
+      uri,
+    );
+    assertContextOmittedOrProperSuperset(ctx, 600, 1100);
   });
 });


### PR DESCRIPTION
The `@microsoft/sarif` port of `FileRegionsCache.constructMultilineContextSnippet` could emit a `contextRegion` that is not a proper superset of its `region`, tripping `SARIF1008` on pathologically long source lines. This ports the two guards the C# reference already has but the TS port had dropped.

## Root cause

Two divergences from `src/Sarif/FileRegionsCache.cs`:

| Variant | Trigger | C# (correct) | TS port (buggy) |
|---|---|---|---|
| identical | `region.charLength >= 512` (minified line) | omit | returns a clone byte-identical to `region` |
| non-superset | ±128/512-char window clamped short of a wide region | omit unless proper superset | returns the window unconditionally |

## Fix

In `npm/sarif/src/regions.ts`: return `undefined` in the `>= 512` branch, and add an `isProperSupersetOf` helper (a port of `Region.IsProperSupersetOf`) gating the char-offset-window return. `contextRegion` is optional (§3.29.5), so omitting it leaves `region` + snippet intact.

## Tests

Two cases in `regions.test.js` (one per variant) asserting a returned `contextRegion` strictly contains its `region` or is omitted. Both failed before, suite green now (41/41).

## Scope

TypeScript port only — the .NET `FileRegionsCache` was already correct and is untouched. No change to normal-length-line rendering.