### PR TITLE
Accept caller-attested self-hosted GHES hosts via --authorized-hosts

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **UNRELEASED**
+* NEW: `@microsoft/sarif-multitool-ts` `emit-run`/`emit-finalize` accept `--authorized-hosts ghe:<host>` (or `SARIF_AUTHORIZED_HOSTS`), so a caller-attested self-hosted GitHub Enterprise Server derives a github.com-style portable root instead of hard-failing; unattested hosts stay rejected.
+
 ## **v5.4.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.4.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.4.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.4.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.4.3) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.4.3)
 * BUG: `GHAzDO1019.ProvidePipelineProperties`, the `emit-run` pipeline-context producer, and the `ai-sarif-log.schema.json` build contract accept `-1` as the buildDefinitionId sentinel for runs with no saved definition, still rejecting `0` and other negatives.
 * BUG: `SarifLogger` indexes only extension `toolComponent`s that declare the optional `guid` (SARIF §3.19.6), instead of throwing when one is absent.

--- a/npm/sarif-multitool-ts/features/emit-finalize-authorized-hosts.feature
+++ b/npm/sarif-multitool-ts/features/emit-finalize-authorized-hosts.feature
@@ -1,0 +1,21 @@
+Feature: Attested self-hosted VCS hosts finalize instead of hard-failing
+
+  As a scanner running against a self-hosted GitHub Enterprise Server
+  I want to attest the GHES host as ghe:<host>
+  So that an unrecognized host does not discard a completed scan
+
+  Background:
+    Given a clean working directory
+
+  Scenario: An attested ghe host rebases to a blob permalink root
+    Given an open event log for tool "ai-scanner" with a GHES source root and VCP authorized as "ghe:gecgithub01.walmart.com"
+    When emit-results is invoked with a result at "src/app.ts" line 1
+    And emit-finalize is invoked with the authorized host
+    Then the finalized SARIF originalUriBaseIds "SRCROOT" uri starts with "https://gecgithub01.walmart.com/"
+    And the finalized SARIF originalUriBaseIds "SRCROOT" uri contains "/blob/"
+    And the finalized SARIF contains no "file://" anywhere
+
+  Scenario: An unattested self-hosted host fails emit-run
+    Given a GHES run header for tool "ai-scanner"
+    When emit-run is invoked expecting failure
+    Then the failure message mentions "is not a supported host"

--- a/npm/sarif-multitool-ts/features/steps/steps.mjs
+++ b/npm/sarif-multitool-ts/features/steps/steps.mjs
@@ -16,6 +16,7 @@ import {
   replay,
   wipPathFor,
 } from '../../dist/index.js';
+import { parseAuthorizedHosts } from '@microsoft/sarif';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -184,6 +185,43 @@ When('emit-run is invoked expecting failure', async function () {
   } catch (err) {
     this.lastError = err;
   }
+});
+
+// ---------------------------------------------------------------------------
+// Given/When — attested self-hosted (GHES) hosts
+// ---------------------------------------------------------------------------
+
+Given(
+  'an open event log for tool {string} with a GHES source root and VCP authorized as {string}',
+  async function (name, hostsSpec) {
+    if (!this.tmp) this.init();
+    this.runHeader = this.ghesRunHeader();
+    this.runHeader.tool.driver.name = name;
+    const parsed = parseAuthorizedHosts(hostsSpec);
+    assert.ok(parsed.ok, parsed.ok ? '' : parsed.error);
+    this.authorizedHosts = parsed.value;
+    await emitRun({
+      output: this.output,
+      run: this.runHeader,
+      authorizedHosts: this.authorizedHosts,
+      env: this.env,
+    });
+  },
+);
+
+Given('a GHES run header for tool {string}', function (name) {
+  if (!this.tmp) this.init();
+  this.runHeader = this.ghesRunHeader();
+  this.runHeader.tool.driver.name = name;
+});
+
+When('emit-finalize is invoked with the authorized host', async function () {
+  const r = await emitFinalize({
+    output: this.output,
+    keepWip: true,
+    authorizedHosts: this.authorizedHosts,
+  });
+  this.finalizedLog = r.log;
 });
 
 // ---------------------------------------------------------------------------

--- a/npm/sarif-multitool-ts/features/steps/world.mjs
+++ b/npm/sarif-multitool-ts/features/steps/world.mjs
@@ -61,6 +61,17 @@ class EmitWorld {
     return header;
   }
 
+  /**
+   * A finalizable run header whose VCP repositoryUri is a self-hosted GitHub
+   * Enterprise Server custom domain (unrecognizable without attestation).
+   */
+  ghesRunHeader() {
+    const header = this.finalizableRunHeader(true);
+    header.versionControlProvenance[0].repositoryUri =
+      'https://gecgithub01.walmart.com/AI-INNOVATION-LAB/pawprints';
+    return header;
+  }
+
   cleanup() {
     if (this.tmp) {
       try {

--- a/npm/sarif-multitool-ts/src/cli.ts
+++ b/npm/sarif-multitool-ts/src/cli.ts
@@ -26,7 +26,7 @@ import { getSchema, listSchemas } from './getSchema.js';
 import { getSkill, listSkills } from './getSkill.js';
 import { getCweTaxonomy } from './getCwe.js';
 import { EmitVerbError, type BatchOutcome } from './batch.js';
-import { atomicWrite } from '@microsoft/sarif';
+import { atomicWrite, parseAuthorizedHosts, type AuthorizedHost } from '@microsoft/sarif';
 
 // Mirrors EmitVerbAliases.cs — accepted through the v5.x deprecation window.
 const DEPRECATED_TO_CANONICAL: Readonly<Record<string, string>> = {
@@ -122,12 +122,12 @@ const HELP = `\
 sarif — native-TypeScript SARIF Multitool verbs (no CLR)
 
 emit chain:
-  sarif emit-run <output.sarif> [--input <run.json>] [--force-overwrite]
+  sarif emit-run <output.sarif> [--input <run.json>] [--authorized-hosts <type:host,...>] [--force-overwrite]
   sarif emit-results <output.sarif> [--input <results.json>]
   sarif emit-invocations <output.sarif> [--input <invocations.json>]
   sarif emit-rule-descriptors <output.sarif> [--input <descriptors.json>]
   sarif emit-notification-descriptors <output.sarif> [--input <descriptors.json>]
-  sarif emit-finalize <output.sarif> [--no-cwe-enrichment] [--minify] [--keep-wip] [--no-repo] [--validate]
+  sarif emit-finalize <output.sarif> [--no-cwe-enrichment] [--minify] [--keep-wip] [--no-repo] [--authorized-hosts <type:host,...>] [--validate]
 
 asset verbs:
   sarif get-schema <emit-verb> [--output <path>] [--force-overwrite] | --list
@@ -135,6 +135,10 @@ asset verbs:
   sarif get-cwe [--output <path>] [--force-overwrite]
 
 When --input is omitted the payload JSON is read from stdin.
+--authorized-hosts attests self-hosted VCS instances as <hostType>:<host>
+(comma-separated, e.g. ghe:githost.contoso.com); pass it to both emit-run and
+emit-finalize, or set SARIF_AUTHORIZED_HOSTS. Only the ghe host type is
+currently recognized.
 Deprecated add-* verb names are accepted with a warning through v5.x.
 Verbs not listed above are not yet ported; use \`npx @microsoft/sarif-multitool <verb>\`.
 `;
@@ -146,6 +150,19 @@ async function main(): Promise<number> {
   const fileOut = typeof flags.output === 'string' ? flags.output : undefined;
   const force = !!flags['force-overwrite'];
 
+  // Caller-attested self-hosted VCS hosts (<hostType>:<host>), from the flag or
+  // the SARIF_AUTHORIZED_HOSTS env fallback. Parsed once; emit-run and
+  // emit-finalize must both see it (the host is derived independently in each).
+  const authorizedHostsRaw =
+    typeof flags['authorized-hosts'] === 'string'
+      ? (flags['authorized-hosts'] as string)
+      : process.env.SARIF_AUTHORIZED_HOSTS;
+  const authorizedHostsResult = parseAuthorizedHosts(authorizedHostsRaw);
+  if (!authorizedHostsResult.ok) {
+    throw new EmitVerbError(authorizedHostsResult.error);
+  }
+  const authorizedHosts: readonly AuthorizedHost[] = authorizedHostsResult.value;
+
   switch (verb) {
     case 'emit-run': {
       const run = readJsonInput(input, 'run');
@@ -156,6 +173,7 @@ async function main(): Promise<number> {
         output,
         run: run as Record<string, unknown>,
         forceOverwrite: force,
+        authorizedHosts,
       });
       for (const w of r.warnings) process.stderr.write(w + '\n');
       process.stdout.write(`Opened '${r.wipPath}' for '${r.toolName}'.\n`);
@@ -194,6 +212,7 @@ async function main(): Promise<number> {
         keepWip: !!flags['keep-wip'],
         noRepo: !!flags['no-repo'],
         validate: !!flags.validate,
+        authorizedHosts,
       });
       for (const w of r.warnings) process.stderr.write(w + '\n');
       process.stdout.write(

--- a/npm/sarif-multitool-ts/src/emitFinalize.ts
+++ b/npm/sarif-multitool-ts/src/emitFinalize.ts
@@ -17,6 +17,7 @@ import { promises as fs } from 'node:fs';
 import { resolve as resolvePath } from 'node:path';
 import {
   type SarifLog,
+  type AuthorizedHost,
   atomicWrite,
   serializeSarifLog,
   isGitHubHostedRun,
@@ -55,6 +56,15 @@ export interface EmitFinalizeOptions {
    * requirement in both the schema and the AI1004 rule. Mirrors the .NET --no-repo switch.
    */
   noRepo?: boolean;
+  /**
+   * Hosts the caller attests are self-hosted VCS instances (`<hostType>:<host>`,
+   * parsed by `parseAuthorizedHosts`), so their
+   * `versionControlProvenance.repositoryUri` derives a portable root per the
+   * attested product instead of failing rebase, and a `ghe` host makes the run
+   * GitHub-hosted. Must match the value passed to `emit-run`. Matched
+   * case-insensitively.
+   */
+  authorizedHosts?: readonly AuthorizedHost[];
 }
 
 export interface EmitFinalizeOutcome {
@@ -95,7 +105,7 @@ export async function emitFinalize(opts: EmitFinalizeOptions): Promise<EmitFinal
 
     applyAISecuritySeverity(run);
 
-    const github = isGitHubHostedRun(run);
+    const github = isGitHubHostedRun(run, { authorizedHosts: opts.authorizedHosts });
     if (github) {
       applyGitHubCweTags(run);
       collapseResultRuleSubIds(run);
@@ -116,7 +126,7 @@ export async function emitFinalize(opts: EmitFinalizeOptions): Promise<EmitFinal
   // file:// bases.
   for (const run of log.runs ?? []) {
     if (!run) continue;
-    const r = rebaseRun(run, opts.noRepo);
+    const r = rebaseRun(run, opts.noRepo, opts.authorizedHosts);
     if (!r.success) {
       throw new EmitVerbError(r.errors.join('\n'));
     }

--- a/npm/sarif-multitool-ts/src/emitRun.ts
+++ b/npm/sarif-multitool-ts/src/emitRun.ts
@@ -24,6 +24,7 @@ import {
   type EnvGetter,
 } from './ciContext.js';
 import { tryValidateRepositoryUri } from '@microsoft/sarif';
+import type { AuthorizedHost } from '@microsoft/sarif';
 import { EmitVerbError } from './batch.js';
 
 export const SOURCE_ROOT_BASE_ID = 'SRCROOT';
@@ -41,6 +42,14 @@ export interface EmitRunOptions {
   run: Obj;
   /** Replace an existing .sarif or in-progress .wip.jsonl at the destination. */
   forceOverwrite?: boolean;
+  /**
+   * Hosts the caller attests are self-hosted VCS instances (`<hostType>:<host>`,
+   * parsed by `parseAuthorizedHosts`), so their
+   * `versionControlProvenance.repositoryUri` validates against the attested
+   * product instead of being rejected as unsupported. Matched
+   * case-insensitively.
+   */
+  authorizedHosts?: readonly AuthorizedHost[];
   /** Test seam; defaults to process.env. */
   env?: EnvGetter;
 }
@@ -88,7 +97,7 @@ export async function emitRun(opts: EmitRunOptions): Promise<EmitRunOutcome> {
     stampVcp(runObject, merged.repositoryUri, merged.revisionId, merged.branch);
   }
 
-  validateVcpRepositoryShapes(runObject);
+  validateVcpRepositoryShapes(runObject, opts.authorizedHosts);
 
   const outputPath = resolvePath(opts.output);
   const wipPath = wipPathFor(outputPath);
@@ -263,13 +272,16 @@ function validateOptionalAiOrigin(token: unknown): void {
   }
 }
 
-function validateVcpRepositoryShapes(runObject: Obj): void {
+function validateVcpRepositoryShapes(
+  runObject: Obj,
+  authorizedHosts?: readonly AuthorizedHost[],
+): void {
   const vcp = runObject.versionControlProvenance;
   if (!Array.isArray(vcp)) return;
   for (let i = 0; i < vcp.length; i++) {
     const repoUri = isObj(vcp[i]) ? (vcp[i] as Obj).repositoryUri : undefined;
     if (typeof repoUri !== 'string' || !repoUri) continue;
-    const r = tryValidateRepositoryUri(repoUri);
+    const r = tryValidateRepositoryUri(repoUri, { authorizedHosts });
     if (!r.ok) {
       throw new EmitVerbError(`versionControlProvenance[${i}]: ${r.error}`);
     }

--- a/npm/sarif-multitool-ts/src/rebase.ts
+++ b/npm/sarif-multitool-ts/src/rebase.ts
@@ -8,7 +8,7 @@
  * Ported from src/Sarif.Multitool.Library/Emit/EmitFinalizeRebaseVisitor.cs.
  */
 
-import type { Run, ArtifactLocation, VersionControlDetails } from '@microsoft/sarif';
+import type { Run, ArtifactLocation, VersionControlDetails, AuthorizedHost } from '@microsoft/sarif';
 import { tryDerivePortableRoot } from '@microsoft/sarif';
 import { tryReconstructAbsoluteUri } from '@microsoft/sarif';
 import { SOURCE_ROOT_BASE_ID } from './emitRun.js';
@@ -31,14 +31,18 @@ export interface RebaseResult {
 }
 
 /** Rebases the run in place. Returns errors (success ↔ errors.length === 0). */
-export function rebaseRun(run: Run, noRepo = false): RebaseResult {
+export function rebaseRun(
+  run: Run,
+  noRepo = false,
+  authorizedHosts?: readonly AuthorizedHost[],
+): RebaseResult {
   if (noRepo) return rebaseRunRepoless(run);
 
   const errors: string[] = [];
   const referencedBaseIds = new Set<string>();
   const leakUris: string[] = [];
 
-  const planResult = buildPlan(run, errors);
+  const planResult = buildPlan(run, errors, authorizedHosts);
   if (!planResult) return { success: false, errors };
   const plan = planResult;
 
@@ -119,7 +123,11 @@ function rebaseRunRepoless(run: Run): RebaseResult {
   return { success: errors.length === 0, errors };
 }
 
-function buildPlan(run: Run, errors: string[]): RepoRoot[] | undefined {
+function buildPlan(
+  run: Run,
+  errors: string[],
+  authorizedHosts?: readonly AuthorizedHost[],
+): RepoRoot[] | undefined {
   const vcp = run.versionControlProvenance;
   if (!vcp || vcp.length === 0) {
     errors.push(
@@ -186,7 +194,7 @@ function buildPlan(run: Run, errors: string[]): RepoRoot[] | undefined {
     }
     seenLocalRoots.set(localKey, i);
 
-    const derived = tryDerivePortableRoot(vcd.repositoryUri, vcd.revisionId);
+    const derived = tryDerivePortableRoot(vcd.repositoryUri, vcd.revisionId, { authorizedHosts });
     if (!derived.ok) {
       errors.push(`${where}: ${derived.error}`);
       return undefined;

--- a/npm/sarif/src/index.ts
+++ b/npm/sarif/src/index.ts
@@ -18,7 +18,11 @@ export {
   tryValidateRepositoryUri,
   tryDerivePortableRoot,
   isGitHubHostedRun,
+  parseAuthorizedHosts,
   type PortableRoot,
+  type VcpOptions,
+  type AuthorizedHost,
+  type AuthorizedHostType,
 } from './vcp.js';
 export {
   insertOptionalData,

--- a/npm/sarif/src/vcp.ts
+++ b/npm/sarif/src/vcp.ts
@@ -33,6 +33,36 @@ export interface PortableRoot {
   revisionWebUrl: string;
 }
 
+/**
+ * A VCS product recognized by portable-root derivation. Extensible: a new
+ * product (e.g. `gitlab`, `bitbucket`) is a new type with its own permalink
+ * shape in `classify`/`tryDerivePortableRoot`. Currently only `ghe` (GitHub
+ * Enterprise Server) is recognized.
+ */
+export type AuthorizedHostType = 'ghe';
+
+const AUTHORIZED_HOST_TYPES: readonly AuthorizedHostType[] = ['ghe'];
+
+export interface AuthorizedHost {
+  /** The VCS product running on `host`. */
+  type: AuthorizedHostType;
+  /** The host, lowercased, e.g. `githost.contoso.com`. */
+  host: string;
+}
+
+export interface VcpOptions {
+  /**
+   * Caller-attested hosts, each tagged with the VCS product running there (see
+   * `parseAuthorizedHosts` for the `<hostType>:<host>` grammar). A self-hosted
+   * instance runs on a custom domain that is structurally indistinguishable
+   * from any other host, so it cannot be auto-recognized; an attested host is
+   * classified per its type (a `ghe` host mints a github.com-style
+   * `{host}/{owner}/{repo}/blob/{sha}/` portable root). Matched
+   * case-insensitively.
+   */
+  authorizedHosts?: readonly AuthorizedHost[];
+}
+
 type Result<T> = { ok: true; value: T } | { ok: false; error: string };
 
 function ok<T>(value: T): Result<T> {
@@ -42,9 +72,47 @@ function err<T>(error: string): Result<T> {
   return { ok: false, error };
 }
 
-function isGitHubHost(host: string): boolean {
+/**
+ * Parses a comma-separated `--authorized-hosts` value of `<hostType>:<host>`
+ * tokens (e.g. `ghe:githost.contoso.com,ghe:other.example.com`) into attested
+ * hosts. A new VCS product is added by extending `AuthorizedHostType` and the
+ * derivation switch, not by changing this grammar. Currently only `ghe`
+ * (GitHub Enterprise Server) is recognized.
+ */
+export function parseAuthorizedHosts(raw: string | undefined): Result<AuthorizedHost[]> {
+  const hosts: AuthorizedHost[] = [];
+  if (!raw?.trim()) return ok(hosts);
+  for (const token of raw.split(',')) {
+    const spec = token.trim();
+    if (!spec) continue;
+    const colon = spec.indexOf(':');
+    if (colon <= 0 || colon === spec.length - 1) {
+      return err(
+        `authorized host '${spec}' must take the form <hostType>:<host> (e.g. ghe:githost.contoso.com).`,
+      );
+    }
+    const type = spec.slice(0, colon).toLowerCase();
+    const host = spec.slice(colon + 1).trim().toLowerCase();
+    if (!(AUTHORIZED_HOST_TYPES as readonly string[]).includes(type)) {
+      return err(
+        `authorized host '${spec}' uses unknown host type '${type}'; supported types: ${AUTHORIZED_HOST_TYPES.join(', ')}.`,
+      );
+    }
+    if (!host || INVALID_SCP_HOST_CHARS.test(host)) {
+      return err(`authorized host '${spec}' has an invalid host.`);
+    }
+    hosts.push({ type: type as AuthorizedHostType, host });
+  }
+  return ok(hosts);
+}
+
+function isGitHubHost(host: string, authorizedHosts?: readonly AuthorizedHost[]): boolean {
   const h = host.toLowerCase();
-  return h === 'github.com' || h.endsWith('.ghe.com');
+  if (h === 'github.com' || h.endsWith('.ghe.com')) return true;
+  // A caller-attested GitHub Enterprise Server runs on a custom domain that is
+  // structurally indistinguishable from any other host, so it cannot be
+  // auto-recognized; an attested `ghe` host is classified as GitHub.
+  return authorizedHosts?.some((a) => a.type === 'ghe' && a.host.toLowerCase() === h) ?? false;
 }
 
 function isLegacyAzureDevOpsHost(host: string): boolean {
@@ -171,7 +239,7 @@ function tryNormalizeToHttps(rawRepositoryUri: string): Result<URL> {
   }
 }
 
-function classify(rawRepositoryUri: string | undefined): Result<Classification> {
+function classify(rawRepositoryUri: string | undefined, options?: VcpOptions): Result<Classification> {
   if (!rawRepositoryUri) {
     return err('repositoryUri is required so a portable root can be derived.');
   }
@@ -198,7 +266,7 @@ function classify(rawRepositoryUri: string | undefined): Result<Classification> 
   const schemeAndServer = `${u.protocol}//${u.host}`;
   const host = u.hostname;
 
-  if (isGitHubHost(host)) {
+  if (isGitHubHost(host, options?.authorizedHosts)) {
     if (segments.length !== 2) {
       return err(`github repositoryUri must take the form https://<host>/<owner>/<repo>; '${display}' did not.`);
     }
@@ -251,8 +319,11 @@ function classify(rawRepositoryUri: string | undefined): Result<Classification> 
 }
 
 /** Validates that a portable root can be derived (no revisionId required). */
-export function tryValidateRepositoryUri(rawRepositoryUri: string): Result<{ leaf: string }> {
-  const c = classify(rawRepositoryUri);
+export function tryValidateRepositoryUri(
+  rawRepositoryUri: string,
+  options?: VcpOptions,
+): Result<{ leaf: string }> {
+  const c = classify(rawRepositoryUri, options);
   return c.ok ? ok({ leaf: c.value.leaf }) : c;
 }
 
@@ -260,8 +331,9 @@ export function tryValidateRepositoryUri(rawRepositoryUri: string): Result<{ lea
 export function tryDerivePortableRoot(
   rawRepositoryUri: string,
   revisionId: string,
+  options?: VcpOptions,
 ): Result<PortableRoot> {
-  const cr = classify(rawRepositoryUri);
+  const cr = classify(rawRepositoryUri, options);
   if (!cr.ok) return cr;
   const c = cr.value;
 
@@ -284,12 +356,12 @@ export function tryDerivePortableRoot(
  * repositoryUri classifies as a supported GitHub host. Mirrors
  * VcpPortableRoot.IsGitHubHostedRun.
  */
-export function isGitHubHostedRun(run: Run): boolean {
+export function isGitHubHostedRun(run: Run, options?: VcpOptions): boolean {
   const vcp = run.versionControlProvenance;
   if (!vcp || vcp.length === 0) return false;
   for (const d of vcp) {
     if (!d) return false;
-    const c = classify(d.repositoryUri);
+    const c = classify(d.repositoryUri, options);
     if (!c.ok || !c.value.isGitHub) return false;
   }
   return true;

--- a/npm/sarif/test/vcp.test.js
+++ b/npm/sarif/test/vcp.test.js
@@ -11,7 +11,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { tryValidateRepositoryUri, tryDerivePortableRoot, isGitHubHostedRun } from '../dist/index.js';
+import {
+  tryValidateRepositoryUri,
+  tryDerivePortableRoot,
+  isGitHubHostedRun,
+  parseAuthorizedHosts,
+} from '../dist/index.js';
 
 test('tryDerivePortableRoot mints a GitHub blob root from an https clone URL', () => {
   const r = tryDerivePortableRoot('https://github.com/contoso/widgets', 'abc123');
@@ -81,5 +86,80 @@ test('isGitHubHostedRun is false when any entry is a non-GitHub host', () => {
       ],
     }),
     false,
+  );
+});
+
+// --- Enterprise GitHub (GHES) host attestation -------------------------------
+// A self-hosted GitHub Enterprise Server uses a custom domain (e.g. Walmart's
+// gecgithub01.walmart.com) that is structurally indistinguishable from any
+// other host, so it cannot be auto-recognized. When the caller attests a host
+// as `ghe`, its permalinks are byte-identical to github.com
+// ({host}/{owner}/{repo}/blob/{sha}/), so the existing GitHub derivation path
+// applies unchanged.
+
+const GHES_URI = 'https://gecgithub01.walmart.com/AI-INNOVATION-LAB/pawprints';
+const GHES_HOSTS = [{ type: 'ghe', host: 'gecgithub01.walmart.com' }];
+
+test('parseAuthorizedHosts parses <hostType>:<host> tokens', () => {
+  const r = parseAuthorizedHosts('ghe:githost.contoso.com, ghe:Other.Example.com');
+  assert.ok(r.ok);
+  assert.deepEqual(r.value, [
+    { type: 'ghe', host: 'githost.contoso.com' },
+    { type: 'ghe', host: 'other.example.com' },
+  ]);
+});
+
+test('parseAuthorizedHosts returns an empty list for empty input', () => {
+  const r = parseAuthorizedHosts(undefined);
+  assert.ok(r.ok);
+  assert.deepEqual(r.value, []);
+});
+
+test('parseAuthorizedHosts rejects a token missing the host type', () => {
+  assert.equal(parseAuthorizedHosts('githost.contoso.com').ok, false);
+});
+
+test('parseAuthorizedHosts rejects an unknown host type', () => {
+  assert.equal(parseAuthorizedHosts('gitlab:git.contoso.com').ok, false);
+});
+
+test('tryDerivePortableRoot mints a GitHub-style blob root for an attested ghe host', () => {
+  const r = tryDerivePortableRoot(GHES_URI, 'abc123', { authorizedHosts: GHES_HOSTS });
+  assert.ok(r.ok);
+  assert.equal(
+    r.value.portableRoot,
+    'https://gecgithub01.walmart.com/AI-INNOVATION-LAB/pawprints/blob/abc123/',
+  );
+  assert.equal(r.value.leaf, 'pawprints');
+  assert.equal(
+    r.value.revisionWebUrl,
+    'https://gecgithub01.walmart.com/AI-INNOVATION-LAB/pawprints/tree/abc123',
+  );
+});
+
+test('tryValidateRepositoryUri accepts an attested ghe host', () => {
+  const r = tryValidateRepositoryUri(GHES_URI, { authorizedHosts: GHES_HOSTS });
+  assert.ok(r.ok);
+  assert.equal(r.value.leaf, 'pawprints');
+});
+
+test('ghe-host attestation is case-insensitive on the host', () => {
+  const r = tryValidateRepositoryUri(GHES_URI, {
+    authorizedHosts: [{ type: 'ghe', host: 'GECGitHub01.Walmart.com' }],
+  });
+  assert.ok(r.ok);
+});
+
+test('tryValidateRepositoryUri still rejects an unattested host (default-deny preserved)', () => {
+  assert.equal(tryValidateRepositoryUri(GHES_URI).ok, false);
+});
+
+test('isGitHubHostedRun is true when every VCP entry is an attested ghe host', () => {
+  assert.equal(
+    isGitHubHostedRun(
+      { versionControlProvenance: [{ repositoryUri: GHES_URI }] },
+      { authorizedHosts: GHES_HOSTS },
+    ),
+    true,
   );
 });


### PR DESCRIPTION
## Problem

`emit-run` / `emit-finalize` hard-fail (exit 1, discarding a completed scan's findings) when a repo's `versionControlProvenance.repositoryUri` is on a host the SDK doesn't recognize — `github.com`, `*.ghe.com`, `dev.azure.com`. Self-hosted **GitHub Enterprise Server** runs on custom domains (e.g. `gecgithub01.walmart.com`) that are structurally indistinguishable from any host, so they're rejected — even though a GHES permalink is byte-identical to github.com.

## Fix

An opt-in, caller-attested host allowlist in the `@microsoft/sarif` TypeScript port:

- `parseAuthorizedHosts()` parses comma-separated `<hostType>:<host>` tokens (e.g. `ghe:gecgithub01.walmart.com`). Extensible by design — a new VCS product is a new host type, not a new mechanism. Only `ghe` is recognized today.
- `VcpOptions.authorizedHosts` threads through `tryValidateRepositoryUri` / `tryDerivePortableRoot` / `isGitHubHostedRun`. An attested `ghe` host classifies as GitHub → mints the `{host}/{owner}/{repo}/blob/{sha}/` root.
- CLI: `emit-run` / `emit-finalize` accept `--authorized-hosts <type:host,...>` (or the `SARIF_AUTHORIZED_HOSTS` env var). Passed to **both** verbs, since the host is derived independently in each.
- **Default-deny preserved:** unattested unknown hosts are still rejected; `github.com` / `*.ghe.com` / `dev.azure.com` are unchanged.

## Tests

- 8 unit tests in `vcp.test.js` (parser grammar, derivation, case-insensitivity, default-deny).
- New `emit-finalize-authorized-hosts.feature`: attested `ghe` host rebases to a blob permalink; unattested host fails `emit-run`.
- `@microsoft/sarif` 48/48, `@microsoft/sarif-multitool-ts` 49 scenarios — all green.

## Scope

TypeScript port only. C# `VcpPortableRoot` parity tracked in #3131. Native GitLab/Bitbucket derivation is a follow-up on the same mechanism.