### PR TITLE
Reject path-traversal escapes in ArtifactLocation.TryReconstructAbsol…

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **UNRELEASED**
+* BUG: `ArtifactLocation.TryReconstructAbsoluteUri` returns false (leaving `resolvedUri` null) when a relative `uri`'s `../` segments escape the `originalUriBaseIds` base it resolves through, so enrichment no longer reads files outside a declared base.
+
 ## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
 * BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char cap or the window is not a proper superset of `region`, so long lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
 * NEW: `@microsoft/sarif-multitool-ts` `emit-run`/`emit-finalize` accept `--authorized-hosts ghe:<host>` (or `SARIF_AUTHORIZED_HOSTS`), so a caller-attested self-hosted GitHub Enterprise Server derives a github.com-style portable root instead of hard-failing; unattested hosts stay rejected.

--- a/src/Sarif/Core/ArtifactLocation.cs
+++ b/src/Sarif/Core/ArtifactLocation.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             //    - which lacks a Uri property (failure).
             ArtifactLocation artifactLocation = this;
             Uri stemUri = this.Uri;
+            string resolvedBaseString = null;
             while (!stemUri.IsAbsoluteUri)
             {
                 if (string.IsNullOrEmpty(artifactLocation.UriBaseId) ||
@@ -51,7 +52,15 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 string artifactLocationOriginalUriString = artifactLocation.Uri.OriginalString;
                 if (!artifactLocation.Uri.ToString().EndsWith("/")) { artifactLocationOriginalUriString += "/"; }
+                resolvedBaseString = artifactLocationOriginalUriString;
                 stemUri = new Uri(artifactLocationOriginalUriString + stemUri.OriginalString, UriKind.RelativeOrAbsolute);
+            }
+
+            // A relative reference must resolve at or beneath its base; '../' escapes (path traversal) are unresolvable.
+            var baseUri = new Uri(resolvedBaseString, UriKind.Absolute);
+            if (!baseUri.IsBaseOf(stemUri))
+            {
+                return false;
             }
 
             // If we got here, we found an absolute URI.

--- a/src/Test.UnitTests.Sarif/Core/ArtifactLocationTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ArtifactLocationTests.cs
@@ -176,6 +176,92 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         }
 
         [Fact]
+        public void TryReconstructAbsoluteUri_WhenRelativeUriEscapesBaseWithDotDot_ReturnsFalse()
+        {
+            AssertReconstructionFails(new Uri("../../../../Windows/System32/drivers/etc/hosts", UriKind.Relative));
+        }
+
+        [Fact]
+        public void TryReconstructAbsoluteUri_WhenRelativeUriEscapesBaseWithSingleDotDot_ReturnsFalse()
+        {
+            AssertReconstructionFails(new Uri("../secret.txt", UriKind.Relative));
+        }
+
+        [Fact]
+        public void TryReconstructAbsoluteUri_WhenDotDotEscapesBaseThroughChainedBase_ReturnsFalse()
+        {
+            var artifactLocation = new ArtifactLocation
+            {
+                Uri = new Uri("../../../../secret.txt", UriKind.Relative),
+                UriBaseId = SourceRootBaseId
+            };
+
+            var originalUriBaseIds = new Dictionary<string, ArtifactLocation>
+            {
+                [ProjectRootBaseId] = new ArtifactLocation
+                {
+                    Uri = new Uri("file://c:/code/sarif-sdk/", UriKind.Absolute)
+                },
+
+                [SourceRootBaseId] = new ArtifactLocation
+                {
+                    Uri = new Uri("src/", UriKind.Relative),
+                    UriBaseId = ProjectRootBaseId
+                }
+            };
+
+            bool wasResolved = artifactLocation.TryReconstructAbsoluteUri(originalUriBaseIds, out Uri resolvedUri);
+
+            wasResolved.Should().BeFalse();
+            resolvedUri.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryReconstructAbsoluteUri_WhenDotDotStaysWithinBase_ReturnsTrueWithResolvedUri()
+        {
+            var artifactLocation = new ArtifactLocation
+            {
+                Uri = new Uri("src/../README.md", UriKind.Relative),
+                UriBaseId = ProjectRootBaseId
+            };
+
+            var originalUriBaseIds = new Dictionary<string, ArtifactLocation>
+            {
+                [ProjectRootBaseId] = new ArtifactLocation
+                {
+                    Uri = new Uri("file://c:/code/sarif-sdk/", UriKind.Absolute)
+                }
+            };
+
+            bool wasResolved = artifactLocation.TryReconstructAbsoluteUri(originalUriBaseIds, out Uri resolvedUri);
+
+            wasResolved.Should().BeTrue();
+            resolvedUri.Should().Be(new Uri("file://c:/code/sarif-sdk/README.md", UriKind.Absolute));
+        }
+
+        private static void AssertReconstructionFails(Uri escapingRelativeUri)
+        {
+            var artifactLocation = new ArtifactLocation
+            {
+                Uri = escapingRelativeUri,
+                UriBaseId = ProjectRootBaseId
+            };
+
+            var originalUriBaseIds = new Dictionary<string, ArtifactLocation>
+            {
+                [ProjectRootBaseId] = new ArtifactLocation
+                {
+                    Uri = new Uri("file://c:/code/sarif-sdk/", UriKind.Absolute)
+                }
+            };
+
+            bool wasResolved = artifactLocation.TryReconstructAbsoluteUri(originalUriBaseIds, out Uri resolvedUri);
+
+            wasResolved.Should().BeFalse();
+            resolvedUri.Should().BeNull();
+        }
+
+        [Fact]
         public void ToLocation_ProducesExpectedLocationObject()
         {
             const string SourceFile = "src/Sarif/Core/ArtifactLocation.cs";


### PR DESCRIPTION
TryReconstructAbsoluteUri resolves a relative artifactLocation uri by concatenating it onto an originalUriBaseIds base. It never checked that the result stayed under that base, so a uri with ../ segments could resolve to an arbitrary path outside the base. When enrichment (insert / rewrite snippet and content population) reads that path, it copies file contents into the output SARIF.

This change validates containment. After the absolute uri is reconstructed, it must be at or beneath the base it resolved through (Uri.IsBaseOf). A reference that escapes its base returns false with a null resolvedUri, which is the method's existing "cannot reconstruct" result, so callers just skip enrichment for it.

The change is non-breaking. The absolute-uri passthrough at the top of the method is untouched, so SARIF with legitimate absolute paths is unaffected, and in-range .. that does not escape the base still resolves.

Reuses the same Uri.IsBaseOf containment check already used by RebaseUriVisitor and EmitFinalizeRebaseVisitor.

Added ArtifactLocationTests covering single, deep, and chained escapes (rejected), in-range .. (allowed), and confirmed the existing InsertOptionalDataVisitor and RebaseUri tests still pass.