### PR TITLE
Release v5.5.0 (contextRegion SARIF1008 fix + --authorized-hosts GHES attestation)

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,7 +13,7 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
-## **UNRELEASED**
+## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
 * BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char cap or the window is not a proper superset of `region`, so long lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
 * NEW: `@microsoft/sarif-multitool-ts` `emit-run`/`emit-finalize` accept `--authorized-hosts ghe:<host>` (or `SARIF_AUTHORIZED_HOSTS`), so a caller-attested self-hosted GitHub Enterprise Server derives a github.com-style portable root instead of hard-failing; unattested hosts stay rejected.
 

--- a/src/build.props
+++ b/src/build.props
@@ -14,7 +14,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>5.4.3</VersionPrefix>
+    <VersionPrefix>5.5.0</VersionPrefix>
 
     <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
Cuts the v5.5.0 release: bumps `VersionPrefix` and promotes the `UNRELEASED` notes. No code changes — both fixes already merged to `main` (#3130, #3132).

## Changes

- **NEW:** `@microsoft/sarif-multitool-ts` `emit-run`/`emit-finalize` accept `--authorized-hosts ghe:<host>` (or `SARIF_AUTHORIZED_HOSTS`), so a caller-attested self-hosted GitHub Enterprise Server derives a github.com-style portable root instead of hard-failing; unattested hosts stay rejected. (#3132)
- **BUG:** `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char cap or the window is not a proper superset of `region`, so long lines no longer emit SARIF that `SARIF1008` rejects. (#3130)

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>