### PR TITLE
Synthesize SarifLogger invocation only when the run has none

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -13,6 +13,9 @@ Each release entry below is prefixed with one of:
 
 Entries are terse by design: one line per change, present-tense behavior, complete but only essential data. No issue/PR archaeology or narrative — that history lives in the engineering system.
 
+## **UNRELEASED**
+* BUG: `SarifLogger` synthesizes an `Invocation` only when the caller-supplied `run.Invocations` is null or empty, instead of always appending one and duplicating an invocation the caller already provided.
+
 ## **v5.5.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/v5.5.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/v5.5.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/v5.5.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/v5.5.0) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/v5.5.0)
 * BUG: `@microsoft/sarif`'s `FileRegionsCache.constructMultilineContextSnippet` omits `contextRegion` when the region meets the 512-char cap or the window is not a proper superset of `region`, so long lines no longer emit SARIF that `SARIF1008.PhysicalLocationPropertiesMustBeConsistent` rejects.
 * NEW: `@microsoft/sarif-multitool-ts` `emit-run`/`emit-finalize` accept `--authorized-hosts ghe:<host>` (or `SARIF_AUTHORIZED_HOSTS`), so a caller-attested self-hosted GitHub Enterprise Server derives a github.com-style portable root instead of hard-failing; unattested hosts stay rejected.

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -252,38 +252,44 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 }
             }
 
-            var invocation = Invocation.Create(
-                emitMachineEnvironment: dataToInsert.HasFlag(OptionallyEmittedData.EnvironmentVariables),
-                emitTimestamps: !dataToRemove.HasFlag(OptionallyEmittedData.NondeterministicProperties),
-                invocationPropertiesToLog);
-
-            // TODO we should actually redact across the complete log file context
-            // by a dedicated rewriting visitor or some other approach.
-
-            if (invocationTokensToRedact != null)
+            // Synthesize an invocation to capture command-line, machine, and timing
+            // data only when the caller has not already provided one. Adding one
+            // unconditionally would duplicate a caller-supplied invocation in the run.
+            if (_run.Invocations.Count == 0)
             {
-                invocation.CommandLine = Redact(invocation.CommandLine, invocationTokensToRedact);
-                invocation.Machine = Redact(invocation.Machine, invocationTokensToRedact);
-                invocation.Account = Redact(invocation.Account, invocationTokensToRedact);
+                var invocation = Invocation.Create(
+                    emitMachineEnvironment: dataToInsert.HasFlag(OptionallyEmittedData.EnvironmentVariables),
+                    emitTimestamps: !dataToRemove.HasFlag(OptionallyEmittedData.NondeterministicProperties),
+                    invocationPropertiesToLog);
 
-                if (invocation.WorkingDirectory != null)
+                // TODO we should actually redact across the complete log file context
+                // by a dedicated rewriting visitor or some other approach.
+
+                if (invocationTokensToRedact != null)
                 {
-                    invocation.WorkingDirectory.Uri = Redact(invocation.WorkingDirectory.Uri, invocationTokensToRedact);
-                }
+                    invocation.CommandLine = Redact(invocation.CommandLine, invocationTokensToRedact);
+                    invocation.Machine = Redact(invocation.Machine, invocationTokensToRedact);
+                    invocation.Account = Redact(invocation.Account, invocationTokensToRedact);
 
-                if (invocation.EnvironmentVariables != null)
-                {
-                    string[] keys = invocation.EnvironmentVariables.Keys.ToArray();
-
-                    foreach (string key in keys)
+                    if (invocation.WorkingDirectory != null)
                     {
-                        string value = invocation.EnvironmentVariables[key];
-                        invocation.EnvironmentVariables[key] = Redact(value, invocationTokensToRedact);
+                        invocation.WorkingDirectory.Uri = Redact(invocation.WorkingDirectory.Uri, invocationTokensToRedact);
+                    }
+
+                    if (invocation.EnvironmentVariables != null)
+                    {
+                        string[] keys = invocation.EnvironmentVariables.Keys.ToArray();
+
+                        foreach (string key in keys)
+                        {
+                            string value = invocation.EnvironmentVariables[key];
+                            invocation.EnvironmentVariables[key] = Redact(value, invocationTokensToRedact);
+                        }
                     }
                 }
-            }
 
-            _run.Invocations.Add(invocation);
+                _run.Invocations.Add(invocation);
+            }
         }
 
         public IDictionary<ReportingDescriptor, ReportingDescriptorReference> RuleToReportingDescriptorReferenceMap { get; }

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -814,6 +814,61 @@ namespace Microsoft.CodeAnalysis.Sarif
             // Start off with a run that doesn't contain any Invocations.
             var run = new Run();
 
+            SarifLog sarifLog = RunSarifLoggerOverRun(run);
+
+            // The logger should have added an Invocation.
+            sarifLog.Runs[0].Invocations?.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void SarifLogger_DoesNotAddInvocationWhenRunAlreadyHasInvocation()
+        {
+            // A caller that supplies its own invocation should see exactly that
+            // invocation in the output; the logger must not append a second one.
+            const string commandLine = "caller-supplied-invocation";
+
+            var run = new Run
+            {
+                Invocations = new List<Invocation>
+                {
+                    new Invocation { CommandLine = commandLine }
+                }
+            };
+
+            SarifLog sarifLog = RunSarifLoggerOverRun(run);
+
+            var invocations = sarifLog.Runs[0].Invocations;
+            invocations?.Count.Should().Be(1);
+            invocations[0].CommandLine.Should().Be(commandLine);
+        }
+
+        [Fact]
+        public void SarifLogger_RetainsAllCallerSuppliedInvocations()
+        {
+            // When a caller supplies multiple invocations, all of them are retained
+            // and no additional invocation is synthesized.
+            const string firstCommandLine = "first-caller-invocation";
+            const string secondCommandLine = "second-caller-invocation";
+
+            var run = new Run
+            {
+                Invocations = new List<Invocation>
+                {
+                    new Invocation { CommandLine = firstCommandLine },
+                    new Invocation { CommandLine = secondCommandLine }
+                }
+            };
+
+            SarifLog sarifLog = RunSarifLoggerOverRun(run);
+
+            var invocations = sarifLog.Runs[0].Invocations;
+            invocations?.Count.Should().Be(2);
+            invocations[0].CommandLine.Should().Be(firstCommandLine);
+            invocations[1].CommandLine.Should().Be(secondCommandLine);
+        }
+
+        private static SarifLog RunSarifLoggerOverRun(Run run)
+        {
             var sb = new StringBuilder();
 
             using (var textWriter = new StringWriter(sb))
@@ -827,10 +882,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             string logText = sb.ToString();
-            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
-
-            // The logger should have added an Invocation.
-            sarifLog.Runs[0].Invocations?.Count.Should().Be(1);
+            return JsonConvert.DeserializeObject<SarifLog>(logText);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

`SarifLogger.EnhanceRun` unconditionally created a new `Invocation` and appended it to `run.Invocations` every time the logger enhanced a run. When a caller supplied a `Run` that already carried one or more `Invocation` objects, the logger appended a second, machine-synthesized invocation — duplicating invocation data the caller had already provided and producing a SARIF run with a spurious trailing invocation.

This change makes the synthesis conditional: `SarifLogger` now synthesizes and appends an `Invocation` only when `run.Invocations` is `null` or empty. When the caller already supplied at least one invocation, the logger leaves the caller's invocations untouched.

Fixes #2519.

## Details

`EnhanceRun` still normalizes `_run.Invocations` to a non-null list (`??= new List<Invocation>()`) because downstream code paths — `Dispose`/`AnalysisStopped` end-time stamping, the notification writers, SARIF v1 conversion, and `ResultProvenance.InvocationIndex` — read `Invocations[0]` / `Invocations.Count` and would `NullReferenceException` against a null list. Only the *creation* of a new invocation (plus its redaction and append) is now guarded by `if (_run.Invocations.Count == 0)`.

- The index-0 caller-supplied invocation is fully preserved, so end-time stamping, v1 conversion, and provenance indexing continue to operate on the caller's object.
- Redaction was never applied to caller-supplied invocations before this change, so scoping redaction to the synthesized invocation is not a behavioral regression.

## Tests

- `SarifLogger_DoesNotAddInvocationWhenRunAlreadyHasInvocation` — asserts no second invocation is appended when the caller supplies one.
- `SarifLogger_RetainsAllCallerSuppliedInvocations` — asserts multiple caller-supplied invocations are all retained and none are added.
- `SarifLogger_EnhancesRunWithInvocation` — refactored to share a private helper (`RunSarifLoggerOverRun`) with the new tests; still asserts the synthesized-invocation path for a run that starts with none.

Per repo convention, the new coverage is expressed as multiple `[Fact]` methods delegating to a shared helper (no `[Theory]`/`[InlineData]`). All `SarifLoggerTests` pass locally (33/33); the solution builds clean.

## Validation

The change was validated with a design review before implementation and an independent diff review afterward across two model families (OpenAI GPT-5.6 and Anthropic Claude Opus 4.8); both reached approve with no blocking findings.
